### PR TITLE
Fix extension on the reStructuredText-formatted changelog.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Tests
 Build
 -----
 
+- Rename changelog extension from ``.txt`` to ``.rst``. (#238)
 - Update EDM version used in Travis CI and Appveyor. (#236)
 - Add ``mock`` to test dependencies on Python 2. (#229)
 - Fix status badges in ``README``. (#216)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include CHANGES.txt
+include CHANGES.rst
 include LICENSE.txt
 include MANIFEST.in
 include README.rst


### PR DESCRIPTION
The changelog (which is formatted as reStructuredText) renders more nicely in GitHub if we give it the correct extension. (And we may even want to include it in the generated documentation some day.)