### PR TITLE
Fix an instance of logging.info that should have been logger.info

### DIFF
--- a/envisage/plugins/remote_editor/communication/server.py
+++ b/envisage/plugins/remote_editor/communication/server.py
@@ -191,7 +191,7 @@ class Server(HasTraits):
             return msg
 
         try:
-            logging.info("Server spawning Client of type '%s.'" % object_type)
+            logger.info("Server spawning Client of type '%s.'" % object_type)
             spawn_independent(command, shell=True)
         except OSError:
             msg = "Error spawning process for '%s' with command '%s'." \


### PR DESCRIPTION
A trivial nitpick: `logging.info` should be `logger.info` here.