### PR TITLE
Actually set 'application_initialized' after the run loop has started

### DIFF
--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -134,7 +134,8 @@ class TasksApplication(Application):
             self._create_windows()
 
             # Start the GUI event loop.
-            gui.set_trait_later(self, 'application_initialized', self)
+            # XXX This is a bit hacky, since gui.set_trait_later runs right away
+            gui.set_trait_after(0.0001, self, 'application_initialized', self)
             gui.start_event_loop()
 
         return started


### PR DESCRIPTION
The _FutureCall class in pyface.ui.qt4.gui doesn't work properly when the event loop hasn't started. I'm not sure if this is the best solution, but it's a quick fix to have the application_initialized trait set after the run loop has started.
