### PR TITLE
Fix deprecated IPython import.

### DIFF
--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -1,10 +1,10 @@
 import unittest
 
 try:
-    import IPython  # noqa
+    import ipykernel  # noqa
 except ImportError:
     from nose.plugins.skip import SkipTest
-    raise SkipTest('IPython not available')
+    raise SkipTest('ipykernel not available')
 
 from ipykernel.kernelapp import IPKernelApp
 from envisage.plugins.ipython_kernel.internal_ipkernel import InternalIPKernel


### PR DESCRIPTION
Importing from `IPython` is deprecated, and doesn't match the imports that we need for the code under test.
```
(canopy-data-ci)(edm)bash-3.2$ python -Wd
Enthought Deployment Manager -- https://www.enthought.com
Python 2.7.10 |Enthought, Inc. (x86_64)| (default, Jun 23 2016, 05:02:55) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import IPython.kernel
/Users/mdickinson/.edm/envs/canopy-data-ci/lib/python2.7/site-packages/IPython/kernel/__init__.py:13: ShimWarning: The `IPython.kernel` package has been deprecated since IPython 4.0.You should import from ipykernel or jupyter_client instead.
  "You should import from ipykernel or jupyter_client instead.", ShimWarning)
```
