### PR TITLE
Remove "sudo: false" from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: generic
-sudo: false
 dist: xenial
 services:
   - xvfb


### PR DESCRIPTION
Use of "sudo: false" is deprecated. Remove it from the Travis CI config.

ref: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration