### PR TITLE
Removed outdated/broken links in tasks docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,8 +38,8 @@ copyright = '2008-2011, Enthought'
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
 d = {}
-execfile(os.path.join('..', '..', 'envisage', '__init__.py'), d)
-version = release = d['__version__']
+execfile(os.path.join('..', '..', 'envisage', '_version.py'), d)
+version = release = d['full_version']
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -79,7 +79,7 @@ pygments_style = 'sphinx'
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
 html_style = 'default.css'
-
+html_theme = 'classic'
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 html_title = "Envisage Documentation"

--- a/docs/source/tasks_user_manual/extensibility.rst
+++ b/docs/source/tasks_user_manual/extensibility.rst
@@ -413,15 +413,15 @@ several other menu-related conveniences, can be found in
 .. rubric:: Footnotes
 
 .. [1] In this section, we shall be referencing--often with considerable
-       simplification--the Attractors example code in the EnvisagePlugins
+       simplification--the Attractors example code in the Envisage
        package, available `online
-       <https://github.com/enthought/envisageplugins/tree/master/examples/tasks/attractors>`_
+       <https://github.com/enthought/envisage/tree/master/examples/plugins/tasks/attractors>`_
        and in the ETS distribution.
 
 .. [2] Although they are expanded into PyFace action items, schemas belong to a
        distinct API. It is beyond the scope of this document to describe the
        PyFace action API. For lack of more complete documentation, the reader is
        referred to the `source code
-       <https://github.com/enthought/traitsgui/blob/master/enthought/pyface/action/>`_.
+       <https://github.com/enthought/pyface/tree/master/pyface/action/>`_.
 
 .. [3] Tasks differs from the Workbench in this regard.

--- a/docs/source/tasks_user_manual/layout.rst
+++ b/docs/source/tasks_user_manual/layout.rst
@@ -228,8 +228,8 @@ appears multiple times in a layout.
 
 .. [1] For more information about the MVC pattern as used in ETS, the reader is
        referred to the `Introduction
-       <http://enthought.github.com/traits/TUIUG/intro.html>`_ of the Traits UI
-       User Guide.
+       <http://docs.enthought.com/traitsui/traitsui_user_manual/intro.html>`_
+       of the Traits UI User Guide.
 
 .. [2] Throughout this document, "``Task``" will refer to the class of that name
        in the Tasks API, while "task" will be reserved for the general UI
@@ -238,5 +238,5 @@ appears multiple times in a layout.
 .. [3] In this and the subsequent section, we will be referencing (often in
        abbreviated form) the Tasks example code in the TraitsGUI package,
        available `online
-       <https://github.com/enthought/traitsgui/tree/master/examples/tasks>`_ and
+       <https://github.com/enthought/pyface/tree/master/examples/tasks>`_ and
        in the ETS distribution.

--- a/docs/source/tasks_user_manual/menus.rst
+++ b/docs/source/tasks_user_manual/menus.rst
@@ -132,5 +132,5 @@ files to our script editing task::
 .. rubric:: Footnotes
 
 .. [1] The most convenient reference in this case is the `source code
-       <https://github.com/enthought/traitsgui/blob/master/enthought/pyface/action/action.py>`_ itself.
+       <https://github.com/enthought/pyface/blob/master/pyface/action/action.py>`_ itself.
 


### PR DESCRIPTION
ref : #71 

- [x] [Footnote #1 in layout](http://docs.enthought.com/envisage/tasks_user_manual/layout.html#id4)
- [x] [Footnote #3 in layout](http://docs.enthought.com/envisage/tasks_user_manual/layout.html#id6)
- [x] [Footnote #2 in menus](http://docs.enthought.com/envisage/tasks_user_manual/menus.html#id2)
- [x] [Footnote #1 in extensibility](http://docs.enthought.com/envisage/tasks_user_manual/extensibility.html#id7)
- [x] [Footnote #2 in extensibility](http://docs.enthought.com/envisage/tasks_user_manual/extensibility.html#id8)