### PR TITLE
Properly skip tests if ETS_TOOLKIT isn't defined.

### DIFF
--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -13,7 +13,7 @@ from envisage.ui.tasks.api import TasksApplication
 from envisage.ui.tasks.tasks_application import DEFAULT_STATE_FILENAME
 
 requires_gui = unittest.skipIf(
-    os.environ.get("ETS_TOOLKIT") == "null",
+    os.environ.get("ETS_TOOLKIT", "none") in {"null", "none"},
     "Test requires a non-null GUI backend",
 )
 


### PR DESCRIPTION
The drive-by-fix in #179 was broken: we want to actually *skip* the test if `ETS_TOOLKIT` is not defined.