### PR TITLE
String repr for ExtensionPoint objects

### DIFF
--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -141,6 +141,10 @@ class ExtensionPoint(TraitType):
 
         return
 
+    def __str__(self):
+        """ String representation of an ExtensionPoint object """
+        return self.id
+
     ###########################################################################
     # 'TraitType' interface.
     ###########################################################################

--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -145,8 +145,6 @@ class ExtensionPoint(TraitType):
         """ String representation of an ExtensionPoint object """
         return "ExtensionPoint(id={})".format(self.id)
 
-    __str__ = __repr__
-
     ###########################################################################
     # 'TraitType' interface.
     ###########################################################################

--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -141,9 +141,11 @@ class ExtensionPoint(TraitType):
 
         return
 
-    def __str__(self):
+    def __repr__(self):
         """ String representation of an ExtensionPoint object """
-        return self.id
+        return "ExtensionPoint(id={})".format(self.id)
+
+    __str__ = __repr__
 
     ###########################################################################
     # 'TraitType' interface.

--- a/envisage/tests/extension_point_test_case.py
+++ b/envisage/tests/extension_point_test_case.py
@@ -251,8 +251,10 @@ class ExtensionPointTestCase(unittest.TestCase):
 
     def test_extension_point_str_representation(self):
         """ test the string representation of the extension point """
+        ep_repr = "ExtensionPoint(id={})"
         ep = self._create_extension_point('my.ep')
-        self.assertEqual(str(ep), 'my.ep')
+        self.assertEqual(ep_repr.format('my.ep'), str(ep))
+        self.assertEqual(ep_repr.format('my.ep'), repr(ep))
 
     ###########################################################################
     # Private interface.

--- a/envisage/tests/extension_point_test_case.py
+++ b/envisage/tests/extension_point_test_case.py
@@ -249,6 +249,11 @@ class ExtensionPointTestCase(unittest.TestCase):
 
         return
 
+    def test_extension_point_str_representation(self):
+        """ test the string representation of the extension point """
+        ep = self._create_extension_point('my.ep')
+        self.assertEqual(str(ep), 'my.ep')
+
     ###########################################################################
     # Private interface.
     ###########################################################################


### PR DESCRIPTION
The str repr should display the `id` attr of `ExtensionPoint` instances.
Fixes #141 