### PR TITLE
BUG: Fix infinite recursion in extension method harvesting.

### DIFF
--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -365,9 +365,13 @@ class Plugin(ExtensionProvider):
         """ Harvest all method-based contributions. """
 
         extensions = []
-        for name, value in inspect.getmembers(self):
+        # Using inspect.getmembers(self) here will cause an infinite recursion,
+        # so use an internal HasTraits method for inspecting the MRO of the
+        # instance's type to find all methods instead.
+        for name in self._each_trait_method(self):
+            value = getattr(self, name)
             if self._is_extension_method(value, extension_point_id):
-                result = getattr(self, name)()
+                result = value()
                 if not isinstance(result, list):
                     result = [result]
 

--- a/envisage/tests/plugin_test_case.py
+++ b/envisage/tests/plugin_test_case.py
@@ -449,6 +449,16 @@ class PluginTestCase(unittest.TestCase):
 
         return
 
+    def test_no_recursion(self):
+        """ Regression test for #119. """
+
+        class PluginA(Plugin):
+            id = 'A'
+            x  = ExtensionPoint(List, id='bob')
+
+        application = Application(plugins=[PluginA()])
+        application.get_extensions('bob')
+
 
 # Entry point for stand-alone testing.
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #119

@mdickinson @rahulporuri I believe this solves the problem. `HasTraits` already has an internal method for inspecting its MRO for methods that avoids tripping the infinite recursion since it doesn't really touch the instance. Swapping that in for `inspect.getmembers()` solves the problem for me.