### PR TITLE
Release Envisage 4.4.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,19 @@
 Envisage CHANGELOG
 ==================
 
-Since 4.3.0:
+Release 4.4.0
+-------------
+
+The major component of this feature is to work with the new
+``traits.adaptation`` mechanism in place of the deprecated
+``traits.protocols``, maintaining compatibility with ``traits`` version
+4.4.0.
+
+This release also adds a new method to retrieve a service that is
+required by the application and provides documentation and test updates.
+
+
+Change summary since 4.3.0
 
 New features
 

--- a/envisage/__init__.py
+++ b/envisage/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2007-2013 by Enthought, Inc.
 # All rights reserved.
 
-__version__ = '4.3.0'
+__version__ = '4.4.0'
 
 __requires__ = [
     'apptools',


### PR DESCRIPTION
This PR:
- bumps the version number to 4.4.0
- adds a summary of the changes to the changelog.
