### PR TITLE
Fixes degenerate case where no layout is specified in create_window

### DIFF
--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -209,7 +209,11 @@ class TasksApplication(Application):
             # Apply a suitable layout.
             if restore:
                 layout = self._restore_layout_from_state(layout)
-            window.set_window_layout(layout)
+        else:
+            # Create an empty layout to set default size and position only
+            layout = TaskWindowLayout()
+
+        window.set_window_layout(layout)
 
         return window
 


### PR DESCRIPTION
As a newbie, I didn't specify a layout for the a window I created using TaskApplication.create_window. When I called Application.exit(), I get the following exception:

```
Traceback (most recent call last):
  File "/data/home/rob/src/enthought/envisage/envisage/ui/tasks/tasks_application.py", line 247, in exit
    self._prepare_exit()
  File "/data/home/rob/src/enthought/envisage/envisage/ui/tasks/tasks_application.py", line 303, in _prepare_exit
    self._save_state()
  File "/data/home/rob/src/enthought/envisage/envisage/ui/tasks/tasks_application.py", line 351, in _save_state
    window_layouts = [ w.get_window_layout() for w in self.windows ]
  File "/data/home/rob/src/enthought/pyface/pyface/tasks/task_window.py", line 306, in get_window_layout
    size_state=self.size_state)
AttributeError: 'TaskWindow' object has no attribute 'size_state'
```

But when I specify an empty layout, e.g.

```
        window = self.create_window(layout=TaskWindowLayout())
```

it works fine. Admittedly it's a degenerate case, but this patch adds an empty layout if the layout argument is None.