### PR TITLE
Let ExtensionPointBinding be garbage collected.

### DIFF
--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -5,7 +5,7 @@
 import weakref
 
 # Enthought library imports.
-from traits.api import Any, HasTraits, Instance, Str, Undefined
+from traits.api import Any, HasTraits, Instance, Str, Undefined, WeakRef
 
 # Local imports.
 from .i_extension_registry import IExtensionRegistry
@@ -23,7 +23,7 @@ class ExtensionPointBinding(HasTraits):
     #### 'ExtensionPointBinding' interface ####################################
 
     # The object that we are binding the extension point to.
-    obj = Any
+    obj = WeakRef
 
     # The Id of the extension point.
     extension_point_id = Str
@@ -31,7 +31,7 @@ class ExtensionPointBinding(HasTraits):
     # The extension registry used by the binding. If this trait is not set then
     # the class-scope extension registry set on the 'ExtensionPoint' class is
     # used (and if that is not set then the binding won't work ;^)
-    extension_registry = Instance(IExtensionRegistry)
+    extension_registry = WeakRef(IExtensionRegistry)
 
     # The name of the trait that we are binding the extension point to.
     trait_name = Str

--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -135,10 +135,16 @@ class ExtensionPointBinding(HasTraits):
     def _set_trait(self, notify):
         """ Set the object's trait to the value of the extension point. """
 
-        value = self.extension_registry.get_extensions(self.extension_point_id)
+        extension_registry = self.extension_registry
+        obj = self.obj
+        if None in (extension_registry, obj):
+            # possibly garbage collected
+            return
+
+        value = extension_registry.get_extensions(self.extension_point_id)
         traits = {self.trait_name : value}
 
-        self.obj.set(trait_change_notify=notify, **traits)
+        obj.set(trait_change_notify=notify, **traits)
 
         return
 
@@ -146,19 +152,22 @@ class ExtensionPointBinding(HasTraits):
         """ Update the object's trait to the value of the extension point. """
 
         self._set_trait(notify=False)
-
-        self.obj.trait_property_changed(
-            self.trait_name + '_items', Undefined, event
-        )
+        obj = self.obj
+        if self.obj is not None:
+            obj.trait_property_changed(
+                self.trait_name + '_items', Undefined, event
+            )
 
         return
 
     def _set_extensions(self, extensions):
         """ Set the extensions to an extension point. """
 
-        self.extension_registry.set_extensions(
-            self.extension_point_id, extensions
-        )
+        extension_registry = self.extension_registry
+        if extension_registry is not None:
+            extension_registry.set_extensions(
+                self.extension_point_id, extensions
+            )
 
         return
 

--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -50,6 +50,10 @@ class ExtensionPointBinding(HasTraits):
 
         super(ExtensionPointBinding, self).__init__(**traits)
 
+        if self.extension_registry is None:
+            # WeakRef traits are not initialized by default initializer method
+            self.extension_registry = self._default_extension_registry()
+
         # Initialize the object's trait from the extension point.
         self._set_trait(notify=False)
 
@@ -62,20 +66,6 @@ class ExtensionPointBinding(HasTraits):
         bindings.append(self)
 
         return
-
-    ###########################################################################
-    # 'ExtensionPointBinding' interface.
-    ###########################################################################
-
-    #### Trait initializers ###################################################
-
-    def _extension_registry_default(self):
-        """ Trait initializer. """
-
-        # fixme: Sneaky global!!!!!
-        from .extension_point import ExtensionPoint
-
-        return ExtensionPoint.extension_registry
 
     ###########################################################################
     # Private interface.
@@ -134,6 +124,13 @@ class ExtensionPointBinding(HasTraits):
         )
 
         return
+
+    def _default_extension_registry(self):
+
+        # fixme: Sneaky global!!!!!
+        from .extension_point import ExtensionPoint
+
+        return ExtensionPoint.extension_registry
 
     def _set_trait(self, notify):
         """ Set the object's trait to the value of the extension point. """


### PR DESCRIPTION
Fixes #97

`ExtensionPointBinding` now holds only weak references to `obj`
and `extension_registry` so that they all can be garbage collected.
This is needed because of the global registry of
`ExtensionPointBinding` instances held at its class level.