### PR TITLE
Replace use of deprecated HasTraits.set method with HasTraits.trait_set.

### DIFF
--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -141,7 +141,7 @@ class ExtensionPointBinding(HasTraits):
         value = self.extension_registry.get_extensions(self.extension_point_id)
         traits = {self.trait_name : value}
 
-        self.obj.set(trait_change_notify=notify, **traits)
+        self.obj.trait_set(trait_change_notify=notify, **traits)
 
         return
 


### PR DESCRIPTION
Fix a single use of the deprecated `HasTraits.set` method. This was causing `DeprecationWarning`s in the test suite of another project.

I did a quick search for other uses of `HasTraits.get` and `HasTraits.set`, but didn't spot any.