### PR TITLE
Update EDM version and simplify Travis and Appveyor configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 env:
   global:
-    - INSTALL_EDM_VERSION=1.9.2
+    - INSTALL_EDM_VERSION="1.11.0"
       PYTHONUNBUFFERED="1"
 
 matrix:
@@ -17,12 +17,6 @@ matrix:
       env: RUNTIME=3.5 TOOLKITS="null pyqt"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="null pyqt"
-  fast_finish: true
-
-branches:
-  only:
-    - master
-    - /release\/\d+\.\d+\.x/
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,9 @@
 build: false
-shallow_clone: false
-skip_branch_with_pr: true
-environment:
 
+environment:
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "1.9.2"
+    INSTALL_EDM_VERSION: "1.11.0"
 
   matrix:
     - RUNTIME: '2.7'
@@ -14,14 +12,6 @@ environment:
       TOOLKITS: "null pyqt"
     - RUNTIME: '3.6'
       TOOLKITS: "null pyqt"
-
-matrix:
-  fast_finish: True
-
-branches:
-  only:
-    - master
-    - /release\/\d+\.\d+\.x/
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt

--- a/install-edm-windows.cmd
+++ b/install-edm-windows.cmd
@@ -14,7 +14,7 @@ SET EDM_INSTALLER_PATH=%HOMEDRIVE%%HOMEPATH%\.cache\%EDM_PACKAGE%
 SET COMMAND="(new-object net.webclient).DownloadFile('https://package-data.enthought.com/edm/win_x86_64/%EDM_MAJOR_MINOR%/%EDM_PACKAGE%', '%EDM_INSTALLER_PATH%')"
 
 IF NOT EXIST %EDM_INSTALLER_PATH% CALL powershell.exe -Command %COMMAND% || GOTO error
-CALL msiexec /qn /a %EDM_INSTALLER_PATH% TARGETDIR=c:\ || GOTO error
+CALL msiexec /qn /i %EDM_INSTALLER_PATH% EDMAPPDIR=c:\Enthought\edm || GOTO error
 
 ENDLOCAL
 @ECHO.DONE


### PR DESCRIPTION
- Update to EDM 1.11.0
- Don't fail fast: we generally want all jobs to run, especially when messing with different GUI backends
- Run CI on PRs against any branch, not just against master or release branches.