### PR TITLE
Remove use of deprecated "profile" kw in connect_qtconsole

### DIFF
--- a/envisage/plugins/ipython_kernel/internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/internal_ipkernel.py
@@ -68,10 +68,8 @@ class InternalIPKernel(HasStrictTraits):
 
     def new_qt_console(self):
         """ Start a new qtconsole connected to our kernel. """
-        console = connect_qtconsole(
-            self.ipkernel.connection_file, profile=self.ipkernel.profile,
-            argv=['--no-confirm-exit'],
-        )
+        console = connect_qtconsole(self.ipkernel.connection_file,
+                                    argv=['--no-confirm-exit'])
         self.consoles.append(console)
         return console
 


### PR DESCRIPTION
This very small update to the `connect_qtconsole` call, removing the use of the [deprecated](https://github.com/ipython/ipykernel/blob/master/ipykernel/connect.py#L157) option profile seems to fix https://github.com/enthought/envisage/issues/62 .
