### PR TITLE
BUG: Add a NullHandler to the 'envisage' logger.

### DIFF
--- a/envisage/__init__.py
+++ b/envisage/__init__.py
@@ -14,7 +14,7 @@ import logging
 
 
 class NullHandler(logging.Handler):
-    # Define our own to accomodate Python < 2.7
+    # Define our own to accommodate Python < 2.7
     def handle(self, record):
         pass
 


### PR DESCRIPTION
Per logging best practices, this allows `envisage` to be used as a library
cleanly without having to configure logging.
