### PR TITLE
Fix DeprecationWarnings, remove boilerplate.

### DIFF
--- a/envisage/resource/tests/test_resource_manager.py
+++ b/envisage/resource/tests/test_resource_manager.py
@@ -56,14 +56,10 @@ class ResourceManagerTestCase(unittest.TestCase):
         self.stored_urlopen = url_library.urlopen
         url_library.urlopen = stubout_urlopen
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
 
         url_library.urlopen = self.stored_urlopen
-
-        return
 
     ###########################################################################
     # Tests.
@@ -87,19 +83,14 @@ class ResourceManagerTestCase(unittest.TestCase):
         with open(filename, 'rb') as g:
             self.assertEqual(g.read(), contents)
 
-        return
-
     def test_no_such_file_resource(self):
         """ no such file resource """
 
         rm = ResourceManager()
 
         # Open a file resource.
-        self.assertRaises(
-            NoSuchResourceError, rm.file, 'file://../bogus.py'
-        )
-
-        return
+        with self.assertRaises(NoSuchResourceError):
+            rm.file("file://../bogus.py")
 
     def test_package_resource(self):
         """ package resource """
@@ -120,26 +111,17 @@ class ResourceManagerTestCase(unittest.TestCase):
         self.assertEqual(g.read(), contents)
         g.close()
 
-        return
-
     def test_no_such_package_resource(self):
         """ no such package resource """
 
         rm = ResourceManager()
 
         # Open a package resource.
-        self.assertRaises(
-            NoSuchResourceError,
-            rm.file,
-            'pkgfile://envisage.resource/bogus.py'
-        )
+        with self.assertRaises(NoSuchResourceError):
+            rm.file("pkgfile://envisage.resource/bogus.py")
 
-        self.assertRaises(
-            NoSuchResourceError, rm.file, 'pkgfile://completely.bogus/bogus.py'
-        )
-
-        return
-
+        with self.assertRaises(NoSuchResourceError):
+            rm.file("pkgfile://completely.bogus/bogus.py")
 
     def test_http_resource(self):
         """ http resource """
@@ -152,10 +134,7 @@ class ResourceManagerTestCase(unittest.TestCase):
         contents = f.read()
         f.close()
 
-        self.assertEquals(contents, 'This is a test file.\n')
-
-        return
-
+        self.assertEqual(contents, 'This is a test file.\n')
 
     def test_no_such_http_resource(self):
         """ no such http resource """
@@ -163,12 +142,8 @@ class ResourceManagerTestCase(unittest.TestCase):
         # Open an HTTP document resource.
         rm = ResourceManager()
 
-        self.assertRaises(
-            NoSuchResourceError, rm.file, 'http://localhost:1234/bogus.dat'
-        )
-
-        return
-
+        with self.assertRaises(NoSuchResourceError):
+            rm.file("http://localhost:1234/bogus.dat")
 
     def test_unknown_protocol(self):
         """ unknown protocol """
@@ -176,13 +151,5 @@ class ResourceManagerTestCase(unittest.TestCase):
         # Open an HTTP document resource.
         rm = ResourceManager()
 
-        self.assertRaises(ValueError, rm.file, 'bogus://foo/bar/baz')
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################
+        with self.assertRaises(ValueError):
+            rm.file("bogus://foo/bar/baz")

--- a/envisage/tests/test_application.py
+++ b/envisage/tests/test_application.py
@@ -30,15 +30,11 @@ def listener(obj, trait_name, old, new):
     listener.old = old
     listener.new = new
 
-    return
-
 
 def vetoer(event):
     """ A function that will veto an event. """
 
     event.veto = True
-
-    return
 
 
 class TestApplication(Application):
@@ -65,15 +61,11 @@ class SimplePlugin(Plugin):
         self.started = True
         self.stopped = False
 
-        return
-
     def stop(self):
         """ Stop the plugin. """
 
         self.started = False
         self.stopped = True
-
-        return
 
 
 class BadPlugin(Plugin):
@@ -118,10 +110,6 @@ class PluginC(Plugin):
 class ApplicationTestCase(unittest.TestCase):
     """ Tests for applications and plugins. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
@@ -130,17 +118,6 @@ class ApplicationTestCase(unittest.TestCase):
         listener.trait_name = None
         listener.old = None
         listener.new = None
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
 
     def test_home(self):
         """ home """
@@ -161,8 +138,6 @@ class ApplicationTestCase(unittest.TestCase):
 
         # Delete the directory.
         shutil.rmtree(application.home)
-
-        return
 
     def test_no_plugins(self):
         """ no plugins """
@@ -190,8 +165,6 @@ class ApplicationTestCase(unittest.TestCase):
             ['starting', 'started', 'stopping', 'stopped'], tracker.event_names
         )
 
-        return
-
     def test_veto_starting(self):
         """ veto starting """
 
@@ -213,8 +186,6 @@ class ApplicationTestCase(unittest.TestCase):
         started = application.start()
         self.assertEqual(False, started)
         self.assertTrue('started' not in tracker.event_names)
-
-        return
 
     def test_veto_stopping(self):
         """ veto stopping """
@@ -243,8 +214,6 @@ class ApplicationTestCase(unittest.TestCase):
         self.assertEqual(False, stopped)
         self.assertTrue('stopped' not in tracker.event_names)
 
-        return
-
     def test_start_and_stop_errors(self):
         """ start and stop errors """
 
@@ -253,22 +222,20 @@ class ApplicationTestCase(unittest.TestCase):
         application   = TestApplication(plugins=[simple_plugin, bad_plugin])
 
         # Try to start the application - the bad plugin should barf.
-        self.assertRaises(ZeroDivisionError, application.start)
+        with self.assertRaises(ZeroDivisionError):
+            application.start()
 
         # Try to stop the application - the bad plugin should barf.
-        self.assertRaises(ZeroDivisionError, application.stop)
+        with self.assertRaises(ZeroDivisionError):
+            application.stop()
 
         # Try to start a non-existent plugin.
-        self.assertRaises(
-            SystemError, application.start_plugin, plugin_id='bogus'
-        )
+        with self.assertRaises(SystemError):
+            application.start_plugin(plugin_id="bogus")
 
         # Try to stop a non-existent plugin.
-        self.assertRaises(
-            SystemError, application.stop_plugin, plugin_id='bogus'
-        )
-
-        return
+        with self.assertRaises(SystemError):
+            application.stop_plugin(plugin_id="bogus")
 
     def test_extension_point(self):
         """ extension point """
@@ -290,8 +257,6 @@ class ApplicationTestCase(unittest.TestCase):
         self.assertEqual(6, len(extensions))
         self.assertEqual([1, 2, 3, 98, 99, 100], extensions)
 
-        return
-
     def test_add_extension_point_listener(self):
         """ add extension point listener """
 
@@ -310,8 +275,6 @@ class ApplicationTestCase(unittest.TestCase):
             listener.added              = event.added
             listener.removed            = event.removed
 
-            return
-
         # Make sure we can get the contributions via the application.
         extensions = application.get_extensions('a.x')
         self.assertEqual(3, len(extensions))
@@ -327,8 +290,6 @@ class ApplicationTestCase(unittest.TestCase):
         self.assertEqual('a.x', listener.extension_point_id)
         self.assertEqual([], listener.removed)
         self.assertEqual([98, 99, 100], listener.added)
-
-        return
 
     def test_remove_extension_point_listener(self):
         """ remove extension point listener """
@@ -347,8 +308,6 @@ class ApplicationTestCase(unittest.TestCase):
             listener.extension_point_id = event.extension_point_id
             listener.added   = event.added
             listener.removed = event.removed
-
-            return
 
         # Make sure we can get the contributions via the application.
         extensions = application.get_extensions('a.x')
@@ -374,8 +333,6 @@ class ApplicationTestCase(unittest.TestCase):
 
         # Make sure the listener was *not* called.
         self.assertEqual(None, listener.extension_point_id)
-
-        return
 
     def test_add_plugin(self):
         """ add plugin """
@@ -411,8 +368,6 @@ class ApplicationTestCase(unittest.TestCase):
         self.assertEqual(6, len(extensions))
         self.assertEqual([1, 2, 3, 98, 99, 100], extensions)
 
-        return
-
     def test_get_plugin(self):
         """ get plugin """
 
@@ -431,8 +386,6 @@ class ApplicationTestCase(unittest.TestCase):
 
         # Make sure we can't get one that isn't there ;^)
         self.assertEqual(None, application.get_plugin('BOGUS'))
-
-        return
 
     def test_remove_plugin(self):
         """ remove plugin """
@@ -467,8 +420,6 @@ class ApplicationTestCase(unittest.TestCase):
         self.assertEqual(3, len(extensions))
         self.assertEqual([98, 99, 100], extensions)
 
-        return
-
     def test_set_plugin_manager_at_contruction_time(self):
         """ set plugin manager at construction time"""
 
@@ -489,12 +440,3 @@ class ApplicationTestCase(unittest.TestCase):
 
         # Make sure we can't get one that isn't there ;^)
         self.assertEqual(None, application.get_plugin('BOGUS'))
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_class_load_hook.py
+++ b/envisage/tests/test_class_load_hook.py
@@ -129,10 +129,3 @@ class ClassLoadHookTestCase(unittest.TestCase):
         """ Return the full (possibly) dotted name of a class. """
 
         return cls.__module__ + '.' + cls.__name__
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_class_load_hook.py
+++ b/envisage/tests/test_class_load_hook.py
@@ -21,24 +21,6 @@ PKG = 'envisage.tests'
 class ClassLoadHookTestCase(unittest.TestCase):
     """ Tests for class load hooks. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_connect(self):
         """ connect """
 
@@ -46,8 +28,6 @@ class ClassLoadHookTestCase(unittest.TestCase):
             """ Called when a class is loaded. """
 
             on_class_loaded.cls = cls
-
-            return
 
         # To register with 'MetaHasTraits' we use 'module_name.class_name'.
         hook = ClassLoadHook(
@@ -61,8 +41,6 @@ class ClassLoadHookTestCase(unittest.TestCase):
 
         self.assertEqual(Foo, on_class_loaded.cls)
 
-        return
-
     def test_class_already_loaded(self):
         """ class already loaded """
 
@@ -70,8 +48,6 @@ class ClassLoadHookTestCase(unittest.TestCase):
             """ Called when a class is loaded. """
 
             on_class_loaded.cls = cls
-
-            return
 
         # To register with 'MetaHasTraits' we use 'module_name.class_name'.
         hook = ClassLoadHook(
@@ -84,8 +60,6 @@ class ClassLoadHookTestCase(unittest.TestCase):
         # already loaded.
         self.assertEqual(ClassLoadHookTestCase, on_class_loaded.cls)
 
-        return
-
     def test_disconnect(self):
         """ disconnect """
 
@@ -93,8 +67,6 @@ class ClassLoadHookTestCase(unittest.TestCase):
             """ Called when a class is loaded. """
 
             on_class_loaded.cls = cls
-
-            return
 
         # To register with 'MetaHasTraits' we use 'module_name.class_name'.
         hook = ClassLoadHook(
@@ -118,8 +90,6 @@ class ClassLoadHookTestCase(unittest.TestCase):
             pass
 
         self.assertEqual(None, on_class_loaded.cls)
-
-        return
 
     ###########################################################################
     # Private interface.

--- a/envisage/tests/test_composite_plugin_manager.py
+++ b/envisage/tests/test_composite_plugin_manager.py
@@ -33,15 +33,11 @@ class SimplePlugin(Plugin):
         self.started = True
         self.stopped = False
 
-        return
-
     def stop(self):
         """ Stop the plugin. """
 
         self.started = False
         self.stopped = True
-
-        return
 
 
 class CustomException(Exception):
@@ -60,28 +56,12 @@ class RaisingPluginManager(PluginManager):
 class CompositePluginManagerTestCase(unittest.TestCase):
     """ Tests for the composite plugin manager. """
 
-    #### 'unittest.TestCase' protocol #########################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    #### Tests ################################################################
-
     def test_find_no_plugins_if_there_are_no_plugin_managers(self):
 
         plugin_manager = CompositePluginManager()
         ids = [plugin.id for plugin in plugin_manager]
 
         self.assertEqual(0, len(ids))
-
-        return
 
     def test_find_no_plugins_if_there_are_no_plugins_in_plugin_managers(self):
 
@@ -91,8 +71,6 @@ class CompositePluginManagerTestCase(unittest.TestCase):
         ids = [plugin.id for plugin in plugin_manager]
 
         self.assertEqual(0, len(ids))
-
-        return
 
     def test_find_plugins_in_a_single_plugin_manager(self):
 
@@ -110,8 +88,6 @@ class CompositePluginManagerTestCase(unittest.TestCase):
         self.assertIn('yellow', ids)
 
         self._test_start_and_stop(plugin_manager, ['red', 'yellow'])
-
-        return
 
     def test_find_plugins_in_a_multiple_plugin_managers(self):
 
@@ -135,8 +111,6 @@ class CompositePluginManagerTestCase(unittest.TestCase):
 
         self._test_start_and_stop(plugin_manager, ['red', 'yellow', 'green'])
 
-        return
-
     def test_application_gets_propogated_to_plugin_managers(self):
 
         application = Application()
@@ -148,8 +122,6 @@ class CompositePluginManagerTestCase(unittest.TestCase):
 
         for plugin_manager in composite_plugin_manager.plugin_managers:
             self.assertEqual(application, plugin_manager.application)
-
-        return
 
     def test_propogate_plugin_added_or_remove_events_from_plugin_managers(self):
 
@@ -179,14 +151,13 @@ class CompositePluginManagerTestCase(unittest.TestCase):
         a.remove_plugin(a.get_plugin('foo'))
         self.assertEqual(0, self._plugin_count(composite_plugin_manager))
 
-        return
-
     def test_correct_exception_propagated_from_plugin_manager(self):
         plugin_manager = CompositePluginManager(
             plugin_managers=[RaisingPluginManager()]
         )
 
-        self.assertRaises(CustomException, plugin_manager.start)
+        with self.assertRaises(CustomException):
+            plugin_manager.start()
 
     #### Private protocol #####################################################
 
@@ -226,12 +197,3 @@ class CompositePluginManagerTestCase(unittest.TestCase):
             plugin = plugin_manager.get_plugin(id)
             self.assertNotEqual(None, plugin)
             self.assertEqual(True, plugin.stopped)
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -196,7 +196,7 @@ class CorePluginTestCase(unittest.TestCase):
         # that! If a test fails we need to work out why - otherwise you have
         # just completely removed the benefits of having tests in the first
         # place! This test works for me on Python 2.4!
-        self.assert_('y' in Bar.class_traits())
+        self.assertTrue('y' in Bar.class_traits())
 
         return
 
@@ -236,7 +236,7 @@ class CorePluginTestCase(unittest.TestCase):
             x = Int
 
         # Make sure the category was imported and added.
-        self.assert_('y' in Bar.class_traits())
+        self.assertTrue('y' in Bar.class_traits())
 
         return
 
@@ -277,7 +277,7 @@ class CorePluginTestCase(unittest.TestCase):
             pass
 
         # Make sure the class load hook was *ignored*.
-        self.assert_(not hasattr(on_class_loaded, 'cls'))
+        self.assertTrue(not hasattr(on_class_loaded, 'cls'))
 
         # Create the target class.
         class Baz(HasTraits):
@@ -334,7 +334,7 @@ class CorePluginTestCase(unittest.TestCase):
             pass
 
         # Make sure the class load hook was *ignored*.
-        self.assert_(not hasattr(on_class_loaded, 'cls'))
+        self.assertTrue(not hasattr(on_class_loaded, 'cls'))
 
         # Create the target class.
         class Baz(HasTraits):
@@ -403,10 +403,3 @@ class CorePluginTestCase(unittest.TestCase):
         self.assertEqual('42', application.preferences.get('enthought.test.x'))
 
         return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -32,24 +32,6 @@ class TestApplication(Application):
 class CorePluginTestCase(unittest.TestCase):
     """ Tests for the core plugin. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_service_offers(self):
         """ service offers """
 
@@ -96,8 +78,6 @@ class CorePluginTestCase(unittest.TestCase):
 
         # Make sure th service has gone.
         self.assertEqual(None, application.get_service(IMyService))
-
-        return
 
     def test_dynamically_added_service_offer(self):
         """ dynamically added service offer """
@@ -157,8 +137,6 @@ class CorePluginTestCase(unittest.TestCase):
         service = application.get_service(IMyService)
         self.assertEqual(42, service)
 
-        return
-
     def test_categories(self):
         """ categories """
 
@@ -198,8 +176,6 @@ class CorePluginTestCase(unittest.TestCase):
         # place! This test works for me on Python 2.4!
         self.assertTrue('y' in Bar.class_traits())
 
-        return
-
     def test_dynamically_added_category(self):
         """ dynamically added category """
 
@@ -238,8 +214,6 @@ class CorePluginTestCase(unittest.TestCase):
         # Make sure the category was imported and added.
         self.assertTrue('y' in Bar.class_traits())
 
-        return
-
     def test_class_load_hooks(self):
         """ class load hooks """
 
@@ -249,8 +223,6 @@ class CorePluginTestCase(unittest.TestCase):
             """ Called when a class has been loaded. """
 
             on_class_loaded.cls = cls
-
-            return
 
         class PluginA(Plugin):
             id = 'A'
@@ -291,8 +263,6 @@ class CorePluginTestCase(unittest.TestCase):
         # place! This test works for me on Python 2.4!
         self.assertEqual(Baz, on_class_loaded.cls)
 
-        return
-
     def test_dynamically_added_class_load_hooks(self):
         """ dynamically class load hooks """
 
@@ -303,7 +273,6 @@ class CorePluginTestCase(unittest.TestCase):
 
             on_class_loaded.cls = cls
 
-            return
 
         class PluginA(Plugin):
             id = 'A'
@@ -343,8 +312,6 @@ class CorePluginTestCase(unittest.TestCase):
         # Make sure the class load hook was called.
         self.assertEqual(Baz, on_class_loaded.cls)
 
-        return
-
     def test_preferences(self):
         """ preferences """
 
@@ -370,8 +337,6 @@ class CorePluginTestCase(unittest.TestCase):
 
         # Make sure we can get one of the preferences.
         self.assertEqual('42', application.preferences.get('enthought.test.x'))
-
-        return
 
     def test_dynamically_added_preferences(self):
         """ dynamically added preferences """
@@ -401,5 +366,3 @@ class CorePluginTestCase(unittest.TestCase):
 
         # Make sure we can get one of the preferences.
         self.assertEqual('42', application.preferences.get('enthought.test.x'))
-
-        return

--- a/envisage/tests/test_egg_based.py
+++ b/envisage/tests/test_egg_based.py
@@ -18,26 +18,11 @@ from traits.testing.unittest_tools import unittest
 class EggBasedTestCase(unittest.TestCase):
     """ Base class for Egg-based test cases. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
         # The location of the 'eggs' directory.
         self.egg_dir = join(dirname(__file__), 'eggs')
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Private interface.
-    ###########################################################################
 
     def _add_egg(self, filename, working_set=None):
         """ Create and add a distribution from the specified '.egg'. """
@@ -55,8 +40,6 @@ class EggBasedTestCase(unittest.TestCase):
         # modules in the eggs available for importing).
         for distribution in distributions:
             working_set.add(distribution)
-
-        return
 
     def _add_eggs_on_path(self, path, working_set=None):
         """ Add all eggs found on the path to a working set. """
@@ -78,7 +61,3 @@ class EggBasedTestCase(unittest.TestCase):
         # modules in the eggs available for importing).
         for distribution in distributions:
             working_set.add(distribution)
-
-        return
-
-#### EOF ######################################################################

--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -32,8 +32,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         self.eggs_dir = join(dirname(__file__), 'eggs')
         self.bad_eggs_dir = join(dirname(__file__), 'bad_eggs')
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
         # Undo any side-effects: egg_basket_plugin_manager modifies sys.path.
@@ -49,8 +47,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         # global working set.
         pkg_resources.working_set = pkg_resources.WorkingSet()
 
-        return
-
     #### Tests ################################################################
 
     def test_find_plugins_in_eggs_on_the_plugin_path(self):
@@ -64,8 +60,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         self.assertIn('acme.foo', ids)
         self.assertIn('acme.bar', ids)
         self.assertIn('acme.baz', ids)
-
-        return
 
     def test_only_find_plugins_whose_ids_are_in_the_include_list(self):
 
@@ -85,8 +79,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_only_find_plugins_matching_a_wildcard_in_the_include_list(self):
 
         # Note that the items in the list use the 'fnmatch' syntax for matching
@@ -104,8 +96,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         # Make sure the plugin manager found only the required plugins and that
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
-
-        return
 
     def test_ignore_plugins_whose_ids_are_in_the_exclude_list(self):
 
@@ -125,8 +115,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_ignore_plugins_matching_a_wildcard_in_the_exclude_list(self):
 
         # Note that the items in the list use the 'fnmatch' syntax for matching
@@ -145,8 +133,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_reflect_changes_to_the_plugin_path(self):
         plugin_manager = EggBasketPluginManager()
         ids = [plugin.id for plugin in plugin_manager]
@@ -163,15 +149,12 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         ids = [plugin.id for plugin in plugin_manager]
         self.assertEqual(len(ids), 0)
 
-        return
-
     def test_ignore_broken_plugins_raises_exceptions_by_default(self):
         plugin_manager = EggBasketPluginManager(
             plugin_path = [self.bad_eggs_dir, self.eggs_dir],
         )
-        self.assertRaises(ImportError, list, plugin_manager)
-
-        return
+        with self.assertRaises(ImportError):
+            list(plugin_manager)
 
     def test_ignore_broken_plugins_loads_good_plugins(self):
         data = {'count': 0}
@@ -197,16 +180,13 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         exc = data['exc']
         self.assertTrue(isinstance(exc, ImportError))
 
-        return
-
     def test_ignore_broken_distributions_raises_exceptions_by_default(self):
         plugin_manager = EggBasketPluginManager(
             plugin_path = [self.bad_eggs_dir,
                 self._create_broken_distribution_eggdir('acme.foo*.egg')],
         )
-        self.assertRaises(SystemError, iter, plugin_manager)
-
-        return
+        with self.assertRaises(SystemError):
+            iter(plugin_manager)
 
     def test_ignore_broken_distributions_loads_good_distributions(self):
         data = {'count':0}
@@ -231,8 +211,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         self.assertEqual(data['distribution'].project_name, 'acme.foo')
         exc = data['exc']
         self.assertTrue(isinstance(exc, pkg_resources.VersionConflict))
-
-        return
 
     #### Private protocol #####################################################
 
@@ -263,8 +241,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
             plugin = plugin_manager.get_plugin(id)
             self.assertNotEqual(None, plugin)
             self.assertEqual(True, plugin.stopped)
-
-        return
 
     def _create_broken_distribution_eggdir(self, egg_pat, replacement=None):
         """ Copy a good egg to a different version egg name in a new temp dir
@@ -298,10 +274,3 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
             shutil.copy(egg, join(tmpdir, new_name))
 
         return tmpdir
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_egg_plugin_manager.py
+++ b/envisage/tests/test_egg_plugin_manager.py
@@ -176,10 +176,3 @@ class EggPluginManagerTestCase(EggBasedTestCase):
             self.assertEqual(True, plugin.stopped)
 
         return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_extension_point.py
+++ b/envisage/tests/test_extension_point.py
@@ -23,11 +23,7 @@ class TestBase(HasTraits):
 
 
 class ExtensionPointTestCase(unittest.TestCase):
-    """ Tests for extension  points. """
-
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
+    """ Tests for extension points. """
 
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
@@ -39,25 +35,13 @@ class ExtensionPointTestCase(unittest.TestCase):
         # Set the extension registry used by the test classes.
         TestBase.extension_registry = self.registry
 
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_invalid_extension_point_type(self):
         """ invalid extension point type """
 
         # Extension points currently have to be 'List's of something! The
         # default is a list of anything.
-        self.failUnlessRaises(TypeError, ExtensionPoint, Int, 'my.ep')
-
-        return
+        with self.assertRaises(TypeError):
+            ExtensionPoint(Int, "my.ep")
 
     def test_no_reference_to_extension_registry(self):
         """ no reference to extension registry """
@@ -77,9 +61,8 @@ class ExtensionPointTestCase(unittest.TestCase):
         # We should get an exception because the object does not have an
         # 'extension_registry' trait.
         f = Foo()
-        self.failUnlessRaises(ValueError, getattr, f, 'x')
-
-        return
+        with self.assertRaises(ValueError):
+            getattr(f, "x")
 
     def test_extension_point_changed(self):
         """ extension point changed """
@@ -98,8 +81,6 @@ class ExtensionPointTestCase(unittest.TestCase):
 
                 self.x_changed_called = True
 
-                return
-
         f = Foo()
 
         # Connect the extension points on the object so that it can listen
@@ -114,7 +95,7 @@ class ExtensionPointTestCase(unittest.TestCase):
         self.assertEqual([42, 'a string', True],  f.x)
 
         # Make sure the trait change handler was called.
-        self.assert_(f.x_changed_called)
+        self.assertTrue(f.x_changed_called)
 
         # Reset the change handler flag.
         f.x_changed_called = False
@@ -127,8 +108,6 @@ class ExtensionPointTestCase(unittest.TestCase):
 
         # Make sure the trait change handler was *not* called.
         self.assertEqual(False, f.x_changed_called)
-
-        return
 
     def test_untyped_extension_point(self):
         """ untyped extension point """
@@ -154,8 +133,6 @@ class ExtensionPointTestCase(unittest.TestCase):
         self.assertEqual(3, len(g.x))
         self.assertEqual([42, 'a string', True],  g.x)
 
-        return
-
     def test_typed_extension_point(self):
         """ typed extension point """
 
@@ -180,8 +157,6 @@ class ExtensionPointTestCase(unittest.TestCase):
         self.assertEqual(3, len(g.x))
         self.assertEqual([42, 43, 44], g.x)
 
-        return
-
     def test_invalid_extension_point(self):
         """ invalid extension point """
 
@@ -200,9 +175,8 @@ class ExtensionPointTestCase(unittest.TestCase):
         # Make sure we get a trait error because the type of the extension
         # doesn't match that of the extension point.
         f = Foo()
-        self.failUnlessRaises(TraitError, getattr, f, 'x')
-
-        return
+        with self.assertRaises(TraitError):
+            getattr(f, "x")
 
     def test_extension_point_with_no_id(self):
         """ extension point with no Id """
@@ -211,9 +185,8 @@ class ExtensionPointTestCase(unittest.TestCase):
             class Foo(TestBase):
                 x = ExtensionPoint(List(Int))
 
-        self.failUnlessRaises(ValueError, factory)
-
-        return
+        with self.assertRaises(ValueError):
+            factory()
 
     def test_set_untyped_extension_point(self):
         """ set untyped extension point """
@@ -234,8 +207,6 @@ class ExtensionPointTestCase(unittest.TestCase):
 
         self.assertEqual([42], registry.get_extensions('my.ep'))
 
-        return
-
     def test_set_typed_extension_point(self):
         """ set typed extension point """
 
@@ -255,8 +226,6 @@ class ExtensionPointTestCase(unittest.TestCase):
 
         self.assertEqual([42], registry.get_extensions('my.ep'))
 
-        return
-
     def test_extension_point_str_representation(self):
         """ test the string representation of the extension point """
         ep_repr = "ExtensionPoint(id={})"
@@ -272,10 +241,3 @@ class ExtensionPointTestCase(unittest.TestCase):
         """ Create an extension point. """
 
         return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_extension_point_binding.py
+++ b/envisage/tests/test_extension_point_binding.py
@@ -29,15 +29,9 @@ def listener(obj, trait_name, old, new):
     listener.old = old
     listener.new = new
 
-    return
-
 
 class ExtensionPointBindingTestCase(unittest.TestCase):
     """ Tests for extension point binding. """
-
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
 
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
@@ -46,17 +40,6 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
 
         # Use the extension registry for all extension points and bindings.
         ExtensionPoint.extension_registry = self.extension_registry
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
 
     def test_untyped_extension_point(self):
         """ untyped extension point """
@@ -88,16 +71,14 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
 
         # Make sure that the object picked up the new extension...
         self.assertEqual(2, len(f.x))
-        self.assert_(42 in f.x)
-        self.assert_('a string' in f.x)
+        self.assertTrue(42 in f.x)
+        self.assertTrue('a string' in f.x)
 
         # ... and that the correct trait change event was fired.
         self.assertEqual(f, listener.obj)
         self.assertEqual('x_items', listener.trait_name)
         self.assertEqual(1, len(listener.new.added))
-        self.assert_('a string' in listener.new.added)
-
-        return
+        self.assertTrue('a string' in listener.new.added)
 
     def test_set_extensions_via_trait(self):
         """ set extensions via trait """
@@ -129,18 +110,16 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
 
         # Make sure that the object picked up the new extension...
         self.assertEqual(1, len(f.x))
-        self.assert_('a string' in f.x)
+        self.assertTrue('a string' in f.x)
 
         self.assertEqual(1, len(registry.get_extensions('my.ep')))
-        self.assert_('a string' in registry.get_extensions('my.ep'))
+        self.assertTrue('a string' in registry.get_extensions('my.ep'))
 
         # ... and that the correct trait change event was fired.
         self.assertEqual(f, listener.obj)
         self.assertEqual('x', listener.trait_name)
         self.assertEqual(1, len(listener.new))
-        self.assert_('a string' in listener.new)
-
-        return
+        self.assertTrue('a string' in listener.new)
 
     def test_set_extensions_via_registry(self):
         """ set extensions via registry """
@@ -172,15 +151,13 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
 
         # Make sure that the object picked up the new extension...
         self.assertEqual(1, len(f.x))
-        self.assert_('a string' in f.x)
+        self.assertTrue('a string' in f.x)
 
         # ... and that the correct trait change event was fired.
         self.assertEqual(f, listener.obj)
         self.assertEqual('x', listener.trait_name)
         self.assertEqual(1, len(listener.new))
-        self.assert_('a string' in listener.new)
-
-        return
+        self.assertTrue('a string' in listener.new)
 
     def test_explicit_extension_registry(self):
         """ explicit extension registry """
@@ -209,8 +186,6 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
         # Make sure that we pick up the empty extension registry and not the
         # default one.
         self.assertEqual(0, len(f.x))
-
-        return
 
     def test_should_be_able_to_bind_multiple_traits_on_a_single_object(self):
 
@@ -241,8 +216,6 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
         self.assertEqual(1, len(f.x))
         self.assertEqual(3, len(f.y))
 
-        return
-
     ###########################################################################
     # Private interface.
     ###########################################################################
@@ -251,10 +224,3 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
         """ Create an extension point. """
 
         return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -21,10 +21,6 @@ from envisage.tests.test_application import (
 class ExtensionPointChangedTestCase(unittest.TestCase):
     """ Tests for the events fired when extension points are changed. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
@@ -33,17 +29,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         listener.trait_name = None
         listener.old = None
         listener.new = None
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
 
     def test_set_extension_point(self):
         """ set extension point """
@@ -54,9 +39,8 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         application.start()
 
         # Try to set the extension point.
-        self.failUnlessRaises(SystemError, setattr, a, 'x', [1, 2, 3])
-
-        return
+        with self.assertRaises(SystemError):
+            setattr(a, "x", [1, 2, 3])
 
     def test_append(self):
         """ append """
@@ -98,8 +82,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual([], listener.new.removed)
         self.assertEqual(3, listener.new.index)
 
-        return
-
     def test_remove(self):
         """ remove """
 
@@ -139,8 +121,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual([], listener.new.added)
         self.assertEqual([3], listener.new.removed)
         self.assertEqual(2, listener.new.index)
-
-        return
 
     def test_assign_empty_list(self):
         """ assign empty list """
@@ -183,8 +163,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual(0, listener.new.index.start)
         self.assertEqual(3, listener.new.index.stop)
 
-        return
-
     def test_assign_empty_list_no_event(self):
         """ assign empty list no event """
 
@@ -215,8 +193,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         # We shouldn't get a trait event here because we haven't accessed the
         # extension point yet!
         self.assertEqual(None, listener.obj)
-
-        return
 
     def test_assign_non_empty_list(self):
         """ assign non-empty list """
@@ -258,8 +234,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual([1, 2, 3], listener.new.removed)
         self.assertEqual(0, listener.new.index.start)
         self.assertEqual(4, listener.new.index.stop)
-
-        return
 
     def test_add_plugin(self):
         """ add plugin """
@@ -311,8 +285,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual([], listener.new.removed)
         self.assertEqual(3, listener.new.index)
 
-        return
-
     def test_remove_plugin(self):
         """ remove plugin """
 
@@ -361,12 +333,3 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual([], listener.new.added)
         self.assertEqual([1, 2, 3], listener.new.removed)
         self.assertEqual(0, listener.new.index)
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -19,27 +19,12 @@ from traits.testing.unittest_tools import unittest
 class ExtensionRegistryTestCase(unittest.TestCase):
     """ Tests for the base extension registry. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
         # We do all of the testing via the application to make sure it offers
         # the same interface!
         self.registry = Application(extension_registry=ExtensionRegistry())
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
 
     def test_empty_registry(self):
         """ empty registry """
@@ -53,8 +38,6 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         # Make sure there are no extension points.
         extension_points = registry.get_extension_points()
         self.assertEqual(0, len(extension_points))
-
-        return
 
     def test_add_extension_point(self):
         """ add extension point """
@@ -73,8 +56,6 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         self.assertEqual(1, len(extension_points))
         self.assertEqual('my.ep', extension_points[0].id)
 
-        return
-
     def test_get_extension_point(self):
         """ get extension point """
 
@@ -87,8 +68,6 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         extension_point = registry.get_extension_point('my.ep')
         self.assertNotEqual(None, extension_point)
         self.assertEqual('my.ep', extension_point.id)
-
-        return
 
     def test_remove_empty_extension_point(self):
         """ remove empty_extension point """
@@ -104,8 +83,6 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         # Make sure there are no extension points.
         extension_points = registry.get_extension_points()
         self.assertEqual(0, len(extension_points))
-
-        return
 
     def test_remove_non_empty_extension_point(self):
         """ remove non-empty extension point """
@@ -128,18 +105,13 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         # And that the extensions are gone too.
         self.assertEqual([], registry.get_extensions('my.ep'))
 
-        return
-
     def test_remove_non_existent_extension_point(self):
         """ remove non existent extension point """
 
         registry = self.registry
 
-        self.failUnlessRaises(
-            UnknownExtensionPoint, registry.remove_extension_point, 'my.ep'
-        )
-
-        return
+        with self.assertRaises(UnknownExtensionPoint):
+            registry.remove_extension_point("my.ep")
 
     def test_remove_non_existent_listener(self):
         """ remove non existent listener """
@@ -151,13 +123,8 @@ class ExtensionRegistryTestCase(unittest.TestCase):
 
             self.listener_called = (registry, extension_point, added, removed)
 
-            return
-
-        self.failUnlessRaises(
-            ValueError, registry.remove_extension_point_listener, listener
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            registry.remove_extension_point_listener(listener)
 
     def test_set_extensions(self):
         """ set extensions """
@@ -173,8 +140,6 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         # Make sure we can get them.
         self.assertEqual([1, 2, 3], registry.get_extensions('my.ep'))
 
-        return
-
     ###########################################################################
     # Private interface.
     ###########################################################################
@@ -183,10 +148,3 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         """ Create an extension point. """
 
         return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_import_manager.py
+++ b/envisage/tests/test_import_manager.py
@@ -17,27 +17,12 @@ from traits.testing.unittest_tools import unittest
 class ImportManagerTestCase(unittest.TestCase):
     """ Tests for the import manager. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
         # We do all of the testing via the application to make sure it offers
         # the same interface!
         self.import_manager = Application(import_manager=ImportManager())
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
 
     def test_import_dotted_symbol(self):
         """ import dotted symbol """
@@ -47,8 +32,6 @@ class ImportManagerTestCase(unittest.TestCase):
         symbol = self.import_manager.import_symbol('tarfile.TarFile')
         self.assertEqual(symbol, tarfile.TarFile)
 
-        return
-
     def test_import_nested_symbol(self):
         """ import nested symbol """
 
@@ -57,8 +40,6 @@ class ImportManagerTestCase(unittest.TestCase):
         symbol = self.import_manager.import_symbol('tarfile:TarFile.open')
         self.assertEqual(symbol, tarfile.TarFile.open)
 
-        return
-
     def test_import_dotted_module(self):
         """ import dotted module """
 
@@ -66,12 +47,3 @@ class ImportManagerTestCase(unittest.TestCase):
             'envisage.api:ImportManager'
         )
         self.assertEqual(symbol, ImportManager)
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_package_plugin_manager.py
+++ b/envisage/tests/test_package_plugin_manager.py
@@ -18,22 +18,11 @@ from traits.testing.unittest_tools import unittest
 class PackagePluginManagerTestCase(unittest.TestCase):
     """ Tests for the 'Package' plugin manager. """
 
-    #### 'unittest.TestCase' protocol #########################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
         # The location of the 'plugins' test data directory.
         self.plugins_dir = join(dirname(__file__), 'plugins')
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    #### Tests ################################################################
 
     def test_find_plugins_in_packages_on_the_plugin_path(self):
 
@@ -44,8 +33,6 @@ class PackagePluginManagerTestCase(unittest.TestCase):
         self.assertIn('banana', ids)
         self.assertIn('orange', ids)
         self.assertIn('pear', ids)
-
-        return
 
     def test_only_find_plugins_whose_ids_are_in_the_include_list(self):
 
@@ -65,8 +52,6 @@ class PackagePluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_only_find_plugins_matching_a_wildcard_in_the_include_list(self):
 
         # Note that the items in the list use the 'fnmatch' syntax for matching
@@ -84,8 +69,6 @@ class PackagePluginManagerTestCase(unittest.TestCase):
         # Make sure the plugin manager found only the required plugins and that
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
-
-        return
 
     def test_ignore_plugins_whose_ids_are_in_the_exclude_list(self):
 
@@ -105,8 +88,6 @@ class PackagePluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_ignore_plugins_matching_a_wildcard_in_the_exclude_list(self):
 
         # Note that the items in the list use the 'fnmatch' syntax for matching
@@ -125,8 +106,6 @@ class PackagePluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_reflect_changes_to_the_plugin_path(self):
         plugin_manager = PackagePluginManager()
         ids = [plugin.id for plugin in plugin_manager]
@@ -142,8 +121,6 @@ class PackagePluginManagerTestCase(unittest.TestCase):
         del plugin_manager.plugin_path[0]
         ids = [plugin.id for plugin in plugin_manager]
         self.assertEqual(len(ids), 0)
-
-        return
 
     #### Private protocol #####################################################
 
@@ -177,12 +154,3 @@ class PackagePluginManagerTestCase(unittest.TestCase):
             plugin = plugin_manager.get_plugin(id)
             self.assertNotEqual(None, plugin)
             self.assertEqual(True, plugin.stopped)
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -28,8 +28,6 @@ def listener(obj, trait_name, old, new):
     listener.old = old
     listener.new = new
 
-    return
-
 
 class TestApplication(Application):
     """ The type of application used in the tests. """
@@ -39,24 +37,6 @@ class TestApplication(Application):
 
 class PluginTestCase(unittest.TestCase):
     """ Tests for plugins. """
-
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
 
     def test_id_policy(self):
         """ id policy """
@@ -73,8 +53,6 @@ class PluginTestCase(unittest.TestCase):
         p = Plugin(name='fred', id='wilma')
         self.assertEqual('wilma', p.id)
         self.assertEqual('fred', p.name)
-
-        return
 
     def test_name_policy(self):
         """ name policy """
@@ -94,8 +72,6 @@ class PluginTestCase(unittest.TestCase):
         p = ThisIsMyPlugin()
         self.assertEqual('This Is My Plugin', p.name)
 
-        return
-
     def test_plugin_activator(self):
         """ plugin activator. """
 
@@ -108,14 +84,10 @@ class PluginTestCase(unittest.TestCase):
 
                 self.started = plugin
 
-                return
-
             def stop_plugin(self, plugin):
                 """ Stop a plugin. """
 
                 self.stopped = plugin
-
-                return
 
         class PluginA(Plugin):
             id = 'A'
@@ -139,8 +111,6 @@ class PluginTestCase(unittest.TestCase):
 
         # Make sure A's plugin activator was called.
         self.assertEqual(a, plugin_activator.stopped)
-
-        return
 
     def test_service(self):
         """ service """
@@ -182,8 +152,6 @@ class PluginTestCase(unittest.TestCase):
         self.assertEqual(None, application.get_service(Bar))
         self.assertEqual(None, application.get_service(Baz))
 
-        return
-
     def test_service_protocol(self):
         """ service protocol """
 
@@ -215,8 +183,6 @@ class PluginTestCase(unittest.TestCase):
         # Make sure the service was unregistered.
         self.assertEqual(None, application.get_service(IBar))
 
-        return
-
     def test_multiple_trait_contributions(self):
         """ multiple trait contributions """
 
@@ -237,9 +203,8 @@ class PluginTestCase(unittest.TestCase):
 
         # We should get an error because the plugin has multiple traits
         # contributing to the same extension point.
-        self.failUnlessRaises(ValueError, application.get_extensions, 'x')
-
-        return
+        with self.assertRaises(ValueError):
+            application.get_extensions("x")
 
     def test_exception_in_trait_contribution(self):
         """ exception in trait contribution """
@@ -265,11 +230,8 @@ class PluginTestCase(unittest.TestCase):
 
         # We should get an when we try to get the contributions to the
         # extension point.
-        self.failUnlessRaises(
-            ZeroDivisionError, application.get_extensions, 'x'
-        )
-
-        return
+        with self.assertRaises(ZeroDivisionError):
+            application.get_extensions("x")
 
     def test_contributes_to(self):
         """ contributes to """
@@ -291,8 +253,6 @@ class PluginTestCase(unittest.TestCase):
         # contributing to the same extension point.
         self.assertEqual([1, 2, 3], application.get_extensions('x'))
 
-        return
-
     def test_contributes_to_decorator(self):
         """ contributes to decorator """
 
@@ -312,8 +272,6 @@ class PluginTestCase(unittest.TestCase):
 
         application = TestApplication(plugins=[a, b])
         self.assertEqual([1, 2, 3], application.get_extensions('x'))
-
-        return
 
     def test_contributes_to_decorator_ignored_if_trait_present(self):
         """ contributes to decorator ignored if trait present """
@@ -336,8 +294,6 @@ class PluginTestCase(unittest.TestCase):
         application = TestApplication(plugins=[a, b])
         self.assertEqual([1, 2, 3], application.get_extensions('x'))
 
-        return
-
     def test_add_plugins_to_empty_application(self):
         """ add plugins to empty application """
 
@@ -348,8 +304,6 @@ class PluginTestCase(unittest.TestCase):
             def _x_items_changed(self, event):
                 self.added   = event.added
                 self.removed = event.removed
-
-                return
 
         class PluginB(Plugin):
             id = 'B'
@@ -416,8 +370,6 @@ class PluginTestCase(unittest.TestCase):
         self.assertEqual([], a.x)
         self.assertEqual([4, 5, 6], a.removed)
 
-        return
-
     def test_home(self):
         """ home """
 
@@ -437,8 +389,8 @@ class PluginTestCase(unittest.TestCase):
         self.assertEqual(join(application.home, 'plugins', b.id), b.home)
 
         # Make sure that the directories got created.
-        self.assert_(exists(a.home))
-        self.assert_(exists(b.home))
+        self.assertTrue(exists(a.home))
+        self.assertTrue(exists(b.home))
 
         # Create a new application with plugins with the same Id to make sure
         # that it all works when the directories already exist.
@@ -452,10 +404,8 @@ class PluginTestCase(unittest.TestCase):
         self.assertEqual(join(application.home, 'plugins', b.id), b.home)
 
         # Make sure the directories got created.
-        self.assert_(exists(a.home))
-        self.assert_(exists(b.home))
-
-        return
+        self.assertTrue(exists(a.home))
+        self.assertTrue(exists(b.home))
 
     def test_no_recursion(self):
         """ Regression test for #119. """
@@ -466,10 +416,3 @@ class PluginTestCase(unittest.TestCase):
 
         application = Application(plugins=[PluginA()])
         application.get_extensions('bob')
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_plugin_manager.py
+++ b/envisage/tests/test_plugin_manager.py
@@ -33,15 +33,11 @@ class SimplePlugin(Plugin):
         self.started = True
         self.stopped = False
 
-        return
-
     def stop(self):
         """ Stop the plugin. """
 
         self.started = False
         self.stopped = True
-
-        return
 
 
 class BadPlugin(Plugin):
@@ -65,24 +61,6 @@ class BadPlugin(Plugin):
 class PluginManagerTestCase(unittest.TestCase):
     """ Tests for the plugin manager. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_get_plugin(self):
         """ get plugin """
 
@@ -95,8 +73,6 @@ class PluginManagerTestCase(unittest.TestCase):
 
         # Try to get a non-existent plugin.
         self.assertEqual(None, plugin_manager.get_plugin('bogus'))
-
-        return
 
     def test_iteration_over_plugins(self):
         """ iteration over plugins """
@@ -112,8 +88,6 @@ class PluginManagerTestCase(unittest.TestCase):
             plugins.append(plugin)
 
         self.assertEqual([simple_plugin, bad_plugin], plugins)
-
-        return
 
     def test_start_and_stop(self):
         """ start and stop """
@@ -135,8 +109,6 @@ class PluginManagerTestCase(unittest.TestCase):
         # Make sure the plugin was stopped.
         self.assertEqual(True, simple_plugin.stopped)
 
-        return
-
     def test_start_and_stop_errors(self):
         """ start and stop errors """
 
@@ -146,23 +118,21 @@ class PluginManagerTestCase(unittest.TestCase):
 
         # Start the plugin manager. This starts all of the plugin manager's
         # plugins.
-        self.failUnlessRaises(ZeroDivisionError, plugin_manager.start)
+        with self.assertRaises(ZeroDivisionError):
+            plugin_manager.start()
 
         # Stop the plugin manager. This stops all of the plugin manager's
         # plugins.
-        self.failUnlessRaises(ZeroDivisionError, plugin_manager.stop)
+        with self.assertRaises(ZeroDivisionError):
+            plugin_manager.stop()
 
         # Try to start a non-existent plugin.
-        self.failUnlessRaises(
-            SystemError, plugin_manager.start_plugin, plugin_id='bogus'
-        )
+        with self.assertRaises(SystemError):
+            plugin_manager.start_plugin(plugin_id="bogus")
 
         # Try to stop a non-existent plugin.
-        self.failUnlessRaises(
-            SystemError, plugin_manager.stop_plugin, plugin_id='bogus'
-        )
-
-        return
+        with self.assertRaises(SystemError):
+            plugin_manager.stop_plugin(plugin_id="bogus")
 
     def test_only_include_plugins_whose_ids_are_in_the_include_list(self):
 
@@ -186,8 +156,6 @@ class PluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_only_include_plugins_matching_a_wildcard_in_the_include_list(self):
 
         # Note that the items in the list use the 'fnmatch' syntax for matching
@@ -209,8 +177,6 @@ class PluginManagerTestCase(unittest.TestCase):
         # Make sure the plugin manager found only the required plugins and that
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
-
-        return
 
     def test_ignore_plugins_whose_ids_are_in_the_exclude_list(self):
 
@@ -234,8 +200,6 @@ class PluginManagerTestCase(unittest.TestCase):
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
 
-        return
-
     def test_ignore_plugins_matching_a_wildcard_in_the_exclude_list(self):
 
         # Note that the items in the list use the 'fnmatch' syntax for matching
@@ -257,8 +221,6 @@ class PluginManagerTestCase(unittest.TestCase):
         # Make sure the plugin manager found only the required plugins and that
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
-
-        return
 
     #### Private protocol #####################################################
 
@@ -289,12 +251,3 @@ class PluginManagerTestCase(unittest.TestCase):
             plugin = plugin_manager.get_plugin(id)
             self.assertNotEqual(None, plugin)
             self.assertEqual(True, plugin.stopped)
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_provider_extension_registry.py
+++ b/envisage/tests/test_provider_extension_registry.py
@@ -24,25 +24,10 @@ from .test_extension_registry import ExtensionRegistryTestCase
 class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
     """ Tests for the provider extension registry. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
         self.registry = ProviderExtensionRegistry()
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
 
     def test_providers(self):
         """ providers """
@@ -106,8 +91,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         self.assertEqual(1, len(extension_points))
         self.assertEqual('x', extension_points[0].id)
 
-        return
-
     def test_provider_extensions_changed(self):
         """ provider extensions changed """
 
@@ -144,16 +127,12 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
                     'my.ep', new, old, slice(0, len(old))
                 )
 
-                return
-
             def _x_items_changed(self, event):
                 """ Static trait change handler. """
 
                 self._fire_extension_point_changed(
                     'my.ep', event.added, event.removed, event.index
                 )
-
-                return
 
 
         class ProviderB(ExtensionProvider):
@@ -181,16 +160,12 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
                     'my.ep', new, old, slice(0, len(old))
                 )
 
-                return
-
             def _x_items_changed(self, event):
                 """ Static trait change handler. """
 
                 self._fire_extension_point_changed(
                     'my.ep', event.added, event.removed, event.index
                 )
-
-                return
 
         # Add the providers to the registry.
         a = ProviderA(x=[42])
@@ -212,8 +187,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
             listener.added = event.added
             listener.removed = event.removed
             listener.index = event.index
-
-            return
 
         registry.add_extension_point_listener(listener, 'my.ep')
 
@@ -260,8 +233,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         self.assertEqual(4, len(extensions))
         self.assertEqual([42, 43, 1, 2], extensions)
 
-        return
-
     def test_add_provider(self):
         """ add provider """
 
@@ -296,15 +267,13 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
                     'x', event.added, event.removed, event.index
                 )
 
-                return
-
         # Add the provider to the registry.
         registry.add_provider(ProviderA())
 
         # The provider's extensions should now be in the registry.
         extensions = registry.get_extensions('x')
         self.assertEqual(1, len(extensions))
-        self.assert_(42 in extensions)
+        self.assertTrue(42 in extensions)
 
         # Add an extension listener to the registry.
         def listener(registry, event):
@@ -315,8 +284,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
             listener.added = event.added
             listener.removed = event.removed
             listener.index = event.index
-
-            return
 
         registry.add_extension_point_listener(listener, 'x')
 
@@ -347,11 +314,9 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         # Now we should get the new extensions.
         extensions = registry.get_extensions('x')
         self.assertEqual(3, len(extensions))
-        self.assert_(42 in extensions)
-        self.assert_(43 in extensions)
-        self.assert_(44 in extensions)
-
-        return
+        self.assertTrue(42 in extensions)
+        self.assertTrue(43 in extensions)
+        self.assertTrue(44 in extensions)
 
     def test_get_providers(self):
         """ get providers """
@@ -374,8 +339,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
 
         # Make sure we can get them.
         self.assertEqual([a, b], registry.get_providers())
-
-        return
 
     def test_remove_provider(self):
         """ remove provider """
@@ -411,8 +374,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
                     'x', event.added, event.removed, event.index
                 )
 
-                return
-
         class ProviderB(ExtensionProvider):
             """ An extension provider. """
 
@@ -438,9 +399,9 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         # The provider's extensions should now be in the registry.
         extensions = registry.get_extensions('x')
         self.assertEqual(3, len(extensions))
-        self.assert_(42 in extensions)
-        self.assert_(43 in extensions)
-        self.assert_(44 in extensions)
+        self.assertTrue(42 in extensions)
+        self.assertTrue(43 in extensions)
+        self.assertTrue(44 in extensions)
 
         # Add an extension listener to the registry.
         def listener(registry, event):
@@ -450,8 +411,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
             listener.extension_point = event.extension_point_id
             listener.added = event.added
             listener.removed = event.removed
-
-            return
 
         registry.add_extension_point_listener(listener, 'x')
 
@@ -466,7 +425,7 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         # Make sure we don't get the removed extensions.
         extensions = registry.get_extensions('x')
         self.assertEqual(1, len(extensions))
-        self.assert_(42 in extensions)
+        self.assertTrue(42 in extensions)
 
         # Now remove the provider that declared the extension point.
         registry.remove_provider(a)
@@ -482,8 +441,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         self.assertEqual('x', listener.extension_point)
         self.assertEqual([], listener.added)
         self.assertEqual([42], listener.removed)
-
-        return
 
     def test_remove_provider_with_no_contributions(self):
         """ remove provider with no contributions """
@@ -523,8 +480,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
             listener.added = event.added
             listener.removed = event.removed
 
-            return
-
         registry.add_extension_point_listener(listener, 'x')
 
         # Remove the provider that declared the extension point.
@@ -541,8 +496,6 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         # not make any contributions anyway!).
         self.assertEqual(None, getattr(listener, 'registry', None))
 
-        return
-
     def test_remove_non_existent_provider(self):
         """ remove provider """
 
@@ -557,9 +510,8 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         a = ProviderA()
 
         # Remove one of the providers.
-        self.failUnlessRaises(ValueError, registry.remove_provider, a)
-
-        return
+        with self.assertRaises(ValueError):
+            registry.remove_provider(a)
 
     # Overriden to test differing behavior between the provider registry and
     # the base class.
@@ -572,11 +524,8 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
         registry.add_extension_point(self._create_extension_point('my.ep'))
 
         # Set some extensions.
-        self.failUnlessRaises(
-            SystemError, registry.set_extensions, 'my.ep', [1, 2, 3]
-        )
-
-        return
+        with self.assertRaises(SystemError):
+            registry.set_extensions("my.ep", [1, 2, 3])
 
     def test_remove_non_empty_extension_point(self):
         """ remove non-empty extension point """
@@ -627,12 +576,3 @@ class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
 
         # And that the extensions are gone too.
         self.assertEqual([], registry.get_extensions('x'))
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_safeweakref.py
+++ b/envisage/tests/test_safeweakref.py
@@ -21,24 +21,6 @@ from traits.testing.unittest_tools import unittest
 class SafeWeakrefTestCase(unittest.TestCase):
     """ Tests for safe weakrefs. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_can_create_weakref_to_bound_method(self):
         class Foo(HasTraits):
             def method(self):
@@ -52,15 +34,13 @@ class SafeWeakrefTestCase(unittest.TestCase):
 
         # Make sure we can call it.
         r()()
-        self.assert_(f.method_called)
+        self.assertTrue(f.method_called)
 
         # Delete the object to delete the method!
         del f
 
         # The reference should now return None.
         self.assertEqual(None, r())
-
-        return
 
     def test_two_weakrefs_to_bound_method_are_identical(self):
         class Foo(HasTraits):
@@ -70,8 +50,6 @@ class SafeWeakrefTestCase(unittest.TestCase):
         f = Foo()
 
         self.assertIs(ref(f.method), ref(f.method))
-
-        return
 
     def test_internal_cache_is_weak_too(self):
         # smell: Fragile test because we are reaching into the internals of the
@@ -106,8 +84,6 @@ class SafeWeakrefTestCase(unittest.TestCase):
         # ... and the cache should be back to its original size!
         self.assertEqual(len_cache, len(cache))
 
-        return
-
     def test_two_weakrefs_to_bound_method_are_equal(self):
         class Foo(HasTraits):
             def method(self):
@@ -121,9 +97,7 @@ class SafeWeakrefTestCase(unittest.TestCase):
         self.assertEqual(r1, r2)
 
         # Make sure that a reference compares as unequal to non-references!
-        self.assert_(not r1 == 99)
-
-        return
+        self.assertTrue(not r1 == 99)
 
     def test_two_weakrefs_to_bound_method_hash_equally(self):
         class Foo(HasTraits):
@@ -144,8 +118,6 @@ class SafeWeakrefTestCase(unittest.TestCase):
 
         self.assertEqual(hash(r1), hash(r2))
 
-        return
-
     def test_get_builtin_weakref_for_non_bound_method(self):
         class Foo(HasTraits):
             pass
@@ -155,12 +127,3 @@ class SafeWeakrefTestCase(unittest.TestCase):
         # Get a weak reference to something that is not a bound method.
         r = ref(f)
         self.assertEqual(weakref.ref, type(r))
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_service.py
+++ b/envisage/tests/test_service.py
@@ -24,24 +24,6 @@ class TestApplication(Application):
 class ServiceTestCase(unittest.TestCase):
     """ Tests for the 'Service' trait type. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_service_trait_type(self):
         """ service trait type"""
 
@@ -72,9 +54,8 @@ class ServiceTestCase(unittest.TestCase):
         self.assertEqual(None, b.foo)
 
         # You can't set service traits!
-        self.failUnlessRaises(SystemError, setattr, b, 'foo', 'bogus')
-
-        return
+        with self.assertRaises(SystemError):
+            setattr(b, "foo", "bogus")
 
     def test_service_trait_type_with_no_service_registry(self):
         """ service trait type with no service registry """
@@ -88,13 +69,5 @@ class ServiceTestCase(unittest.TestCase):
         # We should get an exception because the object does not have an
         # 'service_registry' trait.
         b = Bar()
-        self.failUnlessRaises(ValueError, getattr, b, 'foo')
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################
+        with self.assertRaises(ValueError):
+            getattr(b, "foo")

--- a/envisage/tests/test_service_registry.py
+++ b/envisage/tests/test_service_registry.py
@@ -47,11 +47,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
         if PKG + '.foo' in sys.modules:
             del sys.modules[PKG + '.foo']
 
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        pass
-
     ###########################################################################
     # Tests.
     ###########################################################################

--- a/envisage/tests/test_service_registry.py
+++ b/envisage/tests/test_service_registry.py
@@ -47,12 +47,10 @@ class ServiceRegistryTestCase(unittest.TestCase):
         if PKG + '.foo' in sys.modules:
             del sys.modules[PKG + '.foo']
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
 
-        return
+        pass
 
     ###########################################################################
     # Tests.
@@ -71,8 +69,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
         service = self.service_registry.get_required_service(Foo)
         self.assertIs(foo, service)
 
-        return
-
     def test_should_get_exception_if_required_service_is_missing(self):
 
         class IFoo(Interface):
@@ -80,8 +76,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
 
         with self.assertRaises(NoSuchServiceError):
             self.service_registry.get_required_service(IFoo)
-
-        return
 
     def test_imported_service_factory(self):
         """ imported service factory """
@@ -107,9 +101,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
         # Make sure that the object created by the factory is cached (i.e. we
         # get the same object back from now on!).
         service2 = self.service_registry.get_service(HasTraits, 'price <= 100')
-        self.assert_(service is service2)
-
-        return
+        self.assertTrue(service is service2)
 
     def test_function_service_factory(self):
         """ function service factory """
@@ -139,9 +131,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
         # Make sure that the object created by the factory is cached (i.e. we
         # get the same object back from now on!).
         service2 = self.service_registry.get_service(IFoo, 'price <= 100')
-        self.assert_(service is service2)
-
-        return
+        self.assertTrue(service is service2)
 
     def test_lazy_function_service_factory(self):
         """ lazy function service factory """
@@ -166,23 +156,21 @@ class ServiceRegistryTestCase(unittest.TestCase):
             del sys.modules[foo]
 
         # Make sure that we haven't imported the 'foo' module.
-        self.assert_(foo not in sys.modules)
+        self.assertTrue(foo not in sys.modules)
 
         # Look up a non-existent service.
         services = self.service_registry.get_services('bogus.IBogus')
 
         # Make sure that we *still* haven't imported the 'foo' module.
-        self.assert_(foo not in sys.modules)
+        self.assertTrue(foo not in sys.modules)
 
         # Look it up again.
         services = self.service_registry.get_services(i_foo)
         self.assertEqual([foo_factory.foo], services)
-        self.assert_(foo in sys.modules)
+        self.assertTrue(foo in sys.modules)
 
         # Clean up!
         del sys.modules[foo]
-
-        return
 
     def test_lazy_bound_method_service_factory(self):
         """ lazy bound method service factory """
@@ -216,23 +204,21 @@ class ServiceRegistryTestCase(unittest.TestCase):
             del sys.modules[foo]
 
         # Make sure that we haven't imported the 'foo' module.
-        self.assert_(foo not in sys.modules)
+        self.assertTrue(foo not in sys.modules)
 
         # Look up a non-existent service.
         services = self.service_registry.get_services('bogus.IBogus')
 
         # Make sure that we *still* haven't imported the 'foo' module.
-        self.assert_(foo not in sys.modules)
+        self.assertTrue(foo not in sys.modules)
 
         # Look up the service.
         services = self.service_registry.get_services(i_foo)
         self.assertEqual([sp.foo], services)
-        self.assert_(foo in sys.modules)
+        self.assertTrue(foo in sys.modules)
 
         # Clean up!
         del sys.modules[foo]
-
-        return
 
     def test_get_services(self):
         """ get services """
@@ -262,8 +248,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
         services = self.service_registry.get_services(IBar)
         self.assertEqual([], services)
 
-        return
-
     def test_get_services_with_strings(self):
         """ get services with strings """
 
@@ -278,8 +262,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
         # Look them up using the same string!
         services = self.service_registry.get_services(protocol_name)
         self.assertEqual(2, len(services))
-
-        return
 
     def test_get_services_with_query(self):
         """ get services with query """
@@ -313,8 +295,8 @@ class ServiceRegistryTestCase(unittest.TestCase):
 
         # Create a query that matches both registered objects.
         services = self.service_registry.get_services(IFoo, 'price >= 100')
-        self.assert_(foo in services)
-        self.assert_(goo in services)
+        self.assertTrue(foo in services)
+        self.assertTrue(goo in services)
         self.assertEqual(2, len(services))
 
         class IBar(Interface):
@@ -323,8 +305,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
         # Lookup a non-existent service.
         services = self.service_registry.get_services(IBar, 'price <= 100')
         self.assertEqual([], services)
-
-        return
 
     def test_get_service(self):
         """ get service """
@@ -345,7 +325,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
 
         # Look up one of them!
         service = self.service_registry.get_service(IFoo)
-        self.assert_(foo is service or goo is service)
+        self.assertTrue(foo is service or goo is service)
 
         class IBar(Interface):
             pass
@@ -353,8 +333,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
         # Lookup a non-existent service.
         service = self.service_registry.get_service(IBar)
         self.assertEqual(None, service)
-
-        return
 
     def test_get_service_with_query(self):
         """ get service with query """
@@ -388,7 +366,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
 
         # Create a query that matches both registered objects.
         service = self.service_registry.get_service(IFoo, 'price >= 100')
-        self.assert_(foo is service or goo is service)
+        self.assertTrue(foo is service or goo is service)
 
         class IBar(Interface):
             pass
@@ -396,8 +374,6 @@ class ServiceRegistryTestCase(unittest.TestCase):
         # Lookup a non-existent service.
         service = self.service_registry.get_service(IBar, 'price <= 100')
         self.assertEqual(None, service)
-
-        return
 
     def test_get_and_set_service_properties(self):
         """ get and set service properties """
@@ -444,16 +420,12 @@ class ServiceRegistryTestCase(unittest.TestCase):
         self.assertEqual(500, goo_properties['price'])
 
         # Try to get the properties of a non-existent service.
-        self.failUnlessRaises(
-            ValueError, self.service_registry.get_service_properties, -1
-        )
+        with self.assertRaises(ValueError):
+            self.service_registry.get_service_properties(-1)
 
         # Try to set the properties of a non-existent service.
-        self.failUnlessRaises(
-            ValueError, self.service_registry.set_service_properties, -1, {}
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            self.service_registry.set_service_properties(-1, {})
 
     def test_unregister_service(self):
         """ unregister service """
@@ -489,7 +461,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
 
         # Create a query that matches both registered objects.
         service = self.service_registry.get_service(IFoo, 'price >= 100')
-        self.assert_(foo is service or goo is service)
+        self.assertTrue(foo is service or goo is service)
 
         #### Now do some unregistering! ####
 
@@ -508,11 +480,8 @@ class ServiceRegistryTestCase(unittest.TestCase):
         self.assertEqual(None, service)
 
         # Try to unregister a non-existent service.
-        self.failUnlessRaises(
-            ValueError, self.service_registry.unregister_service, -1
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            self.service_registry.unregister_service(-1)
 
     def test_minimize_and_maximize(self):
         """ minimize and maximize """
@@ -543,12 +512,3 @@ class ServiceRegistryTestCase(unittest.TestCase):
         self.assertNotEqual(None, service)
         self.assertEqual(Foo, type(service))
         self.assertEqual(z, service)
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_slice.py
+++ b/envisage/tests/test_slice.py
@@ -59,8 +59,6 @@ def listener(obj, trait_name, old, event):
 
     listener.clone = clone
 
-    return
-
 
 class SliceTestCase(unittest.TestCase):
     """ Tests to help find out how trait list events work. """
@@ -78,15 +76,11 @@ class SliceTestCase(unittest.TestCase):
         self.f = Foo(l=TEST_LIST)
         self.f.on_trait_change(listener, 'l_items')
 
-        return
-
     def tearDown(self):
         """ Called immediately after each test method has been called. """
 
         # Make sure we successfully recreated the operation.
         self.assertEqual(self.f.l, listener.clone)
-
-        return
 
     ###########################################################################
     # Tests.
@@ -97,102 +91,67 @@ class SliceTestCase(unittest.TestCase):
 
         self.f.l.append(99)
 
-        return
-
     def test_insert(self):
         """ insert """
 
         self.f.l.insert(3, 99)
-
-        return
 
     def test_extend(self):
         """ extend """
 
         self.f.l.append([99, 100])
 
-        return
-
     def test_remove(self):
         """ remove """
 
         self.f.l.remove(5)
-
-        return
 
     def test_reverse(self):
         """ reverse """
 
         self.f.l.reverse()
 
-        return
-
     def test_sort(self):
         """ sort """
 
         self.f.l.sort()
-
-        return
 
     def test_pop(self):
         """ remove """
 
         self.f.l.pop()
 
-        return
-
     def test_del_all(self):
         """ del all """
 
         del self.f.l[:]
-
-        return
 
     def test_assign_item(self):
         """ assign item """
 
         self.f.l[3] = 99
 
-        return
-
     def test_del_item(self):
         """ del item """
 
         del self.f.l[3]
-
-        return
 
     def test_assign_slice(self):
         """ assign slice """
 
         self.f.l[2:4] = [88, 99]
 
-        return
-
     def test_del_slice(self):
         """ del slice """
 
         del self.f.l[2:5]
-
-        return
 
     def test_assign_extended_slice(self):
         """ assign extended slice """
 
         self.f.l[2:6:2] = [88, 99]
 
-        return
-
     def test_del_extended_slice(self):
         """ del extended slice """
 
         del self.f.l[2:6:2]
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################

--- a/envisage/tests/test_slice.py
+++ b/envisage/tests/test_slice.py
@@ -63,10 +63,6 @@ def listener(obj, trait_name, old, event):
 class SliceTestCase(unittest.TestCase):
     """ Tests to help find out how trait list events work. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
@@ -76,82 +72,100 @@ class SliceTestCase(unittest.TestCase):
         self.f = Foo(l=TEST_LIST)
         self.f.on_trait_change(listener, 'l_items')
 
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_append(self):
         """ append """
 
         self.f.l.append(99)
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_insert(self):
         """ insert """
 
         self.f.l.insert(3, 99)
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_extend(self):
         """ extend """
 
         self.f.l.append([99, 100])
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_remove(self):
         """ remove """
 
         self.f.l.remove(5)
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_reverse(self):
         """ reverse """
 
         self.f.l.reverse()
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_sort(self):
         """ sort """
 
         self.f.l.sort()
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_pop(self):
         """ remove """
 
         self.f.l.pop()
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_del_all(self):
         """ del all """
 
         del self.f.l[:]
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_assign_item(self):
         """ assign item """
 
         self.f.l[3] = 99
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_del_item(self):
         """ del item """
 
         del self.f.l[3]
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_assign_slice(self):
         """ assign slice """
 
         self.f.l[2:4] = [88, 99]
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_del_slice(self):
         """ del slice """
 
         del self.f.l[2:5]
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_assign_extended_slice(self):
         """ assign extended slice """
 
         self.f.l[2:6:2] = [88, 99]
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)
 
     def test_del_extended_slice(self):
         """ del extended slice """
 
         del self.f.l[2:6:2]
+        # Make sure we successfully recreated the operation.
+        self.assertEqual(self.f.l, listener.clone)

--- a/envisage/ui/action/tests/test_action_manager_builder.py
+++ b/envisage/ui/action/tests/test_action_manager_builder.py
@@ -19,24 +19,6 @@ from .dummy_action_manager_builder import DummyActionManagerBuilder
 class ActionManagerBuilderTestCase(unittest.TestCase):
     """ Tests for the action manager builder. """
 
-    ###########################################################################
-    # 'TestCase' interface.
-    ###########################################################################
-
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
-
-        return
-
-    def tearDown(self):
-        """ Called immediately after each test method has been called. """
-
-        return
-
-    ###########################################################################
-    # Tests.
-    ###########################################################################
-
     def test_action_with_nonexistent_group(self):
         """ action with non-existent group """
 
@@ -57,11 +39,8 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         builder = DummyActionManagerBuilder(action_sets=action_sets)
 
         # Create a menu bar manager for the 'MenuBar'.
-        self.failUnlessRaises(
-            ValueError, builder.create_menu_bar_manager, 'MenuBar'
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            builder.create_menu_bar_manager("MenuBar")
 
     def test_action_with_nonexistent_sibling(self):
         """ action with non-existent sibling """
@@ -83,11 +62,8 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         builder = DummyActionManagerBuilder(action_sets=action_sets)
 
         # Create a menu bar manager for the 'MenuBar'.
-        self.failUnlessRaises(
-            ValueError, builder.create_menu_bar_manager, 'MenuBar'
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            builder.create_menu_bar_manager("MenuBar")
 
     def test_group_with_nonexistent_sibling(self):
         """ group with non-existent sibling """
@@ -104,11 +80,8 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         builder = DummyActionManagerBuilder(action_sets=action_sets)
 
         # Create a menu bar manager for the 'MenuBar'.
-        self.failUnlessRaises(
-            ValueError, builder.create_menu_bar_manager, 'MenuBar'
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            builder.create_menu_bar_manager("MenuBar")
 
     def test_menu_with_nonexistent_sibling(self):
         """ menu with non-existent sibling """
@@ -125,11 +98,8 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         builder = DummyActionManagerBuilder(action_sets=action_sets)
 
         # Create a menu bar manager for the 'MenuBar'.
-        self.failUnlessRaises(
-            ValueError, builder.create_menu_bar_manager, 'MenuBar'
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            builder.create_menu_bar_manager("MenuBar")
 
     def test_action_with_path_component_that_is_not_a_menu(self):
         """ action with path component that is not a menu """
@@ -155,11 +125,8 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         builder = DummyActionManagerBuilder(action_sets=action_sets)
 
         # Create a menu bar manager for the 'MenuBar'.
-        self.failUnlessRaises(
-            ValueError, builder.create_menu_bar_manager, 'MenuBar'
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            builder.create_menu_bar_manager("MenuBar")
 
     def test_single_top_level_menu_with_no_group(self):
         """ single top level menu with no group """
@@ -186,8 +153,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         ids = [item.id for item in group.items]
         self.assertEqual(['File'], ids)
 
-        return
-
     def test_single_top_level_group(self):
         """ single top level group """
 
@@ -210,8 +175,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         ids = [group.id for group in menu_bar_manager.groups]
         self.assertEqual(['FileMenuGroup', 'additions'], ids)
-
-        return
 
     def test_top_level_menus_with_no_groups(self):
         """ top level menus with_no groups """
@@ -240,8 +203,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         group = menu_bar_manager.find_group('additions')
         ids = [item.id for item in group.items]
         self.assertEqual(['File', 'Edit', 'Tools', 'Help'], ids)
-
-        return
 
     def test_top_level_menus_no_groups_before_and_after(self):
         """ top level menus no groups, before and after """
@@ -286,8 +247,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         ids = [item.id for item in additions.items]
         self.assertEqual(['File', 'Edit', 'Tools', 'Help'], ids)
 
-        return
-
     def test_top_level_menu_non_existent_group(self):
         """ top level menu non-existent group """
 
@@ -303,11 +262,8 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         builder = DummyActionManagerBuilder(action_sets=action_sets)
 
         # Create a menu bar manager for the 'MenuBar'.
-        self.failUnlessRaises(
-            ValueError, builder.create_menu_bar_manager, 'MenuBar'
-        )
-
-        return
+        with self.assertRaises(ValueError):
+            builder.create_menu_bar_manager("MenuBar")
 
     def test_top_level_menu_group(self):
         """ top level menu group """
@@ -339,8 +295,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         group = menu_manager.find_group('FileMenuGroup')
         self.assertEqual('File', group.items[0].id)
-
-        return
 
     def test_sub_menus_no_groups(self):
         """ sub-menus no groups """
@@ -377,8 +331,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         additions = menu.find_group('additions')
 
         self.assertEqual('New', additions.items[0].id)
-
-        return
 
     def test_actions_no_groups(self):
         """ actions no groups """
@@ -424,8 +376,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         self.assertEqual('About', additions.items[0].id)
 
-        return
-
     def test_actions_make_submenus(self):
         """ actions make submenus """
 
@@ -465,8 +415,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         self.assertEqual('Folder', additions.items[0].id)
         self.assertEqual('File', additions.items[1].id)
-
-        return
 
     def test_actions_make_submenus_before_and_after(self):
         """ actions make submenus before and after """
@@ -521,8 +469,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         ids = [item.id for item in additions.items]
         self.assertEqual(['Project', 'Folder', 'File'], ids)
-
-        return
 
     def test_explicit_groups(self):
         """ explicit groups """
@@ -615,8 +561,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         self.assertEqual('Exit', group.items[0].id)
 
-        return
-
     def test_actions_and_menus_in_groups(self):
         """ actions and menus in groups """
 
@@ -689,8 +633,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         self.assertEqual('Exit', group.items[0].id)
 
-        return
-
     def test_duplicate_menu(self):
         """ duplicate menu """
 
@@ -741,8 +683,6 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
             ['NewGroup', 'ExitGroup', 'ExtraGroup', 'additions'], ids
         )
 
-        return
-
     def test_duplicate_group(self):
         """ duplicate group """
 
@@ -792,12 +732,3 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         self.assertEqual(
             ['NewGroup', 'ExitGroup', 'additions'], ids
         )
-
-        return
-
-
-# Entry point for stand-alone testing.
-if __name__ == '__main__':
-    unittest.main()
-
-#### EOF ######################################################################


### PR DESCRIPTION
- Fix DeprecationWarnings from `failUnlessRaises` and `assert_`
- Turn existing non-context-manager uses of `assertRaises` into the context manager form
- Remove some unnecessary boilerplate from test modules

Closes #207