### PR TITLE
Include license, readme and changelog files in the source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,9 @@
+include CHANGES.txt
+include LICENSE.txt
+include MANIFEST.in
+include README.rst
+include image_LICENSE.txt
+include image_LICENSE_CP.txt
 recursive-include envisage/tests/plugins *.py
 recursive-include envisage/tests/eggs *.egg
 recursive-include envisage/tests/bad_eggs *.egg

--- a/setup.py
+++ b/setup.py
@@ -153,12 +153,21 @@ if __name__ == "__main__":
         install_requires = __requires__,
         license = "BSD",
         packages = find_packages(),
-        package_data = {'': ['images/*', '*.ini',],
-                        'envisage.tests': ['bad_eggs/*.egg',
-                                           'eggs/*.egg',
-                                           'plugins/pear/*.py',
-                                           'plugins/banana/*.py',
-                                           'plugins/orange/*.py']},
+        package_data = {
+            '': ['images/*', '*.ini'],
+            'envisage.tests': [
+                'bad_eggs/*.egg',
+                'eggs/*.egg',
+                'plugins/pear/*.py',
+                'plugins/banana/*.py',
+                'plugins/orange/*.py',
+            ],
+            'envisage.ui.single_project': [
+                '*.txt',
+            ],
+            'envisage.plugins.remote_editor.editor_plugins': ["*.txt"],
+            'envisage.plugins.remote_editor.editor_plugins.emacs': ["*.el"],
+        },
         platforms = ["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
         zip_safe = False,
     )


### PR DESCRIPTION
Fixes #106 by adding `LICENSE.txt`, `README.rst`, `CHANGES.txt` and related files to the manifest.