### PR TITLE
InternalIPKernel: fix ResourceWarnings from unclosed pipes.

### DIFF
--- a/envisage/plugins/ipython_kernel/internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/internal_ipkernel.py
@@ -103,6 +103,8 @@ class InternalIPKernel(HasStrictTraits):
         """ Kill all existing consoles. """
         for c in self.consoles:
             c.kill()
+            c.stdout.close()
+            c.stderr.close()
         self.consoles = []
 
     def shutdown(self):

--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -59,6 +59,16 @@ class TestInternalIPKernel(unittest.TestCase):
         self.assertIs(sys.stdout, original_stdout)
         self.assertIs(sys.stderr, original_stderr)
 
+    def test_shutdown_closes_console_pipes(self):
+        kernel = InternalIPKernel(initial_namespace=[('x', 42.1)])
+        kernel.init_ipkernel(gui_backend=None)
+        console = kernel.new_qt_console()
+        self.assertFalse(console.stdout.closed)
+        self.assertFalse(console.stderr.closed)
+        kernel.shutdown()
+        self.assertTrue(console.stdout.closed)
+        self.assertTrue(console.stderr.closed)
+
     def test_io_pub_thread_stopped(self):
         kernel = InternalIPKernel()
         kernel.init_ipkernel(gui_backend=None)


### PR DESCRIPTION
The consoles created by `InternalIPKernel.new_qt_console` are `subprocess.Popen` instances created with `stderr=PIPE` and `stdout=PIPE`. We kill those subprocesses at shutdown time, but don't close the pipes. This leads to `ResourceWarning`s (at least in Python 3) from code using this.

This PR explicitly closes the pipes.