### PR TITLE
Suppress the Ctrl-C message issued by the IPython kernel.

### DIFF
--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -33,7 +33,8 @@ def temp_filename(filename):
 
 @contextlib.contextmanager
 def redirect_stdout_to(filename):
-    """ Redirect stdout output from C libraries to a file.
+    """ Redirect stdout to a file, in a way that's immune to changes
+    to Python's sys.stdout.
 
     Parameters
     ----------


### PR DESCRIPTION
When starting, the IPython kernel prints the following message to the console:
```
NOTE: When using the `ipython kernel` entry point, Ctrl-C will not work.

To exit, you will have to explicitly quit this process, by either sending
"quit" from a client, or using Ctrl-\ in UNIX-like environments.

To read more about this, see https://github.com/ipython/ipython/issues/2049
```

That message isn't particularly useful for our case of embedding an IPython prompt inside an application. This PR suppresses it.