### PR TITLE
Fixed 'MOTD_Using_Eggs' example

### DIFF
--- a/examples/MOTD_Using_Eggs/src/acme.motd.software_quotes/acme/__init__.py
+++ b/examples/MOTD_Using_Eggs/src/acme.motd.software_quotes/acme/__init__.py
@@ -3,6 +3,7 @@
 # All rights reserved.
 #------------------------------------------------------------------------------
 
-
+import pkg_resources
+pkg_resources.declare_namespace('acme')
 
 

--- a/examples/MOTD_Using_Eggs/src/acme.motd.software_quotes/acme/motd/__init__.py
+++ b/examples/MOTD_Using_Eggs/src/acme.motd.software_quotes/acme/motd/__init__.py
@@ -3,6 +3,7 @@
 # All rights reserved.
 #------------------------------------------------------------------------------
 
-
+import pkg_resources
+pkg_resources.declare_namespace('acme.motd')
 
 

--- a/examples/MOTD_Using_Eggs/src/acme.motd.software_quotes/acme/motd/software_quotes/__init__.py
+++ b/examples/MOTD_Using_Eggs/src/acme.motd.software_quotes/acme/motd/software_quotes/__init__.py
@@ -3,6 +3,7 @@
 # All rights reserved.
 #------------------------------------------------------------------------------
 
-
+import pkg_resources
+pkg_resources.declare_namespace('acme.motd.software_quotes')
 
 

--- a/examples/MOTD_Using_Eggs/src/acme.motd/acme/__init__.py
+++ b/examples/MOTD_Using_Eggs/src/acme.motd/acme/__init__.py
@@ -3,6 +3,7 @@
 # All rights reserved.
 #------------------------------------------------------------------------------
 
-
+import pkg_resources
+pkg_resources.declare_namespace('acme')
 
 

--- a/examples/MOTD_Using_Eggs/src/acme.motd/acme/motd/__init__.py
+++ b/examples/MOTD_Using_Eggs/src/acme.motd/acme/motd/__init__.py
@@ -3,6 +3,7 @@
 # All rights reserved.
 #------------------------------------------------------------------------------
 
-
+import pkg_resources
+pkg_resources.declare_namespace('acme.motd')
 
 


### PR DESCRIPTION
running
``` 
python setup.py bdist_egg -d ../../dist/eggs
```
as per README.txt in the relevant folders in ./src gives the output 
```
rahulporuri@astronut:acme.motd$ python setup.py bdist_egg -d ../../dist/eggs
running bdist_egg
running egg_info
creating acme.motd.egg-info
writing requirements to acme.motd.egg-info/requires.txt
writing acme.motd.egg-info/PKG-INFO
writing namespace_packages to acme.motd.egg-info/namespace_packages.txt
writing top-level names to acme.motd.egg-info/top_level.txt
writing dependency_links to acme.motd.egg-info/dependency_links.txt
writing entry points to acme.motd.egg-info/entry_points.txt
writing manifest file 'acme.motd.egg-info/SOURCES.txt'
error: Namespace package problem: acme is a namespace package, but its
__init__.py does not call declare_namespace()! Please fix it.
(See the setuptools manual under "Namespace Packages" for details.)
"
```

Relevant namespaces were added in the init files using declare_namespace from pkg_resources.