### PR TITLE
Bump version information in preparation for 4.8.0 release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 MAJOR = 4
 MINOR = 8
 MICRO = 0
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
[PR against the newly-created `release/4.8.x` branch]

Set `IS_RELEASED` to `True` in preparation for 4.8.0 release.