### PR TITLE
Fix the install_requires field for the acme.motd plugin egg

### DIFF
--- a/examples/MOTD_Using_Eggs/src/acme.motd/setup.py
+++ b/examples/MOTD_Using_Eggs/src/acme.motd/setup.py
@@ -17,7 +17,7 @@ setup(
     ],
 
     install_requires     = [
-        'EnvisageCore>=3.0.0a1',
+        'envisage>=3.0.0a1',
     ],
 
     entry_points = """


### PR DESCRIPTION
Renaming EnvisageCore -> Envisage caused the `MOTD_Using_Eggs` example to break.