### PR TITLE
Fix Travis CI runs: don't attempt to remove distribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
   - pip
 before_install:
   # Travis is using distribute which cause problems with testing envisage
-  - sudo /usr/local/bin/pip2 uninstall -y distribute
+  - /usr/local/bin/pip2 show distribute && sudo /usr/local/bin/pip2 uninstall -y distribute
   - ccache -s
   - pip install --upgrade pip
   - pip --version


### PR DESCRIPTION
The CRON jobs for Travis CI were failing because we were trying to uninstall `distribute`, which apparently isn't installed on Trusty.