### PR TITLE
FIX: Don't create kernel at stop time

### DIFF
--- a/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
+++ b/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
@@ -6,6 +6,15 @@
 # under the conditions described in the aforementioned license.  The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!
+
+import contextlib
+try:
+    # Python 3: mock available in std. lib.
+    from unittest import mock
+except ImportError:
+    # Python 2: use 3rd party mock library
+    import mock
+
 import unittest
 
 from traits.api import List
@@ -41,22 +50,18 @@ class TestIPythonKernelPlugin(unittest.TestCase):
     def test_kernel_service(self):
         # See that we can get the IPython kernel service when the plugin is
         # there.
-        plugins = [CorePlugin(), IPythonKernelPlugin()]
-        app = Application(plugins=plugins, id='test')
+        with self.running_app() as app:
+            kernel = app.get_service(IPYTHON_KERNEL_PROTOCOL)
+            self.assertIsNotNone(kernel)
+            self.assertIsInstance(kernel, InternalIPKernel)
 
-        # Starting the app starts the kernel plugin. The IPython kernel
-        # service should now be available.
-        app.start()
-        kernel = app.get_service(IPYTHON_KERNEL_PROTOCOL)
-        self.assertIsNotNone(kernel)
-        self.assertIsInstance(kernel, InternalIPKernel)
+            # Initialize the kernel. Normally, the application does it when
+            # it starts.
+            kernel.init_ipkernel(gui_backend=None)
+            self.assertIsNotNone(kernel.ipkernel)
 
-        # Initialize the kernel. Normally, the application does it when
-        # it starts.
-        kernel.init_ipkernel(gui_backend=None)
-
-        # Stopping the application should shut the kernel down.
-        app.stop()
+        # After application stop, the InternalIPKernel object should
+        # also have been shut down.
         self.assertIsNone(kernel.ipkernel)
 
     def test_kernel_namespace_extension_point(self):
@@ -66,14 +71,91 @@ class TestIPythonKernelPlugin(unittest.TestCase):
             def _kernel_namespace_default(self):
                 return [('y', 'hi')]
 
-        plugins = [CorePlugin(), IPythonKernelPlugin(), NamespacePlugin()]
-        app = Application(plugins=plugins, id='test')
+        plugins = [IPythonKernelPlugin(), NamespacePlugin()]
 
-        app.start()
-        try:
+        with self.running_app(plugins=plugins) as app:
             kernel = app.get_service(IPYTHON_KERNEL_PROTOCOL)
             kernel.init_ipkernel(gui_backend=None)
             self.assertIn('y', kernel.namespace)
             self.assertEqual(kernel.namespace['y'], 'hi')
+
+    def test_get_service_twice(self):
+        with self.running_app() as app:
+            kernel1 = app.get_service(IPYTHON_KERNEL_PROTOCOL)
+            kernel2 = app.get_service(IPYTHON_KERNEL_PROTOCOL)
+            self.assertIs(kernel1, kernel2)
+
+    def test_service_not_used(self):
+        # If the service isn't used, no kernel should be created.
+        from envisage.plugins.ipython_kernel import internal_ipkernel
+
+        kernel_instances = []
+
+        class TrackingInternalIPKernel(internal_ipkernel.InternalIPKernel):
+            def __init__(self, *args, **kwargs):
+                super(TrackingInternalIPKernel, self).__init__(*args, **kwargs)
+                kernel_instances.append(self)
+
+        patcher = mock.patch.object(
+            internal_ipkernel,
+            "InternalIPKernel",
+            TrackingInternalIPKernel,
+        )
+
+        with patcher:
+            kernel_plugin = IPythonKernelPlugin()
+            with self.running_app(plugins=[kernel_plugin]):
+                pass
+
+        self.assertEqual(kernel_instances, [])
+
+    def test_service_used(self):
+        # This is a complement to the test_service_not_used test. It's mostly
+        # here as a double check on the somewhat messy test machinery used in
+        # test_service_not_used: if the assumptions (e.g., on the location that
+        # InternalIPKernel is imported from) in test_service_not_used break,
+        # then this test will likely break too.
+
+        from envisage.plugins.ipython_kernel import internal_ipkernel
+
+        kernel_instances = []
+
+        class TrackingInternalIPKernel(internal_ipkernel.InternalIPKernel):
+            def __init__(self, *args, **kwargs):
+                super(TrackingInternalIPKernel, self).__init__(*args, **kwargs)
+                kernel_instances.append(self)
+
+        patcher = mock.patch.object(
+            internal_ipkernel,
+            "InternalIPKernel",
+            TrackingInternalIPKernel,
+        )
+
+        with patcher:
+            kernel_plugin = IPythonKernelPlugin()
+            with self.running_app(plugins=[kernel_plugin]) as app:
+                app.get_service(IPYTHON_KERNEL_PROTOCOL)
+
+        self.assertEqual(len(kernel_instances), 1)
+
+    @contextlib.contextmanager
+    def running_app(self, plugins=None):
+        """
+        Returns a context manager that provides a running application.
+
+        Parameters
+        ----------
+        plugins : list of Plugin, optional
+            Plugins to use in the application, other than the CorePlugin
+            (which is always included). If not given, an IPythonKernelPlugin
+            is instantiated and used.
+        """
+        if plugins is None:
+            plugins = [IPythonKernelPlugin()]
+
+        app = Application(plugins=[CorePlugin()] + plugins, id='test')
+        app.start()
+        try:
+            yield app
         finally:
             app.stop()

--- a/etstool.py
+++ b/etstool.py
@@ -122,7 +122,7 @@ source_dependencies = {
     "traitsui",
 }
 
-extra_dependencies = {
+toolkit_dependencies = {
     'pyside': {'pyside'},
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
@@ -132,6 +132,10 @@ extra_dependencies = {
     # FIXME: wxpython 3.0.2.0-6 is broken of OS-X
     'wx': {'wxpython<3.0.2.0-6'},
     'null': set()
+}
+
+runtime_dependencies = {
+    "2.7": {"mock"},
 }
 
 environment_vars = {
@@ -207,7 +211,10 @@ def install(edm, runtime, toolkit, environment, editable, source):
     """
     parameters = get_parameters(edm, runtime, toolkit, environment)
     packages = ' '.join(
-        dependencies | extra_dependencies.get(toolkit, set()))
+        dependencies
+        | toolkit_dependencies.get(toolkit, set())
+        | runtime_dependencies.get(runtime, set())
+    )
     # edm commands to setup the development environment
     commands = [
         "{edm} environments create {environment} --force --version={runtime}",


### PR DESCRIPTION
[Includes commits from #229, which should be reviewed and merged first]

In the current IPythonKernelPlugin, if the service is never used, the expected behaviour is that no kernel application is created.

Instead, thanks to the magic of Traits defaults, what happens is that a kernel application is created, then shut down, at plugin stop time.

This PR fixes that.

Note that this is not a pure bugfix, so should not go into a bugfix release: before this PR, the `kernel` trait is directly accessible on the `IPythonKernelPlugin`. After the PR, it's not: the `kernel` trait has been made private. In practice, it seems unlikely that anyone is accessing this `kernel` trait directly, but we don't know.

IMO, the risk of accidental breakage is big enough that we shouldn't change this in a bugfix release, but small enough that we shouldn't need to go through a deprecation cycle, so this can be included in the next feature release.