### PR TITLE
Test single project ITreeNode adapters

### DIFF
--- a/envisage/ui/single_project/tests/test_project_view.py
+++ b/envisage/ui/single_project/tests/test_project_view.py
@@ -10,6 +10,7 @@
 import unittest
 
 from traits.api import HasTraits, Supports
+from traits.interface_checker import check_implements
 from traitsui.api import ITreeNode
 
 from envisage.ui.single_project.api import Project
@@ -32,7 +33,7 @@ class TestProjectView(unittest.TestCase):
         view.tree_node = empty_project
 
         adapted = view.tree_node
-        self.assertIsInstance(adapted, ITreeNode)
+        check_implements(type(adapted), ITreeNode)
 
     def test_project_adapts_to_i_tree_node(self):
         my_project = MyProject()
@@ -41,4 +42,4 @@ class TestProjectView(unittest.TestCase):
         view.tree_node = my_project
 
         adapted = view.tree_node
-        self.assertIsInstance(adapted, ITreeNode)
+        check_implements(type(adapted), ITreeNode)

--- a/envisage/ui/single_project/tests/test_project_view.py
+++ b/envisage/ui/single_project/tests/test_project_view.py
@@ -1,0 +1,44 @@
+# (C) Copyright 2007-2019 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+
+import unittest
+
+from traits.api import HasTraits, Supports
+from traitsui.api import ITreeNode
+
+from envisage.ui.single_project.api import Project
+from envisage.ui.single_project.view.project_view import EmptyProject
+
+
+class MyProject(Project):
+    pass
+
+
+class MyView(HasTraits):
+    tree_node = Supports(ITreeNode)
+
+
+class TestProjectView(unittest.TestCase):
+    def test_empty_project_adapts_to_i_tree_node(self):
+        empty_project = EmptyProject()
+
+        view = MyView()
+        view.tree_node = empty_project
+
+        adapted = view.tree_node
+        self.assertIsInstance(adapted, ITreeNode)
+
+    def test_project_adapts_to_i_tree_node(self):
+        my_project = MyProject()
+
+        view = MyView()
+        view.tree_node = my_project
+
+        adapted = view.tree_node
+        self.assertIsInstance(adapted, ITreeNode)


### PR DESCRIPTION
This adds unit tests for the `envisage.ui.single_project` adapters.

This is the regression test part of the fix for #124. See #234 for the fix itself.