### PR TITLE
Update (a few) broken imports and usage

### DIFF
--- a/envisage/developer/charm/charm.py
+++ b/envisage/developer/charm/charm.py
@@ -2,7 +2,7 @@
 
 
 # Enthought library imports.
-from envisage.developer.api import CodeBrowser, Module
+from envisage.developer.code_browser.api import CodeBrowser, Module
 from traits.api import Event, HasTraits, Instance, Str
 
 

--- a/envisage/developer/ui/view/plugin_browser.py
+++ b/envisage/developer/ui/view/plugin_browser.py
@@ -2,13 +2,13 @@
 
 
 # Enthought library imports.
-from envisage.api import ExtensionPoint, IPlugin
+from envisage.api import ExtensionPoint, IApplication, IExtensionPoint, IPlugin
 from traits.api import Delegate, HasTraits, Instance, List, Property
 from traits.api import Code, Str
 from traitsui.api import Item, TableEditor, View, VGroup
 from traitsui.table_column import ObjectColumn # fixme: non-api!
 
-class ExtensionPointModel(Hastraits):
+class ExtensionPointModel(HasTraits):
     """ A model for browsing an extension point. """
 
     # The plugin that offered the extension point.
@@ -21,7 +21,7 @@ class ExtensionPointModel(Hastraits):
 
 
 
-class ExtensionModel(Hastraits):
+class ExtensionModel(HasTraits):
     """ A model for browsing a contribution to an extension point. """
 
     # The plugin that made the contribution.

--- a/envisage/ui/single_project/view/project_view.py
+++ b/envisage/ui/single_project/view/project_view.py
@@ -12,7 +12,6 @@ The single project plugin's project view
 
 # Standard library imports.
 import logging
-from string import rfind
 
 # Enthought library imports
 from apptools.naming.api import Binding
@@ -262,7 +261,7 @@ class ProjectView(HasTraits):
         # on the new suffix, if any.
         name = self.name
         if old is not None and len(old) > 0:
-            index = rfind(name, " " + old)
+            index = (" " + old).rfind(name)
             if index > -1:
                 name = name[0:index]
         if new is not None and len(new) > 0:


### PR DESCRIPTION
This PR was prompted by #65 and I made a few trivial fixes to imports and broken usage. See details for the full output when I ran `python setup.py test` from this branch.

<details>

```
running test
running egg_info
creating envisage.egg-info
writing envisage.egg-info/PKG-INFO
writing dependency_links to envisage.egg-info/dependency_links.txt
writing entry points to envisage.egg-info/entry_points.txt
writing requirements to envisage.egg-info/requires.txt
writing top-level names to envisage.egg-info/top_level.txt
writing manifest file 'envisage.egg-info/SOURCES.txt'
reading manifest file 'envisage.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'envisage.egg-info/SOURCES.txt'
running build_ext
/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/IPython/kernel/__init__.py:13: ShimWarning: The `IPython.kernel` package has been deprecated since IPython 4.0.You should import from ipykernel or jupyter_client instead.
  "You should import from ipykernel or jupyter_client instead.", ShimWarning)
project_view (unittest.loader._FailedTest) ... ERROR
project_plugin (unittest.loader._FailedTest) ... ERROR
project_editor (unittest.loader._FailedTest) ... ERROR
project_runnable (unittest.loader._FailedTest) ... ERROR
api (unittest.loader._FailedTest) ... ERROR
test_action_with_nonexistent_group (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
action with non-existent group ... /home/rporuri/Github/work/envisage/envisage/ui/action/tests/action_manager_builder_test_case.py:59: DeprecationWarning: Please use assertRaises instead.
  ValueError, builder.create_menu_bar_manager, 'MenuBar'
ok
test_action_with_nonexistent_sibling (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
action with non-existent sibling ... ok
test_action_with_path_component_that_is_not_a_menu (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
action with path component that is not a menu ... ok
test_actions_and_menus_in_groups (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
actions and menus in groups ... ok
test_actions_make_submenus (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
actions make submenus ... ok
test_actions_make_submenus_before_and_after (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
actions make submenus before and after ... ok
test_actions_no_groups (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
actions no groups ... ok
test_duplicate_group (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
duplicate group ... ok
test_duplicate_menu (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
duplicate menu ... ok
test_explicit_groups (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
explicit groups ... ok
test_group_with_nonexistent_sibling (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
group with non-existent sibling ... ok
test_menu_with_nonexistent_sibling (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
menu with non-existent sibling ... ok
test_single_top_level_group (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
single top level group ... ok
test_single_top_level_menu_with_no_group (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
single top level menu with no group ... ok
test_sub_menus_no_groups (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
sub-menus no groups ... ok
test_top_level_menu_group (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
top level menu group ... ok
test_top_level_menu_non_existent_group (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
top level menu non-existent group ... ok
test_top_level_menus_no_groups_before_and_after (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
top level menus no groups, before and after ... ok
test_top_level_menus_with_no_groups (envisage.ui.action.tests.action_manager_builder_test_case.ActionManagerBuilderTestCase)
top level menus with_no groups ... ok
test_browse_this_module (envisage.developer.code_browser.tests.code_browser_test_case.CodeBrowserTestCase)
browse this module ... parsing module /home/rporuri/Github/work/envisage/envisage/developer/code_browser/tests/code_browser_test_case.py
parsed module /home/rporuri/Github/work/envisage/envisage/developer/code_browser/tests/code_browser_test_case.py
ok
test_has_traits (envisage.developer.code_browser.tests.code_browser_test_case.CodeBrowserTestCase)
has traits ... parsing module /home/rporuri/Github/work/envisage/envisage/developer/code_browser/tests/example_1.py
parsed module /home/rporuri/Github/work/envisage/envisage/developer/code_browser/tests/example_1.py
ok
run (unittest.loader._FailedTest) ... ok
test_file_resource (envisage.resource.tests.resource_manager_test_case.ResourceManagerTestCase)
file resource ... ok
test_http_resource (envisage.resource.tests.resource_manager_test_case.ResourceManagerTestCase)
http resource ... /home/rporuri/Github/work/envisage/envisage/resource/tests/resource_manager_test_case.py:147: DeprecationWarning: Please use assertEqual instead.
  self.assertEquals(contents, 'This is a test file.\n')
ok
test_no_such_file_resource (envisage.resource.tests.resource_manager_test_case.ResourceManagerTestCase)
no such file resource ... ok
test_no_such_http_resource (envisage.resource.tests.resource_manager_test_case.ResourceManagerTestCase)
no such http resource ... ok
test_no_such_package_resource (envisage.resource.tests.resource_manager_test_case.ResourceManagerTestCase)
no such package resource ... ok
test_package_resource (envisage.resource.tests.resource_manager_test_case.ResourceManagerTestCase)
package resource ... ok
test_unknown_protocol (envisage.resource.tests.resource_manager_test_case.ResourceManagerTestCase)
unknown protocol ... ok
ipython_shell_view (unittest.loader._FailedTest) ... ERROR
api (unittest.loader._FailedTest) ... ERROR
testCommunication (envisage.plugins.remote_editor.communication.tests.test_communication.CommunicationTestCase)
Can the Server communicate with Clients and handle errors ... /home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:181: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('0.0.0.0', 0)>
  pass
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/tests/test_communication.py:65: ResourceWarning: unclosed <socket.socket fd=5, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 46623)>
  self.assert_(not Server.ping(get_server_port()))
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/tests/test_communication.py:65: DeprecationWarning: Please use assertTrue instead.
  self.assert_(not Server.ping(get_server_port()))
Server listening on port 53715...
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:159: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 33430), raddr=('127.0.0.1', 53715)>
  send_port(server_port, "ping", port, timeout=timeout)
Server received: ping 39449
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 50348), raddr=('127.0.0.1', 39449)>
  status = send_port(port, command, arguments)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/tests/test_communication.py:76: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 39449)>
  self.assert_(Server.ping(tmp))
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/tests/test_communication.py:76: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 39449), raddr=('127.0.0.1', 50348)>
  self.assert_(Server.ping(tmp))
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:159: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 33434), raddr=('127.0.0.1', 53715)>
  send_port(server_port, "ping", port, timeout=timeout)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:159: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 33436), raddr=('127.0.0.1', 53715)>
  send_port(server_port, "ping", port, timeout=timeout)
Server received: ping 41387
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 44380), raddr=('127.0.0.1', 41387)>
  status = send_port(port, command, arguments)
Server received: ping 52267
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:34: ResourceWarning: unclosed <socket.socket fd=7, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 41387)>
  if server_port == -1 or not Server.ping(server_port, timeout=5):
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=11, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33212), raddr=('127.0.0.1', 52267)>
  status = send_port(port, command, arguments)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:34: ResourceWarning: unclosed <socket.socket fd=6, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 52267)>
  if server_port == -1 or not Server.ping(server_port, timeout=5):
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:34: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 52267), raddr=('127.0.0.1', 33212)>
  if server_port == -1 or not Server.ping(server_port, timeout=5):
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:34: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 41387), raddr=('127.0.0.1', 44380)>
  if server_port == -1 or not Server.ping(server_port, timeout=5):
Server received: register 45943client2client1
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:93: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33442)>
  arguments)
Client listening on port 45943...
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:93: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33444), raddr=('127.0.0.1', 53715)>
  arguments)
Server received: register 56473client1client2
Client listening on port 56473...
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34422), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
Client on port 45943 received: __keepalive__ 
Client on port 56473 received: __orphaned__ 0
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34732), raddr=('127.0.0.1', 56473)>
  status = send_port(port, command, arguments)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34422)>
  server, address = accept_no_intr(sock)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34426), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
Client on port 45943 received: __orphaned__ 0
Client on port 56473 sending: foo bar
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:232: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33452), raddr=('127.0.0.1', 53715)>
  self.error = not send_port(self._server_port, 'send', args)
Server received: send 56473foobar
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34426)>
  server, address = accept_no_intr(sock)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34430), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
Client on port 45943 received: foo bar
Client on port 56473 sending: Très bien
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:232: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33456), raddr=('127.0.0.1', 53715)>
  self.error = not send_port(self._server_port, 'send', args)
Server received: send 56473Trèsbien
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34434), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34430)>
  server, address = accept_no_intr(sock)
Client on port 45943 received: Très bien
Server received: unregister 56473
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:214: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33460), raddr=('127.0.0.1', 53715)>
  send_port(self._server_port, 'unregister', str(self._port))
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34434)>
  server, address = accept_no_intr(sock)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=14, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34438), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
Client on port 45943 received: __orphaned__ 1
Server received: ping 40025
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:159: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 33464), raddr=('127.0.0.1', 53715)>
  send_port(server_port, "ping", port, timeout=timeout)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=15, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 38460), raddr=('127.0.0.1', 40025)>
  status = send_port(port, command, arguments)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:34: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=2049, proto=0, laddr=('127.0.0.1', 40025)>
  if server_port == -1 or not Server.ping(server_port, timeout=5):
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:34: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 40025), raddr=('127.0.0.1', 38460)>
  if server_port == -1 or not Server.ping(server_port, timeout=5):
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:93: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33468), raddr=('127.0.0.1', 53715)>
  arguments)
Server received: register 33403client1client2
Client listening on port 33403...
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34438)>
  server, address = accept_no_intr(sock)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34446), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
Client on port 45943 received: __keepalive__ 
Client on port 33403 received: __orphaned__ 0
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 59744), raddr=('127.0.0.1', 33403)>
  status = send_port(port, command, arguments)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34446)>
  server, address = accept_no_intr(sock)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34450), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
Client on port 45943 received: __orphaned__ 0
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=16, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33403), raddr=('127.0.0.1', 59744)>
  server, address = accept_no_intr(sock)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 59748), raddr=('127.0.0.1', 33403)>
  status = send_port(port, command, arguments)
Client on port 33403 received: dummy 
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:214: ResourceWarning: unclosed <socket.socket fd=9, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33478), raddr=('127.0.0.1', 53715)>
  send_port(self._server_port, 'unregister', str(self._port))
Server received: unregister 33403
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=16, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34456), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
/home/rporuri/.edm/envs/temp3/lib/python3.6/threading.py:916: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33403)>
  self.run()
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=12, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34450)>
  server, address = accept_no_intr(sock)
/home/rporuri/.edm/envs/temp3/lib/python3.6/threading.py:916: ResourceWarning: unclosed <socket.socket fd=15, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33403), raddr=('127.0.0.1', 59748)>
  self.run()
Client on port 45943 received: __orphaned__ 1
Client on port 45943 sending: foo bar
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:232: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 33482), raddr=('127.0.0.1', 53715)>
  self.error = not send_port(self._server_port, 'send', args)
Server received: send 45943foobar
No spawn command is defined for object type 'client1'.
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/client.py:107: ResourceWarning: unclosed <socket.socket fd=8, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 45943), raddr=('127.0.0.1', 34456)>
  server, address = accept_no_intr(sock)
/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/communication/server.py:325: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 34460), raddr=('127.0.0.1', 45943)>
  status = send_port(port, command, arguments)
Client on port 45943 received: __error__ 1No spawn command is defined for object type 'client1'.
Error status received from the server: 1
No spawn command is defined for object type 'client1'.
ok
enshell_plugin (unittest.loader._FailedTest) ... ERROR
start_editra (unittest.loader._FailedTest) ... ERROR
editra_plugin (unittest.loader._FailedTest) ... ERROR
test_import_from_api (envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.TestIPythonKernelPlugin) ... ok
test_kernel_namespace_extension_point (envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.TestIPythonKernelPlugin) ... ---------- application starting ----------
plugin envisage.core starting
/home/rporuri/Github/work/envisage/envisage/plugin.py:181: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  logger.warn('plugin %s has no Id - using <%s>' % (self, id))
plugin <envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.TestIPythonKernelPlugin.test_kernel_namespace_extension_point.<locals>.NamespacePlugin object at 0x7f4a6c51afc0> has no Id - using <envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.NamespacePlugin>
extensions to <envisage.preferences> <[[], [], []]>
loading preferences from </home/rporuri/.enthought/test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[], [], []]>
extensions to <envisage.categories> <[[], [], []]>
extensions to <envisage.service_offers> <[[], [<envisage.service_offer.ServiceOffer object at 0x7f4a6ca84f68>], []]>
service <1> registered envisage.plugins.ipython_kernel.internal_ipkernel.InternalIPKernel
plugin envisage.core started
plugin envisage.plugins.ipython_kernel starting
plugin envisage.plugins.ipython_kernel started
plugin envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.NamespacePlugin starting
plugin envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.NamespacePlugin started
---------- application started ----------
extensions to <ipython_plugin.namespace> <[[], [], [('y', 'hi')]]>
NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing kernel-9482.json
---------- application stopping ----------
plugin envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.NamespacePlugin stopping
plugin envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.NamespacePlugin stopped
plugin envisage.plugins.ipython_kernel stopping
Shutting down the embedded ipython kernel
plugin envisage.plugins.ipython_kernel stopped
plugin envisage.core stopping
service <1> unregistered
plugin envisage.core stopped
saving preferences to </home/rporuri/.enthought/test/preferences.ini>
---------- application stopped ----------
ok
test_kernel_service (envisage.plugins.ipython_kernel.tests.test_ipython_kernel_plugin.TestIPythonKernelPlugin) ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[], []]>
loading preferences from </home/rporuri/.enthought/test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[], []]>
extensions to <envisage.categories> <[[], []]>
extensions to <envisage.service_offers> <[[], [<envisage.service_offer.ServiceOffer object at 0x7f4a6c4fa938>]]>
service <1> registered envisage.plugins.ipython_kernel.internal_ipkernel.InternalIPKernel
plugin envisage.core started
plugin envisage.plugins.ipython_kernel starting
plugin envisage.plugins.ipython_kernel started
---------- application started ----------
extensions to <ipython_plugin.namespace> <[[], []]>
NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing kernel-9482.json
---------- application stopping ----------
plugin envisage.plugins.ipython_kernel stopping
Shutting down the embedded ipython kernel
plugin envisage.plugins.ipython_kernel stopped
plugin envisage.core stopping
service <1> unregistered
plugin envisage.core stopped
saving preferences to </home/rporuri/.enthought/test/preferences.ini>
---------- application stopped ----------
ok
test_initial_namespace (envisage.plugins.ipython_kernel.tests.test_internal_ipkernel.TestInternalIPKernel) ... NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing kernel-9482.json
ok
test_io_pub_thread_stopped (envisage.plugins.ipython_kernel.tests.test_internal_ipkernel.TestInternalIPKernel) ... NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing kernel-9482.json
ok
test_lifecycle (envisage.plugins.ipython_kernel.tests.test_internal_ipkernel.TestInternalIPKernel) ... NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049


To connect another client to this kernel, use:
    --existing kernel-9482.json
ok
bare_app (unittest.loader._FailedTest) ... ERROR
refresh_code_plugin_definition (unittest.loader._FailedTest) ... ERROR
fbi_plugin (unittest.loader._FailedTest) ... ERROR
fbi_plugin_definition (unittest.loader._FailedTest) ... ERROR
test_get_plugin (envisage.tests.plugin_manager_test_case.PluginManagerTestCase)
get plugin ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
ok
test_ignore_plugins_matching_a_wildcard_in_the_exclude_list (envisage.tests.plugin_manager_test_case.PluginManagerTestCase) ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a68238258> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a682382b0> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin foo starting
plugin foo started
plugin bar starting
plugin bar started
plugin baz starting
plugin baz started
plugin baz stopping
plugin baz stopped
plugin bar stopping
plugin bar stopped
plugin foo stopping
plugin foo stopped
ok
test_ignore_plugins_whose_ids_are_in_the_exclude_list (envisage.tests.plugin_manager_test_case.PluginManagerTestCase) ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a68238410> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a68238258> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin foo starting
plugin foo started
plugin bar starting
plugin bar started
plugin baz starting
plugin baz started
plugin baz stopping
plugin baz stopped
plugin bar stopping
plugin bar stopped
plugin foo stopping
plugin foo stopped
ok
test_iteration_over_plugins (envisage.tests.plugin_manager_test_case.PluginManagerTestCase)
iteration over plugins ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.BadPlugin object at 0x7f4a682382b0> has no Id - using <envisage.tests.plugin_manager_test_case.BadPlugin>
ok
test_only_include_plugins_matching_a_wildcard_in_the_include_list (envisage.tests.plugin_manager_test_case.PluginManagerTestCase) ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a682382b0> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a68238410> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin foo starting
plugin foo started
plugin bar starting
plugin bar started
plugin baz starting
plugin baz started
plugin baz stopping
plugin baz stopped
plugin bar stopping
plugin bar stopped
plugin foo stopping
plugin foo stopped
ok
test_only_include_plugins_whose_ids_are_in_the_include_list (envisage.tests.plugin_manager_test_case.PluginManagerTestCase) ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a68238258> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a682382b0> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin foo starting
plugin foo started
plugin bar starting
plugin bar started
plugin baz starting
plugin baz started
plugin baz stopping
plugin baz stopped
plugin bar stopping
plugin bar stopped
plugin foo stopping
plugin foo stopped
ok
test_start_and_stop (envisage.tests.plugin_manager_test_case.PluginManagerTestCase)
start and stop ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin envisage.tests.plugin_manager_test_case.SimplePlugin starting
plugin envisage.tests.plugin_manager_test_case.SimplePlugin started
plugin envisage.tests.plugin_manager_test_case.SimplePlugin stopping
plugin envisage.tests.plugin_manager_test_case.SimplePlugin stopped
ok
test_start_and_stop_errors (envisage.tests.plugin_manager_test_case.PluginManagerTestCase)
start and stop errors ... plugin <envisage.tests.plugin_manager_test_case.SimplePlugin object at 0x7f4a6c4fae08> has no Id - using <envisage.tests.plugin_manager_test_case.SimplePlugin>
plugin envisage.tests.plugin_manager_test_case.SimplePlugin starting
plugin envisage.tests.plugin_manager_test_case.SimplePlugin started
plugin <envisage.tests.plugin_manager_test_case.BadPlugin object at 0x7f4a68238410> has no Id - using <envisage.tests.plugin_manager_test_case.BadPlugin>
plugin envisage.tests.plugin_manager_test_case.BadPlugin starting
plugin envisage.tests.plugin_manager_test_case.BadPlugin stopping
ok
test_class_already_loaded (envisage.tests.class_load_hook_test_case.ClassLoadHookTestCase)
class already loaded ... ok
test_connect (envisage.tests.class_load_hook_test_case.ClassLoadHookTestCase)
connect ... ok
test_disconnect (envisage.tests.class_load_hook_test_case.ClassLoadHookTestCase)
disconnect ... ok
test_function_service_factory (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
function service factory ... service <1> registered envisage.tests.service_registry_test_case.IFoo
ok
test_get_and_set_service_properties (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
get and set service properties ... service <1> registered envisage.tests.service_registry_test_case.IFoo
service <2> registered envisage.tests.service_registry_test_case.IFoo
ok
test_get_service (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
get service ... service <1> registered envisage.tests.service_registry_test_case.IFoo
service <2> registered envisage.tests.service_registry_test_case.IFoo
ok
test_get_service_with_query (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
get service with query ... service <1> registered envisage.tests.service_registry_test_case.IFoo
service <2> registered envisage.tests.service_registry_test_case.IFoo
ok
test_get_services (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
get services ... service <1> registered envisage.tests.service_registry_test_case.IFoo
service <2> registered envisage.tests.service_registry_test_case.IFoo
ok
test_get_services_with_query (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
get services with query ... service <1> registered envisage.tests.service_registry_test_case.IFoo
service <2> registered envisage.tests.service_registry_test_case.IFoo
ok
test_get_services_with_strings (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
get services with strings ... service <1> registered envisage.tests.foo.IFoo
service <2> registered envisage.tests.foo.IFoo
ok
test_imported_service_factory (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
imported service factory ... service <1> registered traits.has_traits.HasTraits
ok
test_lazy_bound_method_service_factory (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
lazy bound method service factory ... service <1> registered envisage.tests.i_foo.IFoo
ok
test_lazy_function_service_factory (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
lazy function service factory ... service <1> registered envisage.tests.i_foo.IFoo
ok
test_minimize_and_maximize (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
minimize and maximize ... service <1> registered envisage.tests.service_registry_test_case.IFoo
service <2> registered envisage.tests.service_registry_test_case.IFoo
service <3> registered envisage.tests.service_registry_test_case.IFoo
ok
test_should_get_exception_if_required_service_is_missing (envisage.tests.service_registry_test_case.ServiceRegistryTestCase) ... ok
test_should_get_required_service (envisage.tests.service_registry_test_case.ServiceRegistryTestCase) ... service <1> registered envisage.tests.service_registry_test_case.Foo
ok
test_unregister_service (envisage.tests.service_registry_test_case.ServiceRegistryTestCase)
unregister service ... service <1> registered envisage.tests.service_registry_test_case.IFoo
service <2> registered envisage.tests.service_registry_test_case.IFoo
service <1> unregistered
service <2> unregistered
ok
test_exclude_multiple (envisage.tests.egg_plugin_manager_test_case.EggPluginManagerTestCase)
exclude multiple ... egg plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a6824f990>]>
plugin acme.foo starting
plugin acme.foo started
plugin acme.foo stopping
plugin acme.foo stopped
ok
test_exclude_specific (envisage.tests.egg_plugin_manager_test_case.EggPluginManagerTestCase)
exclude specific ... egg plugin manager found plugins <[<acme.bar.bar_plugin.BarPlugin object at 0x7f4a6824fd00>]>
plugin acme.bar starting
plugin acme.bar started
plugin acme.bar stopping
plugin acme.bar stopped
ok
test_include_multiple (envisage.tests.egg_plugin_manager_test_case.EggPluginManagerTestCase)
include multiple ... egg plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a6824feb8>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a6824f7d8>, <acme.baz.baz_plugin.BazPlugin object at 0x7f4a6824f6d0>]>
plugin acme.foo starting
plugin acme.foo started
plugin acme.bar starting
plugin acme.bar started
plugin acme.baz starting
plugin acme.baz started
plugin acme.baz stopping
plugin acme.baz stopped
plugin acme.bar stopping
plugin acme.bar stopped
plugin acme.foo stopping
plugin acme.foo stopped
ok
test_include_specific (envisage.tests.egg_plugin_manager_test_case.EggPluginManagerTestCase)
include specific ... egg plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a6824f938>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a6824f6d0>]>
plugin acme.foo starting
plugin acme.foo started
plugin acme.bar starting
plugin acme.bar started
plugin acme.bar stopping
plugin acme.bar stopped
plugin acme.foo stopping
plugin acme.foo stopped
ok
test_no_include_or_exclude (envisage.tests.egg_plugin_manager_test_case.EggPluginManagerTestCase)
no include or exclude ... egg plugin manager found plugins <[<envisage.core_plugin.CorePlugin object at 0x7f4a6824fa40>, <acme.foo.foo_plugin.FooPlugin object at 0x7f4a6824fd00>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a6824fe60>, <acme.baz.baz_plugin.BazPlugin object at 0x7f4a6824feb8>]>
ok
test_find_plugins_in_packages_on_the_plugin_path (envisage.tests.package_plugin_manager_test_case.PackagePluginManagerTestCase) ... Looking for plugins in /home/rporuri/Github/work/envisage/envisage/tests/plugins/pear
package plugin manager found plugins <[<pear.pear_plugin.PearPlugin object at 0x7f4a6824f570>, <orange.orange_plugin.OrangePlugin object at 0x7f4a6824f1a8>, <banana.banana_plugin.BananaPlugin object at 0x7f4a6824f0a0>]>
ok
test_ignore_plugins_matching_a_wildcard_in_the_exclude_list (envisage.tests.package_plugin_manager_test_case.PackagePluginManagerTestCase) ... Looking for plugins in /home/rporuri/Github/work/envisage/envisage/tests/plugins/pear
package plugin manager found plugins <[<banana.banana_plugin.BananaPlugin object at 0x7f4a6824f570>]>
plugin banana starting
plugin banana started
plugin banana stopping
plugin banana stopped
ok
test_ignore_plugins_whose_ids_are_in_the_exclude_list (envisage.tests.package_plugin_manager_test_case.PackagePluginManagerTestCase) ... Looking for plugins in /home/rporuri/Github/work/envisage/envisage/tests/plugins/pear
package plugin manager found plugins <[<banana.banana_plugin.BananaPlugin object at 0x7f4a6824f0a0>]>
plugin banana starting
plugin banana started
plugin banana stopping
plugin banana stopped
ok
test_only_find_plugins_matching_a_wildcard_in_the_include_list (envisage.tests.package_plugin_manager_test_case.PackagePluginManagerTestCase) ... Looking for plugins in /home/rporuri/Github/work/envisage/envisage/tests/plugins/pear
package plugin manager found plugins <[<pear.pear_plugin.PearPlugin object at 0x7f4a6824f0a0>, <orange.orange_plugin.OrangePlugin object at 0x7f4a6824fd00>]>
plugin pear starting
plugin pear started
plugin orange starting
plugin orange started
plugin orange stopping
plugin orange stopped
plugin pear stopping
plugin pear stopped
ok
test_only_find_plugins_whose_ids_are_in_the_include_list (envisage.tests.package_plugin_manager_test_case.PackagePluginManagerTestCase) ... Looking for plugins in /home/rporuri/Github/work/envisage/envisage/tests/plugins/pear
package plugin manager found plugins <[<pear.pear_plugin.PearPlugin object at 0x7f4a6824f0a0>, <orange.orange_plugin.OrangePlugin object at 0x7f4a6824feb8>]>
plugin pear starting
plugin pear started
plugin orange starting
plugin orange started
plugin orange stopping
plugin orange stopped
plugin pear stopping
plugin pear stopped
ok
test_reflect_changes_to_the_plugin_path (envisage.tests.package_plugin_manager_test_case.PackagePluginManagerTestCase) ... package plugin manager found plugins <[]>
Looking for plugins in /home/rporuri/Github/work/envisage/envisage/tests/plugins/pear
package plugin manager found plugins <[<pear.pear_plugin.PearPlugin object at 0x7f4a6824fd00>, <orange.orange_plugin.OrangePlugin object at 0x7f4a6824f150>, <banana.banana_plugin.BananaPlugin object at 0x7f4a6824f048>]>
package plugin manager found plugins <[]>
ok
test_add_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
add extension point ... extension point <my.ep> added
ok
test_empty_registry (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
empty registry ... ok
test_get_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
get extension point ... extension point <my.ep> added
ok
test_remove_empty_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove empty_extension point ... extension point <my.ep> added
extension point <my.ep> removed
ok
test_remove_non_empty_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove non-empty extension point ... extension point <my.ep> added
extension point <my.ep> removed
ok
test_remove_non_existent_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove non existent extension point ... ok
test_remove_non_existent_listener (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove non existent listener ... ok
test_set_extensions (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
set extensions ... extension point <my.ep> added
ok
test_import_dotted_module (envisage.tests.import_manager_test_case.ImportManagerTestCase)
import dotted module ... ok
test_import_dotted_symbol (envisage.tests.import_manager_test_case.ImportManagerTestCase)
import dotted symbol ... ok
test_import_nested_symbol (envisage.tests.import_manager_test_case.ImportManagerTestCase)
import nested symbol ... ok
test_application_gets_propogated_to_plugin_managers (envisage.tests.composite_plugin_manager_test_case.CompositePluginManagerTestCase) ... ok
test_correct_exception_propagated_from_plugin_manager (envisage.tests.composite_plugin_manager_test_case.CompositePluginManagerTestCase) ... ok
test_find_no_plugins_if_there_are_no_plugin_managers (envisage.tests.composite_plugin_manager_test_case.CompositePluginManagerTestCase) ... ok
test_find_no_plugins_if_there_are_no_plugins_in_plugin_managers (envisage.tests.composite_plugin_manager_test_case.CompositePluginManagerTestCase) ... ok
test_find_plugins_in_a_multiple_plugin_managers (envisage.tests.composite_plugin_manager_test_case.CompositePluginManagerTestCase) ... plugin <envisage.tests.composite_plugin_manager_test_case.SimplePlugin object at 0x7f4a68238410> has no Id - using <envisage.tests.composite_plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.composite_plugin_manager_test_case.SimplePlugin object at 0x7f4a68238f10> has no Id - using <envisage.tests.composite_plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.composite_plugin_manager_test_case.SimplePlugin object at 0x7f4a68238e60> has no Id - using <envisage.tests.composite_plugin_manager_test_case.SimplePlugin>
plugin red starting
plugin red started
plugin yellow starting
plugin yellow started
plugin green starting
plugin green started
plugin green stopping
plugin green stopped
plugin yellow stopping
plugin yellow stopped
plugin red stopping
plugin red stopped
ok
test_find_plugins_in_a_single_plugin_manager (envisage.tests.composite_plugin_manager_test_case.CompositePluginManagerTestCase) ... plugin <envisage.tests.composite_plugin_manager_test_case.SimplePlugin object at 0x7f4a68238d58> has no Id - using <envisage.tests.composite_plugin_manager_test_case.SimplePlugin>
plugin <envisage.tests.composite_plugin_manager_test_case.SimplePlugin object at 0x7f4a68238e08> has no Id - using <envisage.tests.composite_plugin_manager_test_case.SimplePlugin>
plugin red starting
plugin red started
plugin yellow starting
plugin yellow started
plugin yellow stopping
plugin yellow stopped
plugin red stopping
plugin red stopped
ok
test_propogate_plugin_added_or_remove_events_from_plugin_managers (envisage.tests.composite_plugin_manager_test_case.CompositePluginManagerTestCase) ... plugin <envisage.plugin.Plugin object at 0x7f4a68238e08> has no Id - using <envisage.plugin.Plugin>
ok
test_add_plugin (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
add plugin ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3]]>
ok
test_append (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
append ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3], [98, 99, 100]]>
provider <<envisage.tests.application_test_case.PluginB object at 0x7f4a6c79f468>> extension point changed
ok
test_assign_empty_list (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
assign empty list ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3], [98, 99, 100]]>
provider <<envisage.tests.application_test_case.PluginB object at 0x7f4a681ddca8>> extension point changed
ok
test_assign_empty_list_no_event (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
assign empty list no event ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
provider <<envisage.tests.application_test_case.PluginB object at 0x7f4a681dd4c0>> extension point changed
extensions to <a.x> <[[], [], [98, 99, 100]]>
ok
test_assign_non_empty_list (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
assign non-empty list ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3], [98, 99, 100]]>
provider <<envisage.tests.application_test_case.PluginB object at 0x7f4a68178468>> extension point changed
ok
test_remove (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
remove ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3], [98, 99, 100]]>
provider <<envisage.tests.application_test_case.PluginB object at 0x7f4a68178780>> extension point changed
ok
test_remove_plugin (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
remove plugin ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3], [98, 99, 100]]>
ok
test_set_extension_point (envisage.tests.extension_point_changed_test_case.ExtensionPointChangedTestCase)
set extension point ... ---------- application starting ----------
plugin A starting
plugin A started
---------- application started ----------
ok
test_categories (envisage.tests.core_plugin_test_case.CorePluginTestCase)
categories ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[], []]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[], []]>
extensions to <envisage.categories> <[[], [<envisage.category.Category object at 0x7f4a6819edb0>]]>
extensions to <envisage.service_offers> <[[], []]>
plugin envisage.core started
plugin A starting
plugin A started
---------- application started ----------
ok
test_class_load_hooks (envisage.tests.core_plugin_test_case.CorePluginTestCase)
class load hooks ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[], []]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[], [<envisage.class_load_hook.ClassLoadHook object at 0x7f4a6819eeb8>]]>
extensions to <envisage.categories> <[[], []]>
extensions to <envisage.service_offers> <[[], []]>
plugin envisage.core started
plugin A starting
plugin A started
---------- application started ----------
ok
test_dynamically_added_category (envisage.tests.core_plugin_test_case.CorePluginTestCase)
dynamically added category ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[]]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[]]>
extensions to <envisage.categories> <[[]]>
extensions to <envisage.service_offers> <[[]]>
plugin envisage.core started
---------- application started ----------
ok
test_dynamically_added_class_load_hooks (envisage.tests.core_plugin_test_case.CorePluginTestCase)
dynamically class load hooks ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[]]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[]]>
extensions to <envisage.categories> <[[]]>
extensions to <envisage.service_offers> <[[]]>
plugin envisage.core started
---------- application started ----------
ok
test_dynamically_added_preferences (envisage.tests.core_plugin_test_case.CorePluginTestCase)
dynamically added preferences ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[]]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[]]>
extensions to <envisage.categories> <[[]]>
extensions to <envisage.service_offers> <[[]]>
plugin envisage.core started
---------- application started ----------
loading preferences from <<_io.BufferedReader name='/home/rporuri/Github/work/envisage/envisage/tests/preferences.ini'>>
ok
test_dynamically_added_service_offer (envisage.tests.core_plugin_test_case.CorePluginTestCase)
dynamically added service offer ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[]]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[]]>
extensions to <envisage.categories> <[[]]>
extensions to <envisage.service_offers> <[[]]>
plugin envisage.core started
---------- application started ----------
service <1> registered envisage.tests.core_plugin_test_case.IMyService
ok
test_preferences (envisage.tests.core_plugin_test_case.CorePluginTestCase)
preferences ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[], ['file:///home/rporuri/Github/work/envisage/envisage/tests/preferences.ini']]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
loading preferences from <<_io.BufferedReader name='/home/rporuri/Github/work/envisage/envisage/tests/preferences.ini'>>
extensions to <envisage.class_load_hooks> <[[], []]>
extensions to <envisage.categories> <[[], []]>
extensions to <envisage.service_offers> <[[], []]>
plugin envisage.core started
plugin A starting
plugin A started
---------- application started ----------
---------- application stopping ----------
plugin A stopping
plugin A stopped
plugin envisage.core stopping
plugin envisage.core stopped
saving preferences to </home/rporuri/.enthought/core.plugin.test/preferences.ini>
---------- application stopped ----------
ok
test_service_offers (envisage.tests.core_plugin_test_case.CorePluginTestCase)
service offers ... ---------- application starting ----------
plugin envisage.core starting
extensions to <envisage.preferences> <[[], []]>
loading preferences from </home/rporuri/.enthought/core.plugin.test/preferences.ini>
extensions to <envisage.class_load_hooks> <[[], []]>
extensions to <envisage.categories> <[[], []]>
extensions to <envisage.service_offers> <[[], [<envisage.service_offer.ServiceOffer object at 0x7f4a6816f9e8>]]>
service <1> registered envisage.tests.core_plugin_test_case.IMyService
plugin envisage.core started
plugin A starting
plugin A started
---------- application started ----------
plugin envisage.core stopping
service <1> unregistered
plugin envisage.core stopped
ok
test_append (envisage.tests.slice_test_case.SliceTestCase)
append ... ok
test_assign_extended_slice (envisage.tests.slice_test_case.SliceTestCase)
assign extended slice ... ok
test_assign_item (envisage.tests.slice_test_case.SliceTestCase)
assign item ... ok
test_assign_slice (envisage.tests.slice_test_case.SliceTestCase)
assign slice ... ok
test_del_all (envisage.tests.slice_test_case.SliceTestCase)
del all ... ok
test_del_extended_slice (envisage.tests.slice_test_case.SliceTestCase)
del extended slice ... ok
test_del_item (envisage.tests.slice_test_case.SliceTestCase)
del item ... ok
test_del_slice (envisage.tests.slice_test_case.SliceTestCase)
del slice ... ok
test_extend (envisage.tests.slice_test_case.SliceTestCase)
extend ... ok
test_insert (envisage.tests.slice_test_case.SliceTestCase)
insert ... ok
test_pop (envisage.tests.slice_test_case.SliceTestCase)
remove ... ok
test_remove (envisage.tests.slice_test_case.SliceTestCase)
remove ... ok
test_reverse (envisage.tests.slice_test_case.SliceTestCase)
reverse ... ok
test_sort (envisage.tests.slice_test_case.SliceTestCase)
sort ... ok
test_explicit_extension_registry (envisage.tests.extension_point_binding_test_case.ExtensionPointBindingTestCase)
explicit extension registry ... extension point <my.ep> added
ok
test_set_extensions_via_registry (envisage.tests.extension_point_binding_test_case.ExtensionPointBindingTestCase)
set extensions via registry ... extension point <my.ep> added
ok
test_set_extensions_via_trait (envisage.tests.extension_point_binding_test_case.ExtensionPointBindingTestCase)
set extensions via trait ... extension point <my.ep> added
ok
test_should_be_able_to_bind_multiple_traits_on_a_single_object (envisage.tests.extension_point_binding_test_case.ExtensionPointBindingTestCase) ... extension point <my.ep> added
extension point <another.ep> added
ok
test_untyped_extension_point (envisage.tests.extension_point_binding_test_case.ExtensionPointBindingTestCase)
untyped extension point ... extension point <my.ep> added
ok
test_add_plugins_to_empty_application (envisage.tests.plugin_test_case.PluginTestCase)
add plugins to empty application ... ---------- application starting ----------
---------- application started ----------
plugin A starting
plugin A started
extensions to <x> <[[]]>
ok
test_contributes_to (envisage.tests.plugin_test_case.PluginTestCase)
contributes to ... extensions to <x> <[[], [1, 2, 3]]>
ok
test_contributes_to_decorator (envisage.tests.plugin_test_case.PluginTestCase)
contributes to decorator ... extensions to <x> <[[], [1, 2, 3]]>
ok
test_contributes_to_decorator_ignored_if_trait_present (envisage.tests.plugin_test_case.PluginTestCase)
contributes to decorator ignored if trait present ... extensions to <x> <[[], [1, 2, 3]]>
ok
test_exception_in_trait_contribution (envisage.tests.plugin_test_case.PluginTestCase)
exception in trait contribution ... getting extensions from <envisage.tests.plugin_test_case.PluginTestCase.test_exception_in_trait_contribution.<locals>.PluginB object at 0x7f4a68108e60>, trait <x>
Traceback (most recent call last):
  File "/home/rporuri/Github/work/envisage/envisage/plugin.py", line 334, in _get_extensions_from_trait
    extensions = getattr(self, trait_name)
  File "/home/rporuri/Github/work/envisage/envisage/tests/plugin_test_case.py", line 251, in _x_default
    raise 1/0
ZeroDivisionError: division by zero
ok
test_home (envisage.tests.plugin_test_case.PluginTestCase)
home ... ok
test_id_policy (envisage.tests.plugin_test_case.PluginTestCase)
id policy ... plugin <envisage.plugin.Plugin object at 0x7f4a680c7570> has no Id - using <envisage.plugin.Plugin>
plugin <envisage.plugin.Plugin object at 0x7f4a680c75c8> has no Id - using <envisage.plugin.Plugin>
plugin <envisage.plugin.Plugin object at 0x7f4a680c7570> has no name - using <Plugin>
plugin <envisage.plugin.Plugin object at 0x7f4a680c7570> has no Id - using <envisage.plugin.Plugin>
ok
test_multiple_trait_contributions (envisage.tests.plugin_test_case.PluginTestCase)
multiple trait contributions ... ok
test_name_policy (envisage.tests.plugin_test_case.PluginTestCase)
name policy ... plugin <envisage.plugin.Plugin object at 0x7f4a6824f468> has no name - using <Plugin>
plugin <envisage.plugin.Plugin object at 0x7f4a680b9ba0> has no name - using <Plugin>
plugin <envisage.tests.plugin_test_case.PluginTestCase.test_name_policy.<locals>.ThisIsMyPlugin object at 0x7f4a680b91a8> has no name - using <This Is My Plugin>
ok
test_no_recursion (envisage.tests.plugin_test_case.PluginTestCase)
Regression test for #119. ... extensions to <bob> <[[]]>
ok
test_plugin_activator (envisage.tests.plugin_test_case.PluginTestCase)
plugin activator. ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
---------- application started ----------
---------- application stopping ----------
plugin B stopping
plugin B stopped
plugin A stopping
plugin A stopped
loading preferences from </home/rporuri/.enthought/test/preferences.ini>
saving preferences to </home/rporuri/.enthought/test/preferences.ini>
---------- application stopped ----------
ok
test_service (envisage.tests.plugin_test_case.PluginTestCase)
service ... ---------- application starting ----------
plugin A starting
DEPRECATED: Do not use the "service=True" metadata anymore. Services should now be offered using the service offer extension point (envisage.service_offers) from the core plugin. Plugin <envisage.tests.plugin_test_case.PluginTestCase.test_service.<locals>.PluginA object at 0x7f4a680b9f10> trait <foo>
service <1> registered envisage.tests.plugin_test_case.Foo
DEPRECATED: Do not use the "service=True" metadata anymore. Services should now be offered using the service offer extension point (envisage.service_offers) from the core plugin. Plugin <envisage.tests.plugin_test_case.PluginTestCase.test_service.<locals>.PluginA object at 0x7f4a680b9f10> trait <bar>
service <2> registered envisage.tests.plugin_test_case.Bar
DEPRECATED: Do not use the "service=True" metadata anymore. Services should now be offered using the service offer extension point (envisage.service_offers) from the core plugin. Plugin <envisage.tests.plugin_test_case.PluginTestCase.test_service.<locals>.PluginA object at 0x7f4a680b9f10> trait <baz>
service <3> registered envisage.tests.plugin_test_case.Baz
plugin A started
---------- application started ----------
---------- application stopping ----------
plugin A stopping
service <3> unregistered
service <2> unregistered
service <1> unregistered
plugin A stopped
loading preferences from </home/rporuri/.enthought/test/preferences.ini>
saving preferences to </home/rporuri/.enthought/test/preferences.ini>
---------- application stopped ----------
ok
test_service_protocol (envisage.tests.plugin_test_case.PluginTestCase)
service protocol ... ---------- application starting ----------
plugin A starting
DEPRECATED: Do not use the "service=True" metadata anymore. Services should now be offered using the service offer extension point (envisage.service_offers) from the core plugin. Plugin <envisage.tests.plugin_test_case.PluginTestCase.test_service_protocol.<locals>.PluginA object at 0x7f4a680b9ba0> trait <foo>
service <1> registered envisage.tests.plugin_test_case.IBar
plugin A started
---------- application started ----------
---------- application stopping ----------
plugin A stopping
service <1> unregistered
plugin A stopped
loading preferences from </home/rporuri/.enthought/test/preferences.ini>
saving preferences to </home/rporuri/.enthought/test/preferences.ini>
---------- application stopped ----------
ok
test_add_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
add extension point ... extension point <my.ep> added
ok
test_empty_registry (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
empty registry ... ok
test_get_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
get extension point ... extension point <my.ep> added
ok
test_remove_empty_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove empty_extension point ... extension point <my.ep> added
extension point <my.ep> removed
ok
test_remove_non_empty_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove non-empty extension point ... extension point <my.ep> added
extension point <my.ep> removed
ok
test_remove_non_existent_extension_point (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove non existent extension point ... ok
test_remove_non_existent_listener (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
remove non existent listener ... ok
test_set_extensions (envisage.tests.extension_registry_test_case.ExtensionRegistryTestCase)
set extensions ... extension point <my.ep> added
ok
test_add_extension_point (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
add extension point ... extension point <my.ep> added
extensions to <my.ep> <[]>
ok
test_add_provider (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
add provider ... extensions to <x> <[[42]]>
ok
test_empty_registry (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
empty registry ... getting extensions of unknown extension point <my.ep>
ok
test_get_extension_point (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
get extension point ... extension point <my.ep> added
ok
test_get_providers (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
get providers ... ok
test_provider_extensions_changed (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
provider extensions changed ... extensions to <my.ep> <[[42], [99, 100]]>
provider <<envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase.test_provider_extensions_changed.<locals>.ProviderA object at 0x7f4a680c7e08>> extension point changed
provider <<envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase.test_provider_extensions_changed.<locals>.ProviderB object at 0x7f4a680ed9e8>> extension point changed
provider <<envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase.test_provider_extensions_changed.<locals>.ProviderB object at 0x7f4a680ed9e8>> extension point changed
ok
test_providers (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
providers ... extensions to <x> <[[42, 43], [44, 45, 46], []]>
ok
test_remove_empty_extension_point (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
remove empty_extension point ... extension point <my.ep> added
extension point <my.ep> removed
ok
test_remove_non_empty_extension_point (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
remove non-empty extension point ... extensions to <x> <[[42, 43]]>
extension point <x> removed
getting extensions of unknown extension point <x>
ok
test_remove_non_existent_extension_point (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
remove non existent extension point ... ok
test_remove_non_existent_listener (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
remove non existent listener ... ok
test_remove_non_existent_provider (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
remove provider ... ok
test_remove_provider (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
remove provider ... extensions to <x> <[[42], [43, 44]]>
getting extensions of unknown extension point <x>
ok
test_remove_provider_with_no_contributions (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
remove provider with no contributions ... extensions to <x> <[[]]>
getting extensions of unknown extension point <x>
ok
test_set_extensions (envisage.tests.provider_extension_registry_test_case.ProviderExtensionRegistryTestCase)
set extensions ... extension point <my.ep> added
ok
test_add_extension_point_listener (envisage.tests.application_test_case.ApplicationTestCase)
add extension point listener ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3]]>
ok
test_add_plugin (envisage.tests.application_test_case.ApplicationTestCase)
add plugin ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3]]>
ok
test_extension_point (envisage.tests.application_test_case.ApplicationTestCase)
extension point ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3], [98, 99, 100]]>
ok
test_get_plugin (envisage.tests.application_test_case.ApplicationTestCase)
get plugin ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
ok
test_home (envisage.tests.application_test_case.ApplicationTestCase)
home ... ok
test_no_plugins (envisage.tests.application_test_case.ApplicationTestCase)
no plugins ... ---------- application starting ----------
---------- application started ----------
---------- application stopping ----------
loading preferences from </home/rporuri/.enthought/test/preferences.ini>
saving preferences to </home/rporuri/.enthought/test/preferences.ini>
---------- application stopped ----------
ok
test_remove_extension_point_listener (envisage.tests.application_test_case.ApplicationTestCase)
remove extension point listener ... ---------- application starting ----------
plugin A starting
plugin A started
---------- application started ----------
extensions to <a.x> <[[]]>
ok
test_remove_plugin (envisage.tests.application_test_case.ApplicationTestCase)
remove plugin ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
extensions to <a.x> <[[], [1, 2, 3], [98, 99, 100]]>
ok
test_set_plugin_manager_at_contruction_time (envisage.tests.application_test_case.ApplicationTestCase)
set plugin manager at construction time ... ---------- application starting ----------
plugin A starting
plugin A started
plugin B starting
plugin B started
plugin C starting
plugin C started
---------- application started ----------
ok
test_start_and_stop_errors (envisage.tests.application_test_case.ApplicationTestCase)
start and stop errors ... ---------- application starting ----------
plugin <envisage.tests.application_test_case.SimplePlugin object at 0x7f4a680b9ca8> has no Id - using <envisage.tests.application_test_case.SimplePlugin>
plugin envisage.tests.application_test_case.SimplePlugin starting
plugin envisage.tests.application_test_case.SimplePlugin started
plugin <envisage.tests.application_test_case.BadPlugin object at 0x7f4a6816f3b8> has no Id - using <envisage.tests.application_test_case.BadPlugin>
plugin envisage.tests.application_test_case.BadPlugin starting
---------- application stopping ----------
plugin envisage.tests.application_test_case.BadPlugin stopping
ok
test_veto_starting (envisage.tests.application_test_case.ApplicationTestCase)
veto starting ... ---------- application starting ----------
---------- application start vetoed ----------
ok
test_veto_stopping (envisage.tests.application_test_case.ApplicationTestCase)
veto stopping ... ---------- application starting ----------
---------- application started ----------
---------- application stopping ----------
---------- application stop vetoed ----------
ok
test_can_create_weakref_to_bound_method (envisage.tests.safeweakref_test_case.SafeWeakrefTestCase) ... ok
test_get_builtin_weakref_for_non_bound_method (envisage.tests.safeweakref_test_case.SafeWeakrefTestCase) ... ok
test_internal_cache_is_weak_too (envisage.tests.safeweakref_test_case.SafeWeakrefTestCase) ... ok
test_two_weakrefs_to_bound_method_are_equal (envisage.tests.safeweakref_test_case.SafeWeakrefTestCase) ... ok
test_two_weakrefs_to_bound_method_are_identical (envisage.tests.safeweakref_test_case.SafeWeakrefTestCase) ... ok
test_two_weakrefs_to_bound_method_hash_equally (envisage.tests.safeweakref_test_case.SafeWeakrefTestCase) ... ok
test_find_plugins_in_eggs_on_the_plugin_path (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... egg basket plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a6816fe60>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a6816ff68>, <acme.baz.baz_plugin.BazPlugin object at 0x7f4a6807adb0>]>
ok
test_ignore_broken_distributions_loads_good_distributions (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... Error loading distributions: {acme.foo 0.1a11 (/tmp/tmpgq391pm4/acme.foo-0.1a11-py3.6.egg): VersionConflict(acme.foo 0.1a1 (/home/rporuri/Github/work/envisage/envisage/tests/eggs/acme.foo-0.1a1-py3.6.egg), Requirement.parse('acme.foo==0.1a11'))}
egg basket plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a6807ae08>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a680cc258>, <acme.baz.baz_plugin.BazPlugin object at 0x7f4a680cc620>]>
ok
test_ignore_broken_distributions_raises_exceptions_by_default (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... Error loading distributions: {acme.foo 0.1a11 (/tmp/tmp23ehrfex/acme.foo-0.1a11-py3.6.egg): VersionConflict(acme.foo 0.1a1 (/home/rporuri/Github/work/envisage/envisage/tests/eggs/acme.foo-0.1a1-py3.6.egg), Requirement.parse('acme.foo==0.1a11'))}
ERROR
test_ignore_broken_plugins_loads_good_plugins (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... Error loading plugin: acme.bad (from /home/rporuri/Github/work/envisage/envisage/tests/bad_eggs/acme.bad-0.1a1-py3.6.egg)
Traceback (most recent call last):
  File "/home/rporuri/Github/work/envisage/envisage/egg_basket_plugin_manager.py", line 119, in _harvest_plugins_in_eggs
    application)
  File "/home/rporuri/Github/work/envisage/envisage/egg_basket_plugin_manager.py", line 77, in _create_plugin_from_entry_point
    klass  = ep.load()
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2408, in load
    return self.resolve()
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2414, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ModuleNotFoundError: No module named 'acme.bad'

egg basket plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a507c6e60>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a507c6eb8>, <acme.baz.baz_plugin.BazPlugin object at 0x7f4a5079a570>]>
ok
test_ignore_broken_plugins_raises_exceptions_by_default (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... Error loading plugin: acme.bad (from /home/rporuri/Github/work/envisage/envisage/tests/bad_eggs/acme.bad-0.1a1-py3.6.egg)
Traceback (most recent call last):
  File "/home/rporuri/Github/work/envisage/envisage/egg_basket_plugin_manager.py", line 119, in _harvest_plugins_in_eggs
    application)
  File "/home/rporuri/Github/work/envisage/envisage/egg_basket_plugin_manager.py", line 77, in _create_plugin_from_entry_point
    klass  = ep.load()
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2408, in load
    return self.resolve()
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2414, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ModuleNotFoundError: No module named 'acme.bad'

ok
test_ignore_plugins_matching_a_wildcard_in_the_exclude_list (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... egg basket plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a507c6e08>]>
plugin acme.foo starting
plugin acme.foo started
plugin acme.foo stopping
plugin acme.foo stopped
ok
test_ignore_plugins_whose_ids_are_in_the_exclude_list (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... egg basket plugin manager found plugins <[<acme.bar.bar_plugin.BarPlugin object at 0x7f4a507c6e08>]>
plugin acme.bar starting
plugin acme.bar started
plugin acme.bar stopping
plugin acme.bar stopped
ok
test_only_find_plugins_matching_a_wildcard_in_the_include_list (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... egg basket plugin manager found plugins <[<acme.bar.bar_plugin.BarPlugin object at 0x7f4a6807aeb8>, <acme.baz.baz_plugin.BazPlugin object at 0x7f4a507c6db0>]>
plugin acme.bar starting
plugin acme.bar started
plugin acme.baz starting
plugin acme.baz started
plugin acme.baz stopping
plugin acme.baz stopped
plugin acme.bar stopping
plugin acme.bar stopped
ok
test_only_find_plugins_whose_ids_are_in_the_include_list (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... egg basket plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a507c6f68>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a507c6d00>]>
plugin acme.foo starting
plugin acme.foo started
plugin acme.bar starting
plugin acme.bar started
plugin acme.bar stopping
plugin acme.bar stopped
plugin acme.foo stopping
plugin acme.foo stopped
ok
test_reflect_changes_to_the_plugin_path (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase) ... egg basket plugin manager found plugins <[]>
egg basket plugin manager found plugins <[<acme.foo.foo_plugin.FooPlugin object at 0x7f4a680edc50>, <acme.bar.bar_plugin.BarPlugin object at 0x7f4a680ed8e0>, <acme.baz.baz_plugin.BazPlugin object at 0x7f4a680ed308>]>
egg basket plugin manager found plugins <[]>
ok
test_service_trait_type (envisage.tests.service_test_case.ServiceTestCase)
service trait type ... ---------- application starting ----------
plugin A starting
DEPRECATED: Do not use the "service=True" metadata anymore. Services should now be offered using the service offer extension point (envisage.service_offers) from the core plugin. Plugin <envisage.tests.service_test_case.ServiceTestCase.test_service_trait_type.<locals>.PluginA object at 0x7f4a680cc468> trait <foo>
service <1> registered envisage.tests.service_test_case.Foo
plugin A started
plugin B starting
plugin B started
---------- application started ----------
---------- application stopping ----------
plugin B stopping
plugin B stopped
plugin A stopping
service <1> unregistered
plugin A stopped
loading preferences from </home/rporuri/.enthought/test/preferences.ini>
saving preferences to </home/rporuri/.enthought/test/preferences.ini>
---------- application stopped ----------
ok
test_service_trait_type_with_no_service_registry (envisage.tests.service_test_case.ServiceTestCase)
service trait type with no service registry ... ok
test_extension_point_changed (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
extension point changed ... extension point <my.ep> added
ok
test_extension_point_with_no_id (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
extension point with no Id ... ok
test_invalid_extension_point (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
invalid extension point ... extension point <my.ep> added
ok
test_invalid_extension_point_type (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
invalid extension point type ... ok
test_no_reference_to_extension_registry (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
no reference to extension registry ... extension point <my.ep> added
ok
test_set_typed_extension_point (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
set typed extension point ... extension point <my.ep> added
ok
test_set_untyped_extension_point (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
set untyped extension point ... extension point <my.ep> added
ok
test_typed_extension_point (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
typed extension point ... extension point <my.ep> added
ok
test_untyped_extension_point (envisage.tests.extension_point_test_case.ExtensionPointTestCase)
untyped extension point ... extension point <my.ep> added
ok

======================================================================
ERROR: project_view (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: project_view
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/view/project_view.py", line 18, in <module>
    from traits.api import adapts, Any, HasTraits, Instance, Str
ImportError: cannot import name 'adapts'


======================================================================
ERROR: project_plugin (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: project_plugin
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/project_plugin.py", line 8, in <module>
    from envisage.ui.single_project.api import FactoryDefinition
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/api.py", line 19, in <module>
    from .view.project_view import ProjectView
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/view/project_view.py", line 18, in <module>
    from traits.api import adapts, Any, HasTraits, Instance, Str
ImportError: cannot import name 'adapts'


======================================================================
ERROR: project_editor (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: project_editor
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/editor/project_editor.py", line 17, in <module>
    from envisage.workbench import DecoratedEditor
ModuleNotFoundError: No module named 'envisage.workbench'


======================================================================
ERROR: project_runnable (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: project_runnable
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/project_runnable.py", line 19, in <module>
    from envisage import Runnable
ImportError: cannot import name 'Runnable'


======================================================================
ERROR: api (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: api
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/api.py", line 19, in <module>
    from .view.project_view import ProjectView
  File "/home/rporuri/Github/work/envisage/envisage/ui/single_project/view/project_view.py", line 18, in <module>
    from traits.api import adapts, Any, HasTraits, Instance, Str
ImportError: cannot import name 'adapts'


======================================================================
ERROR: ipython_shell_view (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: ipython_shell_view
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/ipython_shell/view/ipython_shell_view.py", line 9, in <module>
    from IPython.kernel.core.interpreter import Interpreter
ModuleNotFoundError: No module named 'IPython.kernel.core'


======================================================================
ERROR: api (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: api
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/ipython_shell/view/api.py", line 1, in <module>
    from .ipython_shell_view import IPythonShellView
  File "/home/rporuri/Github/work/envisage/envisage/plugins/ipython_shell/view/ipython_shell_view.py", line 9, in <module>
    from IPython.kernel.core.interpreter import Interpreter
ModuleNotFoundError: No module named 'IPython.kernel.core'


======================================================================
ERROR: enshell_plugin (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: enshell_plugin
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/editor_plugins/emacs/enshell_plugin.py", line 5, in <module>
    from Pymacs import lisp
ModuleNotFoundError: No module named 'Pymacs'


======================================================================
ERROR: start_editra (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: start_editra
Traceback (most recent call last):
  File "/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/editor_plugins/editra/start_editra.py", line 9, in <module>
    import Editra as Editra_root
ModuleNotFoundError: No module named 'Editra'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/editor_plugins/editra/start_editra.py", line 16, in <module>
    import wx.tools
ModuleNotFoundError: No module named 'wx'


======================================================================
ERROR: editra_plugin (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: editra_plugin
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/remote_editor/editor_plugins/editra/editra_plugin.py", line 11, in <module>
    import wx
ModuleNotFoundError: No module named 'wx'


======================================================================
ERROR: bare_app (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: bare_app
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/update_checker/tests/bare_app.py", line 10, in <module>
    from enthought.epdlab.plugins.code_editor.plugin import CodeEditorPlugin
ModuleNotFoundError: No module named 'enthought'


======================================================================
ERROR: refresh_code_plugin_definition (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: refresh_code_plugin_definition
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/refresh_code/refresh_code_plugin_definition.py", line 5, in <module>
    from envisage import PluginDefinition, get_using_workbench
ImportError: cannot import name 'PluginDefinition'


======================================================================
ERROR: fbi_plugin (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: fbi_plugin
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/debug/fbi_plugin.py", line 23, in <module>
    from etsdevtools.debug.fbi import enable_fbi, fbi
ModuleNotFoundError: No module named 'etsdevtools'


======================================================================
ERROR: fbi_plugin_definition (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: fbi_plugin_definition
Traceback (most recent call last):
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/rporuri/Github/work/envisage/envisage/plugins/debug/fbi_plugin_definition.py", line 17, in <module>
    from envisage.core.core_plugin_definition \
ModuleNotFoundError: No module named 'envisage.core'


======================================================================
ERROR: test_ignore_broken_distributions_raises_exceptions_by_default (envisage.tests.egg_basket_plugin_manager_test_case.EggBasketPluginManagerTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rporuri/Github/work/envisage/envisage/tests/egg_basket_plugin_manager_test_case.py", line 37, in tearDown
    print("Removed", path)
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/ipykernel/iostream.py", line 384, in write
    self._schedule_flush()
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/ipykernel/iostream.py", line 325, in _schedule_flush
    self.pub_thread.schedule(_schedule_in_thread)
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/ipykernel/iostream.py", line 205, in schedule
    f()
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/ipykernel/iostream.py", line 324, in _schedule_in_thread
    self._io_loop.call_later(self.flush_interval, self._flush)
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/tornado/ioloop.py", line 520, in call_later
    return self.call_at(self.time() + delay, callback, *args, **kwargs)
  File "/home/rporuri/.edm/envs/temp3/lib/python3.6/site-packages/tornado/ioloop.py", line 921, in call_at
    heapq.heappush(self._timeouts, timeout)
TypeError: heap argument must be a list

----------------------------------------------------------------------
Ran 214 tests in 2.868s

FAILED (errors=15)
```

</details>