### PR TITLE
Correctly restore IPython.utils.io.stdout state in all cases

### DIFF
--- a/envisage/plugins/ipython_kernel/kernelapp.py
+++ b/envisage/plugins/ipython_kernel/kernelapp.py
@@ -39,6 +39,9 @@ if six.PY2:
 else:
     from atexit import unregister as atexit_unregister
 
+# Sentinel object used to represent a missing attribute.
+_MISSING = object()
+
 
 class IPKernelApp(ipykernel.kernelapp.IPKernelApp):
     """
@@ -173,8 +176,10 @@ class IPKernelApp(ipykernel.kernelapp.IPKernelApp):
         Extended to store the original values of IPython.utils.io.stdout
         and IPython.utils.io.stderr, so that they can be restored later.
         """
-        self._original_ipython_utils_io_stdout = IPython.utils.io.stdout
-        self._original_ipython_utils_io_stderr = IPython.utils.io.stderr
+        self._original_ipython_utils_io_stdout = getattr(
+            IPython.utils.io, "stdout", _MISSING)
+        self._original_ipython_utils_io_stderr = getattr(
+            IPython.utils.io, "stderr", _MISSING)
         super(IPKernelApp, self).init_kernel()
 
     # New methods, mostly to control shutdown #################################
@@ -257,10 +262,16 @@ class IPKernelApp(ipykernel.kernelapp.IPKernelApp):
         # Undo changes to IPython.utils.io made at shell creation time.
         # The values written by the shell keep references that prevent
         # proper garbage collection from taking place.
-        IPython.utils.io.stderr = self._original_ipython_utils_io_stderr
+        if self._original_ipython_utils_io_stderr is _MISSING:
+            del IPython.utils.io.stderr
+        else:
+            IPython.utils.io.stderr = self._original_ipython_utils_io_stderr
         del self._original_ipython_utils_io_stderr
 
-        IPython.utils.io.stdout = self._original_ipython_utils_io_stdout
+        if self._original_ipython_utils_io_stdout is _MISSING:
+            del IPython.utils.io.stdout
+        else:
+            IPython.utils.io.stdout = self._original_ipython_utils_io_stdout
         del self._original_ipython_utils_io_stdout
 
     def close_io(self):

--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -108,6 +108,26 @@ class TestInternalIPKernel(unittest.TestCase):
         self.assertIs(IPython.utils.io.stdout, original_io_stdout)
         self.assertIs(IPython.utils.io.stderr, original_io_stderr)
 
+    def test_ipython_util_io_globals_restored_if_they_dont_exist(self):
+        # Regression test for enthought/envisage#218
+        original_io_stdin = IPython.utils.io.stdin
+        original_io_stdout = IPython.utils.io.stdout
+        original_io_stderr = IPython.utils.io.stderr
+
+        del IPython.utils.io.stdin
+        del IPython.utils.io.stdout
+        del IPython.utils.io.stderr
+
+        try:
+            self.create_and_destroy_kernel()
+            self.assertFalse(hasattr(IPython.utils.io, "stdin"))
+            self.assertFalse(hasattr(IPython.utils.io, "stdout"))
+            self.assertFalse(hasattr(IPython.utils.io, "stderr"))
+        finally:
+            IPython.utils.io.stdin = original_io_stdin
+            IPython.utils.io.stdout = original_io_stdout
+            IPython.utils.io.stderr = original_io_stderr
+
     def test_io_pub_thread_stopped(self):
         self.create_and_destroy_kernel()
         io_pub_threads = self.objects_of_type(ipykernel.iostream.IOPubThread)


### PR DESCRIPTION
If `IPython.utils.io.stdout` doesn't exist (which happened in practice in an application, and which could in theory happen in the future in upstream `IPython`), then `IPKernelApp` fails to start correctly. This PR fixes that, and makes sure that the original state is restored in all cases.

Fixes #218.