### PR TITLE
More setup.py revisions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -277,9 +277,7 @@ if __name__ == "__main__":
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
         entry_points={
-            "envisage.plugins": [
-                "envisage.core = envisage.core_plugin:CorePlugin",
-            ],
+            "envisage.plugins": ["envisage.core = envisage.core_plugin:CorePlugin"]
         },
         install_requires=["apptools", "traits"],
         license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -283,7 +283,7 @@ if __name__ == "__main__":
                 "envisage.core = envisage.core_plugin:CorePlugin"
             ]
         },
-        install_requires=["apptools", "six", "traits"],
+        install_requires=["apptools", "setuptools", "six", "traits"],
         license="BSD",
         packages=find_packages(),
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ def archive_version():
 
     version_template = RELEASED_VERSION if IS_RELEASED else UNRELEASED_VERSION
     version = version_template.format(
-        major=MAJOR, minor=MINOR, micro=MICRO, dev="unknown"
+        major=MAJOR, minor=MINOR, micro=MICRO, dev="<unknown>"
     )
     return version, ARCHIVE_COMMIT_HASH
 
@@ -283,7 +283,7 @@ if __name__ == "__main__":
                 "envisage.core = envisage.core_plugin:CorePlugin"
             ]
         },
-        install_requires=["apptools", "traits"],
+        install_requires=["apptools", "six", "traits"],
         license="BSD",
         packages=find_packages(),
         package_data={
@@ -298,7 +298,6 @@ if __name__ == "__main__":
             "envisage.ui.single_project": ["*.txt"],
             "envisage.ui.tasks.tests": ["data/*.pkl"],
         },
-        platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
         python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
         zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ def archive_version():
 
     version_template = RELEASED_VERSION if IS_RELEASED else UNRELEASED_VERSION
     version = version_template.format(
-        major=MAJOR, minor=MINOR, micro=MICRO, dev="<unknown>"
+        major=MAJOR, minor=MINOR, micro=MICRO, dev="-unknown"
     )
     return version, ARCHIVE_COMMIT_HASH
 

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ def archive_version():
     ValueError
         If this does not appear to be an archive.
     """
-    if ARCHIVE_COMMIT_HASH == "$Format:%H$":
+    if "$" in ARCHIVE_COMMIT_HASH:
         raise ValueError("This does not appear to be an archive.")
 
     version_template = RELEASED_VERSION if IS_RELEASED else UNRELEASED_VERSION
@@ -210,7 +210,7 @@ def resolve_version():
         print(u"Computed package version: {}".format(version))
         print(u"Writing version to version file {}.".format(VERSION_FILE))
         write_version_file(*version)
-    elif ARCHIVE_COMMIT_HASH != "$Format:%H$":
+    elif "$" not in ARCHIVE_COMMIT_HASH:
         # This is a source archive.
         version = archive_version()
         print(u"Archive package version: {}".format(version))

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,9 @@ def write_version_file(version, git_revision):
     """
     with io.open(VERSION_FILE, "w", encoding="ascii") as version_file:
         version_file.write(
-            VERSION_FILE_TEMPLATE.format(version=version, git_revision=git_revision)
+            VERSION_FILE_TEMPLATE.format(
+                version=version, git_revision=git_revision
+            )
         )
 
 
@@ -277,7 +279,9 @@ if __name__ == "__main__":
         long_description=get_long_description(),
         long_description_content_type="text/x-rst",
         entry_points={
-            "envisage.plugins": ["envisage.core = envisage.core_plugin:CorePlugin"]
+            "envisage.plugins": [
+                "envisage.core = envisage.core_plugin:CorePlugin"
+            ]
         },
         install_requires=["apptools", "traits"],
         license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -111,9 +111,7 @@ def write_version_file(version, git_revision):
     """
     with io.open(VERSION_FILE, "w", encoding="ascii") as version_file:
         version_file.write(
-            VERSION_FILE_TEMPLATE.format(
-                version=version, git_revision=git_revision
-            )
+            VERSION_FILE_TEMPLATE.format(version=version, git_revision=git_revision)
         )
 
 
@@ -164,6 +162,32 @@ def git_version():
     return version, git_revision
 
 
+def archive_version():
+    """
+    Construct version information for an archive.
+
+    Returns
+    -------
+    version : unicode
+        Package version.
+    git_revision : unicode
+        The full commit hash for the current Git revision.
+
+    Raises
+    ------
+    ValueError
+        If this does not appear to be an archive.
+    """
+    if ARCHIVE_COMMIT_HASH == "$Format:%H$":
+        raise ValueError("This does not appear to be an archive.")
+
+    version_template = RELEASED_VERSION if IS_RELEASED else UNRELEASED_VERSION
+    version = version_template.format(
+        major=MAJOR, minor=MINOR, micro=MICRO, dev="unknown"
+    )
+    return version, ARCHIVE_COMMIT_HASH
+
+
 def resolve_version():
     """
     Process version information and write a version file if necessary.
@@ -184,13 +208,11 @@ def resolve_version():
         print(u"Computed package version: {}".format(version))
         print(u"Writing version to version file {}.".format(VERSION_FILE))
         write_version_file(*version)
-    elif IS_RELEASED and ARCHIVE_COMMIT_HASH != "$Format:%H$":
-        # This is a source archive for a released version.
-        pkg_version = RELEASED_VERSION.format(
-            major=MAJOR, minor=MINOR, micro=MICRO
-        )
-        git_revision = ARCHIVE_COMMIT_HASH
-        version = pkg_version, git_revision
+    elif ARCHIVE_COMMIT_HASH != "$Format:%H$":
+        # This is a source archive.
+        version = archive_version()
+        print(u"Archive package version: {}".format(version))
+        print(u"Writing version to version file {}.".format(VERSION_FILE))
         write_version_file(*version)
     elif os.path.isfile(VERSION_FILE):
         # This is a source distribution. Read the version information.
@@ -208,60 +230,73 @@ def resolve_version():
     return version
 
 
+def get_long_description():
+    """ Read long description from README.txt. """
+    with io.open("README.rst", "r", encoding="utf-8") as readme:
+        return readme.read()
+
+
 if __name__ == "__main__":
     version, git_revision = resolve_version()
 
     setup(
-        name = 'envisage',
-        version = version,
-        author = "Martin Chilvers, et. al.",
-        author_email = "info@enthought.com",
-        maintainer = 'ETS Developers',
-        maintainer_email = 'enthought-dev@enthought.com',
-        url = 'http://docs.enthought.com/envisage',
-        download_url = 'https://github.com/enthought/envisage',
-        classifiers = [c.strip() for c in """\
+        name="envisage",
+        version=version,
+        url="http://docs.enthought.com/envisage",
+        author="Enthought",
+        author_email="info@enthought.com",
+        maintainer="ETS Developers",
+        maintainer_email="enthought-dev@enthought.com",
+        download_url="https://github.com/enthought/envisage",
+        classifiers=[
+            c.strip()
+            for c in """\
             Development Status :: 5 - Production/Stable
             Intended Audience :: Developers
             Intended Audience :: Science/Research
             License :: OSI Approved :: BSD License
-            Operating System :: MacOS
+            Operating System :: MacOS :: MacOS X
             Operating System :: Microsoft :: Windows
-            Operating System :: OS Independent
-            Operating System :: POSIX
-            Operating System :: Unix
+            Operating System :: POSIX :: Linux
             Programming Language :: Python
+            Programming Language :: Python :: 2
+            Programming Language :: Python :: 2.7
+            Programming Language :: Python :: 3
+            Programming Language :: Python :: 3.5
+            Programming Language :: Python :: 3.6
+            Programming Language :: Python :: 3.7
+            Programming Language :: Python :: Implementation :: CPython
             Topic :: Scientific/Engineering
             Topic :: Software Development
             Topic :: Software Development :: Libraries
-            """.splitlines() if len(c.strip()) > 0],
-        description = 'extensible application framework',
-        long_description = open('README.rst').read(),
-        entry_points = """
-            [envisage.plugins]
-            envisage.core = envisage.core_plugin:CorePlugin
-            """,
-        ext_modules = [],
-        install_requires = ['apptools', 'traits'],
-        license = "BSD",
-        packages = find_packages(),
-        package_data = {
-            '': ['images/*', '*.ini'],
-            'envisage.tests': [
-                'bad_eggs/*.egg',
-                'eggs/*.egg',
-                'plugins/pear/*.py',
-                'plugins/banana/*.py',
-                'plugins/orange/*.py',
-            ],
-            'envisage.ui.single_project': [
-                '*.txt',
-            ],
-            'envisage.ui.tasks.tests': [
-                'data/*.pkl',
+            Topic :: Software Development :: User Interfaces
+            """.splitlines()
+            if len(c.strip()) > 0
+        ],
+        description="Extensible application framework",
+        long_description=get_long_description(),
+        long_description_content_type="text/x-rst",
+        entry_points={
+            "envisage.plugins": [
+                "envisage.core = envisage.core_plugin:CorePlugin",
             ],
         },
-        platforms = ["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
-        python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*',
-        zip_safe = False,
+        install_requires=["apptools", "traits"],
+        license="BSD",
+        packages=find_packages(),
+        package_data={
+            "": ["images/*", "*.ini"],
+            "envisage.tests": [
+                "bad_eggs/*.egg",
+                "eggs/*.egg",
+                "plugins/pear/*.py",
+                "plugins/banana/*.py",
+                "plugins/orange/*.py",
+            ],
+            "envisage.ui.single_project": ["*.txt"],
+            "envisage.ui.tasks.tests": ["data/*.pkl"],
+        },
+        platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
+        python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
+        zip_safe=False,
     )


### PR DESCRIPTION
`setup.py` cleanup and changes in preparation for release

@rahulporuri : I've extended the install-from-archive logic a bit; could you take a look, and see what you think? It now allows installation from an archive for a non-released version, but instead of inventing a dev number it uses `"4.5.6.dev-unknown"` in that case. That's not PEP 440 compliant, so it'll force would-be uploaders to think before uploading, but the package will be otherwise functional.

Other highlights:
- add "six" and "setuptools" to dependencies
- don't leave a file unclosed when reading the long description
- change "author" field
- add missing "long_description_content_type" field (twine warns about this)
- refine and extend trove classifiers
- remove "platform" field, which is redundant with the classifiers
- style fixes; blacken the whole module
