### PR TITLE
Fix syntax errors on Python 3.

### DIFF
--- a/examples/Hello_World/hello_world.py
+++ b/examples/Hello_World/hello_world.py
@@ -43,9 +43,7 @@ class HelloWorld(Plugin):
         # this specific plugin.
         import random
 
-        print random.choice(self.greetings), 'World!'
-
-        return
+        print("{} World!".format(random.choice(self.greetings)))
 
 
 class Greetings(Plugin):

--- a/examples/MOTD/acme/motd/motd_plugin.py
+++ b/examples/MOTD/acme/motd/motd_plugin.py
@@ -102,8 +102,6 @@ class MOTDPlugin(Plugin):
         message = motd.motd()
 
         # ... and print it.
-        print '\n"%s"\n\n- %s' % (message.text, message.author)
-
-        return
+        print('\n"%s"\n\n- %s' % (message.text, message.author))
 
 #### EOF ######################################################################

--- a/examples/MOTD_Using_Eggs/src/acme.motd/acme/motd/motd_plugin.py
+++ b/examples/MOTD_Using_Eggs/src/acme.motd/acme/motd/motd_plugin.py
@@ -101,8 +101,6 @@ class MOTDPlugin(Plugin):
         message = motd.motd()
 
         # ... and print it.
-        print '\n"%s"\n\n- %s' % (message.text, message.author)
-
-        return
+        print('\n"%s"\n\n- %s' % (message.text, message.author))
 
 #### EOF ######################################################################

--- a/examples/plugins/tasks/ipython_kernel/example.py
+++ b/examples/plugins/tasks/ipython_kernel/example.py
@@ -43,7 +43,7 @@ class ExamplePlugin(Plugin):
     tasks = List(contributes_to='envisage.ui.tasks.tasks')
 
     def _tasks_default(self):
-        print 'Default tasks'
+        print('Default tasks')
         return [
             TaskFactory(
                 id='example_task',


### PR DESCRIPTION
Fix some `print`-related SyntaxErrors on Python 3.

This leaves the codebase free of syntax errors for me: tested with `flake8 --select=E9`.