### PR TITLE
ENH: EventManagerPlugin: Use package_global EventManager for service.

### DIFF
--- a/envisage/plugins/event_manager/plugin.py
+++ b/envisage/plugins/event_manager/plugin.py
@@ -17,9 +17,6 @@ of the application to the created event manager.
 from envisage.api import Plugin, ServiceOffer
 from traits.api import List, Any
 
-# Local imports.
-from encore.events.api import BaseEventManager, EventManager
-
 
 class EventManagerPlugin(Plugin):
     """ Plugin to add event manager to the application. """
@@ -29,23 +26,12 @@ class EventManagerPlugin(Plugin):
     SERVICE_OFFERS = 'envisage.service_offers'
     service_offers = List(contributes_to=SERVICE_OFFERS)
 
-    evt_mgr = Any
-
     def _service_offers_default(self):
-        evt_mgr = self.evt_mgr # Ensure evt_mgr is created
+        from encore.events.api import BaseEventManager, get_event_manager
+
         evt_mgr_service_offer = ServiceOffer(
             protocol   = BaseEventManager,
-            factory    = lambda: evt_mgr,
+            factory    = get_event_manager,
         )
         return [evt_mgr_service_offer]
-
-    def _evt_mgr_default(self):
-        """ If application already has an EventManager, then that is returned.
-        """
-        app = self.application
-        evt_mgr = getattr(app, 'evt_mgr', None)
-        if evt_mgr is None:
-            evt_mgr = EventManager()
-            app.evt_mgr = evt_mgr
-        return evt_mgr
 


### PR DESCRIPTION
This change makes the EventManagerPlugin offer the event api's
package_globals EventManager instead of instantiating its own
EventManager. This enables components to directly use that
event manager without having access to the application and the
need to look up to the service.
This will also be needed for encore.storage api's move to use that
event manager instead of being passed as an argument. (Encore PR 23)

PS: I think we can do away with this plugin in near future?
