### PR TITLE
InternalIPKernel: restore original streams at kernel shutdown time.

### DIFF
--- a/envisage/plugins/ipython_kernel/internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/internal_ipkernel.py
@@ -4,6 +4,7 @@ https://github.com/ipython/ipython/blob/2.x/examples/Embedding/internal_ipkernel
 
 """
 from distutils.version import StrictVersion as Version
+import sys
 
 import ipykernel
 from ipykernel.connect import connect_qtconsole
@@ -55,6 +56,12 @@ class InternalIPKernel(HasStrictTraits):
     #: This is a list of tuples (name, value).
     initial_namespace = List()
 
+    #: sys.stdout value at time kernel was started
+    _original_stdout = Any()
+
+    #: sys.stderr value at time kernel was started
+    _original_stderr = Any()
+
     def init_ipkernel(self, gui_backend):
         """ Initialize the IPython kernel.
 
@@ -64,6 +71,12 @@ class InternalIPKernel(HasStrictTraits):
           The GUI mode used to initialize the GUI mode. For options, see
           the `ipython --gui` help pages.
         """
+        # The IPython kernel modifies sys.stdout and sys.stderr when started,
+        # and doesn't currently provide a way to restore them. So we restore
+        # them ourselves at shutdown.
+        self._original_stdout = sys.stdout
+        self._original_stderr = sys.stderr
+
         # Start IPython kernel with GUI event loop support
         self.ipkernel = gui_kernel(gui_backend)
 
@@ -73,7 +86,7 @@ class InternalIPKernel(HasStrictTraits):
         # Workaround: Retrieve the kernel on the IPykernelApp and set the
         # io_loop without starting it!
         if NEEDS_IOLOOP_PATCH and not hasattr(self.ipkernel.kernel, 'io_loop'):
-            self.ipkernel.kernel.io_loop = ioloop.IOLoop.instance() 
+            self.ipkernel.kernel.io_loop = ioloop.IOLoop.instance()
 
         # This application will also act on the shell user namespace
         self.namespace = self.ipkernel.shell.user_ns
@@ -101,5 +114,20 @@ class InternalIPKernel(HasStrictTraits):
             self.cleanup_consoles()
             self.ipkernel.shell.exit_now = True
             self.ipkernel.cleanup_connection_file()
+
+            # The stdout and stderr streams created by the kernel use the
+            # IOPubThread, so we need to close them and restore the originals
+            # before we shut down the thread. Without this, we get obscure
+            # errors of the form "TypeError: heap argument must be a list".
+            kernel_stdout = sys.stdout
+            if kernel_stdout is not self._original_stdout:
+                sys.stdout = self._original_stdout
+                kernel_stdout.close()
+
+            kernel_stderr = sys.stderr
+            if kernel_stderr is not self._original_stderr:
+                sys.stderr = self._original_stderr
+                kernel_stderr.close()
+
             self.ipkernel.iopub_thread.stop()
             self.ipkernel = None

--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import unittest
 
 try:
@@ -46,6 +47,17 @@ class TestInternalIPKernel(unittest.TestCase):
         self.assertIn('x', kernel.namespace)
         self.assertEqual(kernel.namespace['x'], 42.1)
         kernel.shutdown()
+
+    def test_shutdown_restores_output_streams(self):
+        original_stdout = sys.stdout
+        original_stderr = sys.stderr
+
+        kernel = InternalIPKernel(initial_namespace=[('x', 42.1)])
+        kernel.init_ipkernel(gui_backend=None)
+        kernel.shutdown()
+
+        self.assertIs(sys.stdout, original_stdout)
+        self.assertIs(sys.stderr, original_stderr)
 
     def test_io_pub_thread_stopped(self):
         kernel = InternalIPKernel()


### PR DESCRIPTION
The internal IPython kernel, at start time, replaces `sys.stdout` and `sys.stderr` with its own objects of type `OutStream`. This PR records the original values of `sys.stdout` and `sys.stderr` at kernel start time, and restores them when shutting down the kernel.

This fixes some causes of obscure "TypeError: heap argument must be a list" exceptions in envisage and projects using it: the replacement `sys.stdout` and `sys.stderr` objects had references to a shut-down tornado IO loop, and attempts to write to either of those streams after the IO loop had been shut down would fail.