### PR TITLE
Fix exception swallowing in CompositePluginManager.start.

### DIFF
--- a/envisage/composite_plugin_manager.py
+++ b/envisage/composite_plugin_manager.py
@@ -129,7 +129,8 @@ class CompositePluginManager(HasTraits):
     def start(self):
         """ Start the plugin manager. """
 
-        map(lambda plugin: self.start_plugin(plugin), self)
+        for plugin in self:
+            self.start_plugin(plugin)
 
         return
 
@@ -154,7 +155,8 @@ class CompositePluginManager(HasTraits):
         stop_order = list(iter(self))
         stop_order.reverse()
 
-        map(lambda plugin: self.stop_plugin(plugin), stop_order)
+        for plugin in stop_order:
+            self.stop_plugin(plugin)
 
         return
 

--- a/envisage/tests/composite_plugin_manager_test_case.py
+++ b/envisage/tests/composite_plugin_manager_test_case.py
@@ -36,6 +36,19 @@ class SimplePlugin(Plugin):
         return
 
 
+class CustomException(Exception):
+    """ Custom exception used for testing purposes. """
+
+    pass
+
+
+class RaisingPluginManager(PluginManager):
+    """ A PluginManager that raises on iteration. """
+
+    def __iter__(self):
+        raise CustomException("Something went wrong.")
+
+
 class CompositePluginManagerTestCase(unittest.TestCase):
     """ Tests for the composite plugin manager. """
 
@@ -160,6 +173,13 @@ class CompositePluginManagerTestCase(unittest.TestCase):
         
         return
     
+    def test_correct_exception_propagated_from_plugin_manager(self):
+        plugin_manager = CompositePluginManager(
+            plugin_managers=[RaisingPluginManager()]
+        )
+
+        self.assertRaises(CustomException, plugin_manager.start)
+
     #### Private protocol #####################################################
 
     def _plugin_count(self, plugin_manager):


### PR DESCRIPTION
The `CompositePluginManager.start` method swallows exceptions, leading to an inscrutable "TypeError: argument 2 to map() must support iteration" message (for example when iterating through a `PluginManager` fails due to an `ImportError`).  The exception swallowing is the result of http://bugs.python.org/issue11655.  It's easily avoided by replacing the (abominable, IMO :-) `map` uses in `CompositePluginManager.start`.  For good measure, I've made the same change in `CompositePluginManager.stop`.
