### PR TITLE
Fix attractors example

### DIFF
--- a/examples/plugins/tasks/attractors/model/lorenz.py
+++ b/examples/plugins/tasks/attractors/model/lorenz.py
@@ -4,7 +4,7 @@ from scipy.integrate import odeint
 
 # Enthought libary imports.
 from traits.api import Adapter, Array, Float, HasTraits, Instance, \
-     Property, Str, Unicode, adapts, cached_property, provides
+     Property, Str, Unicode, cached_property, provides, register_factory
 from traitsui.api import View, Item
 
 # Local imports
@@ -77,4 +77,5 @@ class LorenzIPlottable2dAdapter(Adapter, IModel3dIPlottable2dMixin):
 
     plot_type = Str('line')
 
-adapts(LorenzIPlottable2dAdapter, Lorenz, IPlottable2d)
+
+register_factory(LorenzIPlottable2dAdapter, Lorenz, IPlottable2d)

--- a/examples/plugins/tasks/attractors/model/rossler.py
+++ b/examples/plugins/tasks/attractors/model/rossler.py
@@ -4,7 +4,7 @@ from scipy.integrate import odeint
 
 # Enthought libary imports.
 from traits.api import Adapter, Array, Float, HasTraits, Instance, \
-     Property, Str, Unicode, adapts, cached_property, provides
+     Property, Str, Unicode, cached_property, provides, register_factory
 from traitsui.api import View, Item
 
 # Local imports
@@ -74,4 +74,5 @@ class RosslerIPlottable2dAdapter(Adapter, IModel3dIPlottable2dMixin):
 
     plot_type = Str('line')
 
-adapts(RosslerIPlottable2dAdapter, Rossler, IPlottable2d)
+
+register_factory(RosslerIPlottable2dAdapter, Rossler, IPlottable2d)

--- a/examples/plugins/tasks/attractors/visualize_2d_task.py
+++ b/examples/plugins/tasks/attractors/visualize_2d_task.py
@@ -2,9 +2,10 @@
 from pyface.tasks.action.api import SGroup, SMenu, SMenuBar, \
     TaskToggleGroup
 from pyface.tasks.api import Task, TaskLayout, Tabbed, PaneItem
-from traits.api import Any, List
+from traits.api import Any, Instance, List, adapt
 
 # Local imports.
+from model.i_plottable_2d import IPlottable2d
 from model_config_pane import ModelConfigPane
 from model_help_pane import ModelHelpPane
 from plot_2d_pane import Plot2dPane
@@ -30,7 +31,7 @@ class Visualize2dTask(Task):
     active_model = Any
 
     # The list of available attractor models.
-    models = List
+    models = List(Instance(IPlottable2d))
 
     ###########################################################################
     # 'Task' interface.
@@ -66,7 +67,10 @@ class Visualize2dTask(Task):
         from model.henon import Henon
         from model.lorenz import Lorenz
         from model.rossler import Rossler
-        return [ Henon(), Lorenz(), Rossler() ]
+
+        models = [Henon(), Lorenz(), Rossler()]
+
+        return [adapt(model, IPlottable2d) for model in models]
 
     #### Trait change handlers ################################################
 


### PR DESCRIPTION
- Do explicit adaptation when creating models for the 2d view
- Replace uses of the deprecated `adapts` function with the newer `register_factory`.

On my machine, this restores the attractors example to working state. Thanks @martinRenou for help debugging.

Fixes #52. Alternative to #81.