### PR TITLE
Add a test to check that the InternalIPKernel doesn't affect sys.path.

### DIFF
--- a/envisage/plugins/ipython_kernel/kernelapp.py
+++ b/envisage/plugins/ipython_kernel/kernelapp.py
@@ -347,8 +347,9 @@ class IPKernelApp(ipykernel.kernelapp.IPKernelApp):
         """
         Undo changes made in init_profile_dir.
         """
-        if self.ipython_dir in sys.path:
-            sys.path.remove(self.ipython_dir)
+        ipython_dir_entry = os.path.abspath(self.ipython_dir)
+        if ipython_dir_entry in sys.path:
+            sys.path.remove(ipython_dir_entry)
 
     def cleanup_singletons(self):
         """

--- a/envisage/plugins/ipython_kernel/kernelapp.py
+++ b/envisage/plugins/ipython_kernel/kernelapp.py
@@ -205,6 +205,7 @@ class IPKernelApp(ipykernel.kernelapp.IPKernelApp):
         atexit_unregister(self.cleanup_connection_file)
 
         self.close_crash_handler()
+        self.close_profile_dir()
         self.cleanup_singletons()
 
     def close_shell(self):
@@ -341,6 +342,13 @@ class IPKernelApp(ipykernel.kernelapp.IPKernelApp):
             self.log.debug("Terminating zmq context")
             self.context.term()
             self.log.debug("Terminated zmq context")
+
+    def close_profile_dir(self):
+        """
+        Undo changes made in init_profile_dir.
+        """
+        if self.ipython_dir in sys.path:
+            sys.path.remove(self.ipython_dir)
 
     def cleanup_singletons(self):
         """

--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -87,6 +87,13 @@ class TestInternalIPKernel(unittest.TestCase):
         self.assertIs(sys.displayhook, original_displayhook)
         self.assertIs(sys.excepthook, original_excepthook)
 
+    def test_shutdown_restores_sys_path(self):
+        original_sys_path = sys.path[:]
+
+        self.create_and_destroy_kernel()
+
+        self.assertEqual(sys.path, original_sys_path)
+
     def test_shutdown_closes_console_pipes(self):
         kernel = InternalIPKernel()
         kernel.init_ipkernel(gui_backend=None)


### PR DESCRIPTION
Closes #217.