### PR TITLE
Update edm version and config/install scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 env:
   global:
-    - INSTALL_EDM_VERSION="1.11.0"
+    - INSTALL_EDM_VERSION="2.0.0"
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build: false
 environment:
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "1.11.0"
+    INSTALL_EDM_VERSION: "2.0.0"
 
   matrix:
     - RUNTIME: '2.7'

--- a/install-edm-linux.sh
+++ b/install-edm-linux.sh
@@ -4,11 +4,11 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}_linux_x86_64.sh"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then
-        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh5_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
+        curl -o "$EDM_INSTALLER_PATH" -L "https://package-data.enthought.com/edm/rh6_x86_64/${EDM_MAJOR_MINOR}/${EDM_PACKAGE}"
     fi
 
     bash "$EDM_INSTALLER_PATH" -b -p "${HOME}/edm"

--- a/install-edm-osx.sh
+++ b/install-edm-osx.sh
@@ -4,7 +4,7 @@ set -e
 
 install_edm() {
     local EDM_MAJOR_MINOR="$(echo "$INSTALL_EDM_VERSION" | sed -E -e 's/([[:digit:]]+\.[[:digit:]]+)\..*/\1/')"
-    local EDM_PACKAGE="edm_${INSTALL_EDM_VERSION}.pkg"
+    local EDM_PACKAGE="edm_cli_${INSTALL_EDM_VERSION}.pkg"
     local EDM_INSTALLER_PATH="${HOME}/.cache/download/${EDM_PACKAGE}"
 
     if [ ! -e "$EDM_INSTALLER_PATH" ]; then

--- a/install-edm-windows.cmd
+++ b/install-edm-windows.cmd
@@ -9,7 +9,7 @@ FOR /F "tokens=1,2,3 delims=." %%a in ("%INSTALL_EDM_VERSION%") do (
 )
 
 SET EDM_MAJOR_MINOR=%MAJOR%.%MINOR%
-SET EDM_PACKAGE=edm_%INSTALL_EDM_VERSION%_x86_64.msi
+SET EDM_PACKAGE=edm_cli_%INSTALL_EDM_VERSION%_x86_64.msi
 SET EDM_INSTALLER_PATH=%HOMEDRIVE%%HOMEPATH%\.cache\%EDM_PACKAGE%
 SET COMMAND="(new-object net.webclient).DownloadFile('https://package-data.enthought.com/edm/win_x86_64/%EDM_MAJOR_MINOR%/%EDM_PACKAGE%', '%EDM_INSTALLER_PATH%')"
 


### PR DESCRIPTION
This PR prempts CI failures seen on other ETS packages related to invalid metadata found in new eggs. 

NOTE : Ensure that we install the cli installer and not the full edm installer - which is very large in size and install the GUI which is not needed on the CI machines.

See similar PR in traits here - https://github.com/enthought/traits/pull/560 