### PR TITLE
Post-release version-number bump on master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
 branches:
   only:
     - master
+    - /release\/\d+\.\d+\.x/
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ matrix:
 branches:
   only:
     - master
+    - /release\/\d+\.\d+\.x/
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import subprocess
 from setuptools import setup, find_packages
 
 MAJOR = 4
-MINOR = 7
+MINOR = 8
 MICRO = 0
 
 IS_RELEASED = False


### PR DESCRIPTION
Now that Envisage 4.7.0 is released, we should bump the version number on master.

EDIT: Also updates the CI configs to build PRs against branches named "release/<nnn>.<nnn>.x".