### PR TITLE
Fix confusing doc-comment for always_use_default_layout.

### DIFF
--- a/docs/source/tasks_user_manual/extensibility.rst
+++ b/docs/source/tasks_user_manual/extensibility.rst
@@ -149,8 +149,8 @@ the application is started again. If, however, the
 ``always_use_default_layout`` attribute of the application is set, the default
 application layout will be applied when the application is restarted. Tasks
 will still attempt to restore as much user interface state as possible,
-including window positions and task layouts. This setting is partcularly useful
-for multi-window applications.
+including window positions and task layouts. This setting is particularly
+useful for multi-window applications.
 
 Apart from this functionality, the Tasks plugin provides no additional *default*
 behavior for managing tasks and their windows, permitting users to switch tasks

--- a/docs/source/tasks_user_manual/extensibility.rst
+++ b/docs/source/tasks_user_manual/extensibility.rst
@@ -144,12 +144,13 @@ default.
 
 By default, the Tasks framework will restore application-level layout when the
 application is restarted. That is, the set of windows and tasks attached to
-those windows that is extant when application exits will be restored when
-application is started again. If, however, the ``always_use_default_layout``
-attribute of the application is set, the default application-layout will be
-applied when the application is restarted. Tasks will still attempt to restore
-as much user interface state as possible, including window positions and task
-layouts. This setting is partcularly useful for multi-window applications.
+those windows that is extant when the application exits will be restored when
+the application is started again. If, however, the
+``always_use_default_layout`` attribute of the application is set, the default
+application layout will be applied when the application is restarted. Tasks
+will still attempt to restore as much user interface state as possible,
+including window positions and task layouts. This setting is partcularly useful
+for multi-window applications.
 
 Apart from this functionality, the Tasks plugin provides no additional *default*
 behavior for managing tasks and their windows, permitting users to switch tasks

--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -73,7 +73,7 @@ class TasksApplication(Application):
         Instance('pyface.tasks.task_window_layout.TaskWindowLayout'))
 
     # Whether to always apply the default *application level* layout when the
-    # application is started. Even if this is False, the layout state of
+    # application is started. Even if this is True, the layout state of
     # individual tasks will be restored.
     always_use_default_layout = Bool(False)
 


### PR DESCRIPTION
Fixes the comment for `TasksApplication.always_use_default_layout` to be consistent with the usage.

Also makes some grammar and spelling fixes in the corresponding documentation.

See also #143 and #144.