### PR TITLE
Use a fixed protocol when saving task layout state.

### DIFF
--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -1,0 +1,59 @@
+# (C) Copyright 2019 Enthought, Inc., Austin, TX
+# All rights reserved.
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from envisage._compat import pickle
+from envisage.ui.tasks.api import TasksApplication
+
+
+class TestTasksApplication(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir)
+
+    def test_layout_save_uses_protocol_2(self):
+        # We use pickle protocol 2 by default, to allow compatibility
+        # across Python versions.
+        state_location = self.tmpdir
+
+        # Create application, and set it up to exit as soon as it's launched.
+        app = TasksApplication(state_location=state_location)
+        app.on_trait_change(app.exit, "application_initialized")
+
+        memento_file = os.path.join(state_location, "application_memento")
+        self.assertFalse(os.path.exists(memento_file))
+        app.run()
+        self.assertTrue(os.path.exists(memento_file))
+
+        # Check that the generated file has protocol 2.
+        with open(memento_file, "rb") as f:
+            protocol_bytes = f.read(2)
+        self.assertEqual(protocol_bytes, b"\x80\x02")
+
+    @unittest.skipUnless(
+        3 <= pickle.HIGHEST_PROTOCOL, "Test uses pickle protocol 3")
+    def test_layout_save_with_protocol_3(self):
+        # Test that the protocol can be overridden on a per-application basis.
+        state_location = self.tmpdir
+
+        # Create application, and set it up to exit as soon as it's launched.
+        app = TasksApplication(
+            state_location=state_location,
+            layout_save_protocol=3,
+        )
+        app.on_trait_change(app.exit, "application_initialized")
+
+        memento_file = os.path.join(state_location, "application_memento")
+        self.assertFalse(os.path.exists(memento_file))
+        app.run()
+        self.assertTrue(os.path.exists(memento_file))
+
+        # Check that the generated file uses protocol 3.
+        with open(memento_file, "rb") as f:
+            protocol_bytes = f.read(2)
+        self.assertEqual(protocol_bytes, b"\x80\x03")


### PR DESCRIPTION
The `TasksApplication` state is currently saved using `pickle.dump`; the pickle protocol version used depends on the Python version: protocol 0 for Python 2, protocol 3 (which is not Python 2-compatible) for Python 3.<recent>, and potentially a higher version of the protocol in the future.

This can lead to problems when a state is saved under one version of Python and loaded under a different version.

This PR forces the state to always be dumped with pickle protocol 2 to avoid these issues. Once we no longer need Python 2 support, this could potentially be upgraded to protocol 3 or later.

Some minimal tests are added (more tests for `TasksApplication` would be nice, but that's outside the scope of this PR).

I've also cleaned up and expanded the logging during state save and restore so that the log file contains more information about what happened.