### PR TITLE
Update .travis.yml for framebuffer-related changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,21 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
-    - env: RUNTIME=3.5 TOOLKITS="null pyqt"
-    - env: RUNTIME=3.6 TOOLKITS="null pyqt"
+    - os: linux
+      dist: xenial
+      services:
+        - xvfb
+      env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
+    - os: linux
+      dist: xenial
+      services:
+        - xvfb
+      env: RUNTIME=3.5 TOOLKITS="null pyqt"
+    - os: linux
+      dist: xenial
+      services:
+        - xvfb
+      env: RUNTIME=3.6 TOOLKITS="null pyqt"
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: generic
 sudo: false
+dist: xenial
+services:
+  - xvfb
 
 env:
   global:
@@ -8,21 +11,9 @@ env:
 
 matrix:
   include:
-    - os: linux
-      dist: xenial
-      services:
-        - xvfb
-      env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
-    - os: linux
-      dist: xenial
-      services:
-        - xvfb
-      env: RUNTIME=3.5 TOOLKITS="null pyqt"
-    - os: linux
-      dist: xenial
-      services:
-        - xvfb
-      env: RUNTIME=3.6 TOOLKITS="null pyqt"
+    - env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
+    - env: RUNTIME=3.5 TOOLKITS="null pyqt"
+    - env: RUNTIME=3.6 TOOLKITS="null pyqt"
     - os: osx
       env: RUNTIME=2.7 TOOLKITS="null pyqt pyside wx"
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ cache:
 
 before_install:
   - mkdir -p "${HOME}/.cache/download"
-  - export DISPLAY=:99.0
-  - if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage


### PR DESCRIPTION
This PR is an attempt to fix recently failing Travis CI cron jobs for this repository.

See https://docs.travis-ci.com/user/gui-and-headless-browsers/ for details on currently supported methods for launching xvfb.

See also the [blog post](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) from Travis CI about the Xenial rollout.

Here's the tail of the log for a [recent failing run](https://travis-ci.org/enthought/envisage/jobs/544772333)
```
travis_fold:start:before_install.1
[0Ktravis_time:start:0b9aa365
[0K$ mkdir -p "${HOME}/.cache/download"
travis_time:end:0b9aa365:start=1560349798741229483,finish=1560349798745664143,duration=4434660
[0Ktravis_fold:end:before_install.1
[0Ktravis_fold:start:before_install.2
[0Ktravis_time:start:2ef9439a
[0K$ export DISPLAY=:99.0
travis_time:end:2ef9439a:start=1560349798750269069,finish=1560349798753601568,duration=3332499
[0Ktravis_fold:end:before_install.2
[0Ktravis_fold:start:before_install.3
[0Ktravis_time:start:03cd483a
[0K$ if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi
sh: 0: Can't open /etc/init.d/xvfb
travis_time:end:03cd483a:start=1560349798758495552,finish=1560349798763595229,duration=5099677
[0K[31;1mThe command "if [[ ${TRAVIS_OS_NAME} == "linux" ]] ; then sh -e /etc/init.d/xvfb start; fi" failed and exited with 127 during .[0m
```

