### PR TITLE
NumpyDoc style fixes

### DIFF
--- a/envisage/plugins/python_shell/view/namespace_view.py
+++ b/envisage/plugins/python_shell/view/namespace_view.py
@@ -56,8 +56,8 @@ def type_to_str(obj):
 
 def module_to_str(obj):
     """
-    Return the string representation of `obj`s __module__ attribute, or an
-    empty string if there is no such attribute.
+    Return the string representation of *obj*'s ``__module__`` attribute, or
+    an empty string if there is no such attribute.
     """
     if hasattr(obj, '__module__'):
         return str(obj.__module__)

--- a/envisage/ui/gui_application.py
+++ b/envisage/ui/gui_application.py
@@ -21,12 +21,12 @@ class GUIApplication(Application):
 
     This class handles the life-cycle of a Pyface GUI.  Plugins can
     display windows via mechinisms such as edit_traits().
-    
+
     This is intended to be a very simple shell for lifting an existing
     pure TraitsUI or Pyface (or even Qt) app into an Envisage app.
-    
+
     More sophisticated applications should use Tasks.
-    
+
     """
 
     #### 'GUIApplication' interface #########################################
@@ -50,12 +50,14 @@ class GUIApplication(Application):
     def run(self):
         """ Run the application.
 
-        Returns:
-        --------
-        Whether the application started successfully (i.e., without a veto).
-        
+        Returns
+        -------
+        bool
+            Whether the application started successfully (i.e., without a
+            veto).
+
         """
-        
+
         # Make sure the GUI has been created (so that, if required, the splash
         # screen is shown).
         gui = self.gui
@@ -65,7 +67,7 @@ class GUIApplication(Application):
             gui.set_trait_later(self, 'application_initialized', self)
             # Start the GUI event loop.  The application will block here.
             gui.start_event_loop()
-            
+
             # clean up plugins once event loop stops
             self.stop()
 
@@ -76,4 +78,3 @@ class GUIApplication(Application):
     def _gui_default(self):
         from pyface.api import GUI
         return GUI(splash_screen=self.splash_screen)
-

--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -126,9 +126,11 @@ class TasksApplication(Application):
     def run(self):
         """ Run the application.
 
-        Returns:
-        --------
-        Whether the application started successfully (i.e., without a veto).
+        Returns
+        -------
+        bool
+            Whether the application started successfully (i.e., without a
+            veto).
         """
         # Make sure the GUI has been created (so that, if required, the splash
         # screen is shown).
@@ -152,9 +154,10 @@ class TasksApplication(Application):
     def create_task(self, id):
         """ Creates the Task with the specified ID.
 
-        Returns:
-        --------
-        The new Task, or None if there is not a suitable TaskFactory.
+        Returns
+        -------
+        pyface.tasks.task.Task
+            The new Task, or None if there is not a suitable TaskFactory.
         """
         # Get the factory for the task.
         factory = self._get_task_factory(id)
@@ -171,8 +174,8 @@ class TasksApplication(Application):
     def create_window(self, layout=None, restore=True, **traits):
         """Creates a new TaskWindow, possibly with some Tasks.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         layout : TaskWindowLayout, optional
              The layout to use for the window. The tasks described in
              the layout will be created and added to the window
@@ -188,9 +191,10 @@ class TasksApplication(Application):
              Additional parameters to pass to ``window_factory()``
              when creating the TaskWindow.
 
-        Returns:
-        --------
-        The new TaskWindow.
+        Returns
+        -------
+        envisage.ui.tasks.task_window.TaskWindow
+            The new TaskWindow.
 
         """
         from .task_window_event import TaskWindowEvent
@@ -241,17 +245,18 @@ class TasksApplication(Application):
         her window manager. It is only called via the File->Exit menu
         item. It can also, of course, be called programatically.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         force : bool, optional (default False)
             If set, windows will receive no closing events and will be
             destroyed unconditionally. This can be useful for reliably
             tearing down regression tests, but should be used with
             caution.
 
-        Returns:
-        --------
-        A boolean indicating whether the application exited.
+        Returns
+        -------
+        bool
+            A boolean indicating whether the application exited.
 
         """
         self._explicit_exit = True

--- a/examples/plugins/single_project/sample_project/data/plugin/model_service.py
+++ b/examples/plugins/single_project/sample_project/data/plugin/model_service.py
@@ -49,10 +49,10 @@ class ModelService(ApplicationObject):
     def delete_context_item(self, context, item_name):
         """ Deleting an item from a numeric context
 
-            Parameters:
-            -----------
-            context: NumericContext
-            item_name: Str
+        Parameters
+        ----------
+        context : NumericContext
+        item_name : Str
 
         """
 
@@ -63,4 +63,3 @@ class ModelService(ApplicationObject):
 
         return
 #### EOF #####################################################################
-

--- a/examples/plugins/tasks/ipython_kernel/example.py
+++ b/examples/plugins/tasks/ipython_kernel/example.py
@@ -75,9 +75,11 @@ class ExampleApplication(TasksApplication):
     def run(self):
         """ Run the application.
 
-        Returns:
-        --------
-        Whether the application started successfully (i.e., without a veto).
+        Returns
+        -------
+        bool
+            Whether the application started successfully (i.e., without a
+            veto).
         """
         # Make sure the GUI has been created (so that, if required, the splash
         # screen is shown).


### PR DESCRIPTION
Some low-hanging fruit in the current Sphinx autodoc warnings (from #165): remove (ab)uses of "Returns:" and "Parameters:" in the codebase.