### PR TITLE
Fix deprecation warnings from use of Logger.warn

### DIFF
--- a/envisage/egg_basket_plugin_manager.py
+++ b/envisage/egg_basket_plugin_manager.py
@@ -80,7 +80,7 @@ class EggBasketPluginManager(PluginManager):
         # Warn if the entry point is an old-style one where the LHS didn't have
         # to be the same as the plugin Id.
         if ep.name != plugin.id:
-            logger.warn(
+            logger.warning(
                 'entry point name <%s> should be the same as the '
                 'plugin id <%s>' % (ep.name, plugin.id)
             )

--- a/envisage/egg_plugin_manager.py
+++ b/envisage/egg_plugin_manager.py
@@ -88,7 +88,7 @@ class EggPluginManager(PluginManager):
         # Warn if the entry point is an old-style one where the LHS didn't have
         # to be the same as the plugin Id.
         if ep.name != plugin.id:
-            logger.warn(
+            logger.warning(
                 'entry point name <%s> should be the same as the '
                 'plugin id <%s>' % (ep.name, plugin.id)
             )

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -178,7 +178,7 @@ class Plugin(ExtensionProvider):
         """ Trait initializer. """
 
         id = '%s.%s' % (type(self).__module__, type(self).__name__)
-        logger.warn('plugin %s has no Id - using <%s>' % (self, id))
+        logger.warning('plugin %s has no Id - using <%s>' % (self, id))
 
         return id
 
@@ -186,7 +186,7 @@ class Plugin(ExtensionProvider):
         """ Trait initializer. """
 
         name = camel_case_to_words(type(self).__name__)
-        logger.warn('plugin %s has no name - using <%s>' % (self, name))
+        logger.warning('plugin %s has no name - using <%s>' % (self, name))
 
         return name
 
@@ -247,7 +247,7 @@ class Plugin(ExtensionProvider):
         """ Register the services offered by the plugin. """
 
         for trait_name, trait in self.traits(service=True).items():
-            logger.warn(
+            logger.warning(
                 'DEPRECATED: Do not use the "service=True" metadata anymore. '
                 'Services should now be offered using the service '
                 'offer extension point (envisage.service_offers) '

--- a/envisage/provider_extension_registry.py
+++ b/envisage/provider_extension_registry.py
@@ -78,7 +78,7 @@ class ProviderExtensionRegistry(ExtensionRegistry):
         # If we don't know about the extension point then it sure ain't got
         # any extensions!
         if not extension_point_id in self._extension_points:
-            logger.warn(
+            logger.warning(
                 'getting extensions of unknown extension point <%s>' \
                 % extension_point_id
             )

--- a/envisage/ui/action/action_set.py
+++ b/envisage/ui/action/action_set.py
@@ -91,7 +91,7 @@ class ActionSet(HasTraits):
         """ Trait initializer. """
 
         id = '%s.%s' % (type(self).__module__, type(self).__name__)
-        logger.warn('action set %s has no Id - using <%s>' % (self, id))
+        logger.warning('action set %s has no Id - using <%s>' % (self, id))
 
         return id
 
@@ -99,7 +99,7 @@ class ActionSet(HasTraits):
         """ Trait initializer. """
 
         name = camel_case_to_words(type(self).__name__)
-        logger.warn('action set %s has no name - using <%s>' % (self, name))
+        logger.warning('action set %s has no name - using <%s>' % (self, name))
 
         return name
 

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -334,7 +334,7 @@ class Project(HasTraits):
         if not self._contains_resource(resource):
             logger.warning(
                 'This Project [%s] does not contain resource [%s]',
-                (self, resource))
+                self, resource)
 
         # Add or remove from our set of editors as requested
         if not remove:

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -332,7 +332,8 @@ class Project(HasTraits):
 
         # Warn if the resource is not part of this project
         if not self._contains_resource(resource):
-            logger.warn('This Project [%s] does not contain resource [%s]' % \
+            logger.warning(
+                'This Project [%s] does not contain resource [%s]',
                 (self, resource))
 
         # Add or remove from our set of editors as requested

--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -340,7 +340,7 @@ class TasksApplication(Application):
                 if state.version == restored_state.version:
                     state = restored_state
                 else:
-                    logger.warn('Discarding outdated application layout')
+                    logger.warning('Discarding outdated application layout')
             except:
                 # If anything goes wrong, log the error and continue.
                 logger.exception('Restoring application layout from %s',


### PR DESCRIPTION
Replace uses of the long-deprecated `Logger.warn` with `Logger.warning`.