### PR TITLE
Stop the IOPubThread as part of IPython kernel shutdown.

### DIFF
--- a/envisage/plugins/ipython_kernel/internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/internal_ipkernel.py
@@ -87,4 +87,5 @@ class InternalIPKernel(HasStrictTraits):
             self.cleanup_consoles()
             self.ipkernel.shell.exit_now = True
             self.ipkernel.cleanup_connection_file()
+            self.ipkernel.iopub_thread.stop()
             self.ipkernel = None

--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -1,3 +1,4 @@
+import gc
 import unittest
 
 try:
@@ -7,6 +8,7 @@ except ImportError:
     raise SkipTest('ipykernel not available')
 
 from ipykernel.kernelapp import IPKernelApp
+from ipykernel.iostream import IOPubThread
 from envisage.plugins.ipython_kernel.internal_ipkernel import InternalIPKernel
 
 
@@ -37,3 +39,18 @@ class TestInternalIPKernel(unittest.TestCase):
         self.assertIn('x', kernel.namespace)
         self.assertEqual(kernel.namespace['x'], 42.1)
         kernel.shutdown()
+
+    def test_io_pub_thread_stopped(self):
+        kernel = InternalIPKernel()
+        kernel.init_ipkernel(gui_backend=None)
+        kernel.new_qt_console()
+        kernel.new_qt_console()
+        kernel.shutdown()
+
+        io_pub_threads = [
+            obj for obj in gc.get_objects()
+            if isinstance(obj, IOPubThread)
+        ]
+
+        for thread in io_pub_threads:
+            self.assertFalse(thread.thread.is_alive())

--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -2,16 +2,20 @@ import gc
 import unittest
 
 try:
-    import ipykernel  # noqa
+    import ipykernel  # noqa: F401
 except ImportError:
-    from nose.plugins.skip import SkipTest
-    raise SkipTest('ipykernel not available')
+    ipykernel_available = False
+else:
+    ipykernel_available = True
+    from ipykernel.iostream import IOPubThread
+    from ipykernel.kernelapp import IPKernelApp
 
-from ipykernel.kernelapp import IPKernelApp
-from ipykernel.iostream import IOPubThread
-from envisage.plugins.ipython_kernel.internal_ipkernel import InternalIPKernel
+    from envisage.plugins.ipython_kernel.internal_ipkernel import (
+        InternalIPKernel)
 
 
+@unittest.skipUnless(ipykernel_available,
+                     "skipping tests that require the ipykernel package")
 class TestInternalIPKernel(unittest.TestCase):
 
     def tearDown(self):


### PR DESCRIPTION
Fixes #93.

Also fixes the imports at the top of the test module to skip tests correctly under unittest if `ipykernel` isn't available.