### PR TITLE
Add mock to dependencies on Python 2.

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -122,7 +122,7 @@ source_dependencies = {
     "traitsui",
 }
 
-extra_dependencies = {
+toolkit_dependencies = {
     'pyside': {'pyside'},
     # XXX once pyside2 is available in EDM, we will want it here
     'pyside2': set(),
@@ -132,6 +132,10 @@ extra_dependencies = {
     # FIXME: wxpython 3.0.2.0-6 is broken of OS-X
     'wx': {'wxpython<3.0.2.0-6'},
     'null': set()
+}
+
+runtime_dependencies = {
+    "2.7": {"mock"},
 }
 
 environment_vars = {
@@ -207,7 +211,10 @@ def install(edm, runtime, toolkit, environment, editable, source):
     """
     parameters = get_parameters(edm, runtime, toolkit, environment)
     packages = ' '.join(
-        dependencies | extra_dependencies.get(toolkit, set()))
+        dependencies
+        | toolkit_dependencies.get(toolkit, set())
+        | runtime_dependencies.get(runtime, set())
+    )
     # edm commands to setup the development environment
     commands = [
         "{edm} environments create {environment} --force --version={runtime}",


### PR DESCRIPTION
Both #227 and #228 will require `mock` for testing on Python 2. This PR pulls out the necessary etstool.py changes.