### PR TITLE
Minor improvements to etstool.py usability.

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -93,7 +93,7 @@ available_runtimes = ["2.7", "3.5", "3.6"]
 default_runtime = "3.6"
 
 # Toolkits supported by this tool.
-available_toolkits = ["pyside", "pyqt", "pyqt5", "wx", "null"]
+available_toolkits = ["pyside", "pyside2", "pyqt", "pyqt5", "wx", "null"]
 
 # Toolkit used by default.
 default_toolkit = "null"
@@ -116,6 +116,8 @@ dependencies = {
 
 extra_dependencies = {
     'pyside': {'pyside'},
+    # XXX once pyside2 is available in EDM, we will want it here
+    'pyside2': set(),
     'pyqt': {'pyqt<4.12'},  # FIXME: build of 4.12-1 appears to be bad
     # XXX once pyqt5 is available in EDM, we will want it here
     'pyqt5': set(),
@@ -126,6 +128,7 @@ extra_dependencies = {
 
 environment_vars = {
     'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
+    'pyside2': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside2'},
     'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
     'pyqt5': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt5'},
     'wx': {'ETS_TOOLKIT': 'wx'},
@@ -187,9 +190,11 @@ def install(runtime, toolkit, environment, editable):
         "edm install -y -e {environment} " + packages,
         "edm run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
     ]
-    # pip install pyqt5, because we don't have it in EDM yet
+    # pip install pyqt5 and pyside2, because we don't have them in EDM yet
     if toolkit == 'pyqt5':
         commands.append("edm run -e {environment} -- pip install pyqt5==5.9.2")
+    elif toolkit == 'pyside2':
+        commands.append("edm run -e {environment} -- pip install pyside2==5.11")
 
     if editable:
         install_cmd = "edm run -e {environment} -- pip install --editable . --no-dependencies"

--- a/etstool.py
+++ b/etstool.py
@@ -99,9 +99,9 @@ available_toolkits = ["pyside", "pyside2", "pyqt", "pyqt5", "wx", "null"]
 default_toolkit = "null"
 
 supported_combinations = {
-    '2.7': {'pyside', 'pyqt', 'wx', 'null'},
-    '3.5': {'pyqt', 'pyqt5', 'null'},
-    '3.6': {'pyqt', 'pyqt5', 'null'},
+    '2.7': {'pyside', 'pyside2', 'pyqt', 'wx', 'null'},
+    '3.5': {'pyside2', 'pyqt', 'pyqt5', 'null'},
+    '3.6': {'pyside2', 'pyqt', 'pyqt5', 'null'},
 }
 
 dependencies = {

--- a/etstool.py
+++ b/etstool.py
@@ -191,9 +191,10 @@ def install(runtime, toolkit, environment, editable):
     if toolkit == 'pyqt5':
         commands.append("edm run -e {environment} -- pip install pyqt5==5.9.2")
 
-    install_cmd = "edm run -e {environment} -- pip install . --no-dependencies"
     if editable:
-        install_cmd += " --editable"
+        install_cmd = "edm run -e {environment} -- pip install --editable . --no-dependencies"
+    else:
+        install_cmd = "edm run -e {environment} -- pip install . --no-dependencies"
     commands.append(install_cmd)
 
     click.echo("Creating environment '{environment}'".format(**parameters))
@@ -269,9 +270,10 @@ def update(runtime, toolkit, environment, editable):
 
     """
     parameters = get_parameters(runtime, toolkit, environment)
-    install_cmd = "edm run -e {environment} -- pip install . --no-dependencies"
     if editable:
-        install_cmd += " --editable"
+        install_cmd = "edm run -e {environment} -- pip install --editable . --no-dependencies"
+    else:
+        install_cmd = "edm run -e {environment} -- pip install . --no-dependencies"
     commands = [install_cmd]
     click.echo("Re-installing in  '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/etstool.py
+++ b/etstool.py
@@ -54,10 +54,10 @@ using::
 
     python etstool.py test_all
 
-Currently supported runtime values are ``2.7`` and ``3.5``, and currently
-supported toolkits are ``null``, ``pyqt``, ``pyside`` and ``wx``.  Not all
-combinations of toolkits and runtimes will work, but the tasks will fail with
-a clear error if that is the case.
+Currently supported runtime values are ``2.7``, ``3.5`` and ``3.6``, and
+currently supported toolkits are ``null``, ``pyqt``, ``pyside`` and ``wx``.
+Not all combinations of toolkits and runtimes will work, but the tasks will
+fail with a clear error if that is the case.
 
 Tests can still be run via the usual means in other environments if that suits
 a developer's purpose.
@@ -85,6 +85,18 @@ from tempfile import mkdtemp
 from contextlib import contextmanager
 
 import click
+
+# Python runtime versions supported by this tool.
+available_runtimes = ["2.7", "3.5", "3.6"]
+
+# Python runtime used by default.
+default_runtime = "3.6"
+
+# Toolkits supported by this tool.
+available_toolkits = ["pyside", "pyqt", "pyqt5", "wx", "null"]
+
+# Toolkit used by default.
+default_toolkit = "null"
 
 supported_combinations = {
     '2.7': {'pyside', 'pyqt', 'wx', 'null'},
@@ -120,14 +132,29 @@ environment_vars = {
 }
 
 
+# Options shared between different click commands.
+runtime_option = click.option(
+    "--runtime", default=default_runtime,
+    type=click.Choice(available_runtimes),
+    show_default=True,
+    help="Python runtime version",
+)
+toolkit_option = click.option(
+    "--toolkit", default=default_toolkit,
+    type=click.Choice(available_toolkits),
+    show_default=True,
+    help="Toolkit",
+)
+
+
 @click.group()
 def cli():
     pass
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
-@click.option('--toolkit', default='null')
+@runtime_option
+@toolkit_option
 @click.option('--environment', default=None)
 def install(runtime, toolkit, environment):
     """ Install project and dependencies into a clean EDM environment.
@@ -154,8 +181,8 @@ def install(runtime, toolkit, environment):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
-@click.option('--toolkit', default='null')
+@runtime_option
+@toolkit_option
 @click.option('--environment', default=None)
 def test(runtime, toolkit, environment):
     """ Run the test suite in a given environment with the specified toolkit.
@@ -180,8 +207,8 @@ def test(runtime, toolkit, environment):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
-@click.option('--toolkit', default='null')
+@runtime_option
+@toolkit_option
 @click.option('--environment', default=None)
 def cleanup(runtime, toolkit, environment):
     """ Remove a development environment.
@@ -197,8 +224,8 @@ def cleanup(runtime, toolkit, environment):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
-@click.option('--toolkit', default='null')
+@runtime_option
+@toolkit_option
 def test_clean(runtime, toolkit):
     """ Run tests in a clean environment, cleaning up afterwards
 
@@ -212,8 +239,8 @@ def test_clean(runtime, toolkit):
 
 
 @cli.command()
-@click.option('--runtime', default='3.5')
-@click.option('--toolkit', default='null')
+@runtime_option
+@toolkit_option
 @click.option('--environment', default=None)
 def update(runtime, toolkit, environment):
     """ Update/Reinstall package into environment.

--- a/etstool.py
+++ b/etstool.py
@@ -143,7 +143,7 @@ toolkit_option = click.option(
     "--toolkit", default=default_toolkit,
     type=click.Choice(available_toolkits),
     show_default=True,
-    help="Toolkit",
+    help="GUI toolkit",
 )
 
 


### PR DESCRIPTION
- Make `--toolkit` and `--runtime` options use `click.Choices`, to improve help and error reporting.
- Change default Python version to 3.6.
- Factor out repetition of defaults for the various tasks.
- Provide support for `--editable` model for the `install` and `update` commands.
- Replace uses of `python setup.py install` with `pip install .`

