### PR TITLE
fix broken tests with ipykernel 4.7

### DIFF
--- a/envisage/plugins/ipython_kernel/internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/internal_ipkernel.py
@@ -8,6 +8,8 @@ from ipykernel.kernelapp import IPKernelApp
 
 from traits.api import Any, HasStrictTraits, Instance, List
 
+from tornado import ioloop
+
 
 def gui_kernel(gui_backend):
     """ Launch and return an IPython kernel GUI with support.
@@ -60,6 +62,11 @@ class InternalIPKernel(HasStrictTraits):
         """
         # Start IPython kernel with GUI event loop support
         self.ipkernel = gui_kernel(gui_backend)
+
+        # ipykernel 4.7 has changed the way it initializes the kernel which 
+        # requires
+        if not hasattr(self.ipkernel.kernel, 'io_loop'):
+            self.ipkernel.kernel.io_loop = ioloop.IOLoop.instance() # does not start it
 
         # This application will also act on the shell user namespace
         self.namespace = self.ipkernel.shell.user_ns

--- a/envisage/plugins/ipython_kernel/internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/internal_ipkernel.py
@@ -8,10 +8,9 @@ from distutils.version import StrictVersion as Version
 import ipykernel
 from ipykernel.connect import connect_qtconsole
 from ipykernel.kernelapp import IPKernelApp
+from tornado import ioloop
 
 from traits.api import Any, HasStrictTraits, Instance, List
-
-from tornado import ioloop
 
 NEEDS_IOLOOP_PATCH = Version(ipykernel.__version__) >= Version('4.7.0')
 
@@ -70,6 +69,7 @@ class InternalIPKernel(HasStrictTraits):
 
         # Since ipykernel 4.7, the io_loop attribute of the kernel is not
         # initialized anymore
+        # Reference: https://github.com/enthought/envisage/issues/107
         # Workaround: Retrieve the kernel on the IPykernelApp and set the
         # io_loop without starting it!
         if NEEDS_IOLOOP_PATCH and not hasattr(self.ipkernel.kernel, 'io_loop'):

--- a/envisage/plugins/ipython_kernel/internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/internal_ipkernel.py
@@ -3,12 +3,17 @@
 https://github.com/ipython/ipython/blob/2.x/examples/Embedding/internal_ipkernel.py
 
 """
+from distutils.version import StrictVersion as Version
+
+import ipykernel
 from ipykernel.connect import connect_qtconsole
 from ipykernel.kernelapp import IPKernelApp
 
 from traits.api import Any, HasStrictTraits, Instance, List
 
 from tornado import ioloop
+
+NEEDS_IOLOOP_PATCH = Version(ipykernel.__version__) >= Version('4.7.0')
 
 
 def gui_kernel(gui_backend):
@@ -63,10 +68,12 @@ class InternalIPKernel(HasStrictTraits):
         # Start IPython kernel with GUI event loop support
         self.ipkernel = gui_kernel(gui_backend)
 
-        # ipykernel 4.7 has changed the way it initializes the kernel which 
-        # requires
-        if not hasattr(self.ipkernel.kernel, 'io_loop'):
-            self.ipkernel.kernel.io_loop = ioloop.IOLoop.instance() # does not start it
+        # Since ipykernel 4.7, the io_loop attribute of the kernel is not
+        # initialized anymore
+        # Workaround: Retrieve the kernel on the IPykernelApp and set the
+        # io_loop without starting it!
+        if NEEDS_IOLOOP_PATCH and not hasattr(self.ipkernel.kernel, 'io_loop'):
+            self.ipkernel.kernel.io_loop = ioloop.IOLoop.instance() 
 
         # This application will also act on the shell user namespace
         self.namespace = self.ipkernel.shell.user_ns

--- a/etstool.py
+++ b/etstool.py
@@ -107,7 +107,7 @@ extra_dependencies = {
     'pyqt': {'pyqt<4.12'},  # FIXME: build of 4.12-1 appears to be bad
     # XXX once pyqt5 is available in EDM, we will want it here
     'pyqt5': set(),
-    'wx': {'wxpython'},
+    'wx': {'wxpython<3.0.2.0-6'},
     'null': set()
 }
 

--- a/etstool.py
+++ b/etstool.py
@@ -107,7 +107,7 @@ extra_dependencies = {
     'pyqt': {'pyqt<4.12'},  # FIXME: build of 4.12-1 appears to be bad
     # XXX once pyqt5 is available in EDM, we will want it here
     'pyqt5': set(),
-    'wx': {'wxpython<3.0.2.0-6'},
+    'wx': {'wxpython<3.0.2.0-6'}, # FIXME: wxpython 3.0.2.0-6 is broken of OS-X
     'null': set()
 }
 


### PR DESCRIPTION
This is a proposed fix to get over the changes coming with ipykernel 4.7. The `kernel.io_loop` was not initialized as in 4.6 leading to a failure in our test suite because the initialization was not triggered and the cleanup code of IPython was expecting the `io_loop` to be present. 

The changes introduced in this PR should not cause any troubles as they initialize the io_loop but does not start it.

It should fix #107 