### PR TITLE
Add api to remove extension point binding.

### DIFF
--- a/envisage/tests/mutable_extension_registry.py
+++ b/envisage/tests/mutable_extension_registry.py
@@ -26,7 +26,7 @@ class MutableExtensionRegistry(ExtensionRegistry):
 
         old   = self._get_extensions(extension_point_id)
         index = len(old)
-        old.extend(extensions)
+        self.set_extensions(extension_point_id, old + extensions)
 
         # Let any listeners know that the extensions have been added.
         refs = self._get_listener_refs(extension_point_id)


### PR DESCRIPTION
`ExtensionPointBinding` instances now have a `remove` method
and `bind_extension_point` function now takes an optional
`remove` argument similar to `on_traits_change` to remove
the binding.

@mdickinson Is this something similar to what you intended in your review of https://github.com/enthought/envisage/pull/98