### PR TITLE
Redirect IPython's raw_print and raw_print_err to logging.

### DIFF
--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -1,7 +1,7 @@
 import contextlib
 import gc
+import logging
 import os
-import shutil
 import sys
 import tempfile
 import unittest
@@ -17,41 +17,88 @@ else:
 if ipykernel_available:
     from ipykernel.iostream import IOPubThread
     from ipykernel.kernelapp import IPKernelApp
+    import IPython.utils.io
 
     from envisage.plugins.ipython_kernel.internal_ipkernel import (
         InternalIPKernel)
 
 
+# Machinery for catching logged messages in tests (both for testing
+# the existence and content of those messages, and for hiding the
+# logger output during the test run).
+
+class ListHandler(logging.Handler):
+    """
+    Simple logging handler that stores all records in a list.
+
+    Used by catch_logs below.
+    """
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
 @contextlib.contextmanager
-def temp_filename(filename):
-    tmpdir = tempfile.mkdtemp()
+def catch_logs(logger_name, level=logging.WARNING):
+    """
+    Temporarily redirect logs for the given logger to a list.
+
+    Also allows temporarily changing the level of that logger.
+    """
+    logger = logging.getLogger(logger_name)
+    handler = ListHandler()
+    old_propagate = logger.propagate
+    old_level = logger.level
+
+    logger.addHandler(handler)
+    logger.propagate = False
+    logger.setLevel(level)
     try:
-        yield os.path.join(tmpdir, filename)
+        yield handler.records
     finally:
-        shutil.rmtree(tmpdir)
+        logger.setLevel(old_level)
+        logger.propagate = old_propagate
+        logger.removeHandler(handler)
 
 
 @contextlib.contextmanager
-def redirect_stdout_to(filename):
-    """ Redirect stdout to a file, in a way that's immune to changes
-    to Python's sys.stdout.
+def capture_stream(stream, callback=None):
+    """
+    Context manager to capture output to a particular stream.
+
+    Capture all output written to the given stream. If the optional
+    callback is provided, call it with the captured output (which
+    will be a bytestring) when exiting the with block.
 
     Parameters
     ----------
-    filename : str
-        Path to filename to use for the redirected output.
+    stream : Python stream
+        For example, sys.__stdout__.
+    callback : callable
+        Callable of a single argument.
     """
-    with open(filename, 'w') as stream:
-        stdout_fd = sys.__stdout__.fileno()
-        old_stdout_fd = os.dup(stdout_fd)
-        dest_fd = stream.fileno()
-        os.dup2(dest_fd, stdout_fd)
+    stream_fd = stream.fileno()
+
+    with tempfile.TemporaryFile() as new_stream:
+        old_stream_fd = os.dup(stream_fd)
+        stream.flush()
+        os.dup2(new_stream.fileno(), stream_fd)
         try:
             yield
         finally:
-            sys.__stdout__.flush()
-            os.dup2(old_stdout_fd, stdout_fd)
-            os.close(old_stdout_fd)
+            stream.flush()
+            os.dup2(old_stream_fd, stream_fd)
+            os.close(old_stream_fd)
+
+        new_stream.flush()
+        new_stream.seek(0)
+        captured = new_stream.read()
+
+    if callback is not None:
+        callback(captured)
 
 
 @unittest.skipUnless(ipykernel_available,
@@ -121,13 +168,110 @@ class TestInternalIPKernel(unittest.TestCase):
             self.assertFalse(thread.thread.is_alive())
 
     def test_ctrl_c_message_suppressed(self):
-        with temp_filename("captured_stdout.txt") as captured_stdout:
-            with redirect_stdout_to(captured_stdout):
-                kernel = InternalIPKernel()
-                kernel.init_ipkernel(gui_backend=None)
-                kernel.shutdown()
+        captured = []
+        with capture_stream(sys.__stdout__, callback=captured.append):
+            kernel = InternalIPKernel()
+            kernel.init_ipkernel(gui_backend=None)
+            kernel.shutdown()
 
-            with open(captured_stdout, "rb") as f:
-                stdout = f.read().decode("utf-8")
+        self.assertEqual(len(captured), 1)
+        captured_stdout = captured[0].decode("utf-8")
+        self.assertNotIn("Ctrl-C will not work", captured_stdout)
 
-        self.assertNotIn("Ctrl-C will not work", stdout)
+    def test_raw_print_logged(self):
+        test_message = "norwegian blue"
+
+        # Outside the context of the kernel, raw_print prints as expected.
+        captured = []
+        with capture_stream(sys.__stdout__, callback=captured.append):
+            IPython.utils.io.raw_print(test_message)
+        self.assertEqual(len(captured), 1)
+        captured_stdout = captured[0].decode("utf-8")
+        self.assertIn(test_message, captured_stdout)
+
+        # Again, with a running kernel.
+        kernel = InternalIPKernel()
+        kernel.init_ipkernel(gui_backend=None)
+        captured = []
+        log_catcher = catch_logs(
+            "envisage.plugins.ipython_kernel", level=logging.INFO)
+
+        try:
+            with log_catcher as log_records:
+                with capture_stream(sys.__stdout__, callback=captured.append):
+                    IPython.utils.io.raw_print(test_message)
+        finally:
+            kernel.shutdown()
+
+        # Check captured output (which should not contain the test message)
+        # and the INFO-level log records (which should).
+        messages = [
+            record.getMessage() for record in log_records
+            if record.levelno == logging.INFO
+        ]
+        test_message_found = any(
+            test_message in message for message in messages)
+        self.assertTrue(
+            test_message_found,
+            msg="raw_print messages were not found in the logs"
+        )
+        self.assertEqual(len(captured), 1)
+        captured_stdout = captured[0].decode("utf-8")
+        self.assertNotIn(test_message, captured_stdout)
+
+        # After shutdown, raw_print again prints to __stdout__.
+        captured = []
+        with capture_stream(sys.__stdout__, callback=captured.append):
+            IPython.utils.io.raw_print(test_message)
+        self.assertEqual(len(captured), 1)
+        captured_stdout = captured[0].decode("utf-8")
+        self.assertIn(test_message, captured_stdout)
+
+    def test_raw_print_err_logged(self):
+        test_message = "your hovercraft is full of eels"
+
+        # Outside the context of the kernel, raw_print_err prints as expected.
+        captured = []
+        with capture_stream(sys.__stderr__, callback=captured.append):
+            IPython.utils.io.raw_print_err(test_message)
+        self.assertEqual(len(captured), 1)
+        captured_stdout = captured[0].decode("utf-8")
+        self.assertIn(test_message, captured_stdout)
+
+        # Again, with a running kernel.
+        kernel = InternalIPKernel()
+        kernel.init_ipkernel(gui_backend=None)
+        captured = []
+        log_catcher = catch_logs(
+            "envisage.plugins.ipython_kernel", level=logging.WARNING)
+
+        try:
+            with log_catcher as log_records:
+                with capture_stream(sys.__stderr__, callback=captured.append):
+                    IPython.utils.io.raw_print_err(test_message)
+        finally:
+            kernel.shutdown()
+
+        # Check captured output (which should not contain the test message)
+        # and the INFO-level log records (which should).
+        messages = [
+            record.getMessage() for record in log_records
+            if record.levelno == logging.WARNING
+        ]
+        test_message_found = any(
+            test_message in message for message in messages)
+        self.assertTrue(
+            test_message_found,
+            msg="raw_print_err messages were not found in the logs"
+        )
+        self.assertEqual(len(captured), 1)
+        captured_stdout = captured[0].decode("utf-8")
+        self.assertNotIn(test_message, captured_stdout)
+
+        # After shutdown, raw_print_err again prints to __stderr__.
+        captured = []
+        with capture_stream(sys.__stderr__, callback=captured.append):
+            IPython.utils.io.raw_print_err(test_message)
+        self.assertEqual(len(captured), 1)
+        captured_stdout = captured[0].decode("utf-8")
+        self.assertIn(test_message, captured_stdout)


### PR DESCRIPTION
This PR replaces IPython's `raw_print` and `raw_print_err` utilities with functions that log instead of printing to `sys.__stdout__` and `sys.__stderr__`. This prevents the kernel startup messages from being printed to `sys.__stdout__` (which may not even exist in the context of a Windows GUI application).