### PR TITLE
Replace uses of 'file' and 'execfile' for Python 3 compatibility

### DIFF
--- a/envisage/developer/code_browser/code_browser.py
+++ b/envisage/developer/code_browser/code_browser.py
@@ -59,7 +59,7 @@ class CodeBrowser(HasTraits):
         if os.path.isfile(self.filename):
             logger.debug('loading code database...')
 
-            f = file(self.filename, 'rb')
+            f = open(self.filename, 'rb')
             self._database = pickle.load(f)
             f.close()
 
@@ -77,7 +77,7 @@ class CodeBrowser(HasTraits):
         if self._database_changed:
             logger.debug('saving code database...')
 
-            f = file(self.filename, 'wb')
+            f = open(self.filename, 'wb')
             pickle.dump(self._database, f, 1)
             f.close()
 

--- a/envisage/developer/code_browser/enclbr.py
+++ b/envisage/developer/code_browser/enclbr.py
@@ -39,7 +39,7 @@ def save_cache(filename):
     if MODULES_CHANGED:
         logger.debug('saving cache...')
 
-        f = file(filename, 'wb')
+        f = open(filename, 'wb')
         pickle.dump(MODULES, f, 1)
         f.close()
 
@@ -56,7 +56,7 @@ def load_cache(filename):
     if os.path.isfile(filename):
         logger.debug('loading cache...')
 
-        f = file(filename, 'rb')
+        f = open(filename, 'rb')
         MODULES = pickle.load(f)
         f.close()
 

--- a/envisage/plugins/text_editor/editor/text_editor.py
+++ b/envisage/plugins/text_editor/editor/text_editor.py
@@ -52,7 +52,7 @@ class TextEditor(TraitsUIEditor):
             self.save_as()
 
         else:
-            f = file(self.obj.path, 'w')
+            f = open(self.obj.path, 'w')
             f.write(self.text)
             f.close()
 
@@ -114,7 +114,7 @@ class TextEditor(TraitsUIEditor):
 
             if view is not None:
                 view.execute_command(
-                    'execfile(r"%s")' % self.obj.path, hidden=False
+                    'exec(open(r"%s").read())' % self.obj.path, hidden=False
                 )
 
         return
@@ -166,7 +166,7 @@ class TextEditor(TraitsUIEditor):
             self.id   = new.path
             self.name = basename(new.path)
 
-            f = file(new.path, 'r')
+            f = open(new.path, 'r')
             self.text = f.read()
             f.close()
 

--- a/envisage/plugins/update_checker/tests/bare_app.py
+++ b/envisage/plugins/update_checker/tests/bare_app.py
@@ -11,7 +11,7 @@ from enthought.epdlab.plugins.code_editor.plugin import CodeEditorPlugin
 
 # Logging.
 logger = logging.getLogger()
-logger.addHandler(logging.StreamHandler(file('update_checker.log', 'w')))
+logger.addHandler(logging.StreamHandler(open('update_checker.log', 'w')))
 logger.setLevel(logging.DEBUG)
 
 
@@ -33,4 +33,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -573,7 +573,7 @@ class Project(HasTraits):
         # opened.
         fh = None
         try:
-            fh = file(filename, 'rb')
+            fh = open(filename, 'rb')
             pickle_package = cls.get_pickle_package()
             project = pickle_package.load(fh)
 
@@ -667,7 +667,7 @@ class Project(HasTraits):
             # applied.
             self._save_hook(location)
 
-            fh = file(filename, 'wb')
+            fh = open(filename, 'wb')
             pickle_package = self.get_pickle_package()
             pickle_package.dump(self, fh, 1)
 


### PR DESCRIPTION
See enthought/traitsui#297 and enthought/traitsui#300.
