### PR TITLE
Remove debugging helper from ExtensionPoint source.

### DIFF
--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -245,19 +245,10 @@ class ExtensionPoint(TraitType):
 
         extension_registry = getattr(obj, 'extension_registry', None)
         if extension_registry is None:
-            # If the debug package is present then log the call stack to help
-            # the developer see where the problem occurred.
-            try:
-                from etsdevtools.debug.api import log_called_from
-                log_called_from(10)
-
-            except:
-                pass
-
             raise ValueError(
-                'The "ExtensionPoint" trait type can only be used in ' \
-                'objects that have a reference to an extension registry ' \
-                'via their "extension_registry" trait. ' \
+                'The "ExtensionPoint" trait type can only be used in '
+                'objects that have a reference to an extension registry '
+                'via their "extension_registry" trait. '
                 'Extension point Id <%s>' % self.id
             )
 


### PR DESCRIPTION
This PR removes some debugging code from the `ExtensionPoint` source: it's hard to imagine that it's particularly useful to have this one `etsdevtools` usage right here but not in any other failure paths. And it's not hard for a developer to insert an `import traceback; traceback.print_stack()` during debugging if they want equivalent functionality.

Together with #166, this removes all uses of the obsolescent (senescent?) `etsdevtools` package.