### PR TITLE
BUG: TaskApplication stop() wrongly flushes event queue before stopping.

### DIFF
--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -425,9 +425,7 @@ class TasksApplication(Application):
 
         # Was this the last window?
         if len(self.windows) == 0:
-            # Invoke later to ensure that 'closed' event handlers get called
-            # before 'stop()' does.
-            self.gui.invoke_later(self.stop)
+            self.stop()
 
 
 class TasksApplicationState(HasStrictTraits):


### PR DESCRIPTION
Stop cannot be invoked later in gui thread because the gui loop
exits as soon as last window is closed, unless `quitOnLastWindowClosed`
is set to False, which would require other changes.
Invoke later does not seem necessary here because `closed` event is
traits event and all handlers are executed before proceeding.
This fixes bug in task application exit if invoke_later is actually
fixed to invoke via gui event loop
(pyface commit https://github.com/enthought/pyface/commit/385a67e5350722586531e7860002e301e6e368f2 ,
which was reverted because of this bug).
