### PR TITLE
Add ipykernel package to CI setup

### DIFF
--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -7,6 +7,9 @@ except ImportError:
     ipykernel_available = False
 else:
     ipykernel_available = True
+
+
+if ipykernel_available:
     from ipykernel.iostream import IOPubThread
     from ipykernel.kernelapp import IPKernelApp
 

--- a/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
+++ b/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
@@ -12,6 +12,9 @@ except ImportError:
     ipykernel_available = False
 else:
     ipykernel_available = True
+
+
+if ipykernel_available:
     from ipykernel.kernelapp import IPKernelApp
 
     from envisage.plugins.ipython_kernel.internal_ipkernel import (

--- a/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
+++ b/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
@@ -1,21 +1,27 @@
 import unittest
 
-try:
-    import IPython  # noqa
-except ImportError:
-    from nose.plugins.skip import SkipTest
-    raise SkipTest('IPython not available')
-
-from ipykernel.kernelapp import IPKernelApp
+from traits.api import List
 
 from envisage.api import Application, Plugin
 from envisage.core_plugin import CorePlugin
-from envisage.plugins.ipython_kernel.internal_ipkernel import InternalIPKernel
-from envisage.plugins.ipython_kernel.ipython_kernel_plugin import (
-    IPYTHON_KERNEL_PROTOCOL, IPYTHON_NAMESPACE, IPythonKernelPlugin)
-from traits.api import List
+
+# Skip these tests unless ipykernel is available.
+try:
+    import ipykernel  # noqa: F401
+except ImportError:
+    ipykernel_available = False
+else:
+    ipykernel_available = True
+    from ipykernel.kernelapp import IPKernelApp
+
+    from envisage.plugins.ipython_kernel.internal_ipkernel import (
+        InternalIPKernel)
+    from envisage.plugins.ipython_kernel.ipython_kernel_plugin import (
+        IPYTHON_KERNEL_PROTOCOL, IPYTHON_NAMESPACE, IPythonKernelPlugin)
 
 
+@unittest.skipUnless(ipykernel_available,
+                     "skipping tests that require the ipykernel package")
 class TestIPythonKernelPlugin(unittest.TestCase):
 
     def tearDown(self):

--- a/etstool.py
+++ b/etstool.py
@@ -95,6 +95,7 @@ supported_combinations = {
 dependencies = {
     "apptools",
     "coverage",
+    "ipykernel",
     "nose",
     "pyface",
     "traits",


### PR DESCRIPTION
- Include `ipykernel` in CI setup, so that the IPython-related tests are run as part of the CI (they're currently skipped).

- Rework the check in one of the test files so that we don't try to import `IPython`.