### PR TITLE
Test ETS packages from source using cron jobs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,11 @@ before_install:
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:
-  - for toolkit in ${TOOLKITS};
-        if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then
-            do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
+  - for toolkit in ${TOOLKITS}; do
+        if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]] ; then
+            edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
         else
-            do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
+            edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
         fi;
     done
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
         if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then
             do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
         else
-            do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit;
+            do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
         fi;
     done
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
         if [[ ${TRAVIS_EVENT_TYPE} == "cron" ]] ; then
             edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
         else
-            edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
+            edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit;
         fi;
     done
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,13 @@ before_install:
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:
-  - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
+  - for toolkit in ${TOOLKITS};
+        if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then
+            do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit;
+        else
+            do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit;
+        fi;
+    done
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
 


### PR DESCRIPTION
The changes introduced in this PR are based on similar changes in the PR https://github.com/enthought/traits/pull/479

Essentially, we do two things here

- update the `install` command to install certain packages from source, via the use of a `--source` command line flag
- update travis to use the `--source` flag when the event type is a cron job.