### PR TITLE
Remove a use of 'print' in the test suite.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ Fixes
 Tests
 -----
 
-- Remove a ``print`` call from a unit tests. (#240)
+- Remove a ``print`` call from a unit test. (#240)
 - Add unit tests for the ``envisage.ui.single_project`` adapters. (#235)
 - Add unit tests to check that ``InternalIPKernel`` doesn't affect
   ``sys.path``. (#233)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Fixes
 Tests
 -----
 
+- Remove a ``print`` call from a unit tests. (#240)
 - Add unit tests for the ``envisage.ui.single_project`` adapters. (#235)
 - Add unit tests to check that ``InternalIPKernel`` doesn't affect
   ``sys.path``. (#233)

--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -7,7 +7,6 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!
 """ Tests for the 'Egg Basket' plugin manager. """
-from __future__ import print_function
 
 import glob
 import sys
@@ -39,8 +38,6 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         for path in sys.path:
             if self.bad_eggs_dir not in path:
                 sys_path.append(path)
-            else:
-                print("Removed", path)
         sys.path = sys_path
 
         # `envisage.egg_utils.get_entry_points_in_egg_order` modifies the


### PR DESCRIPTION
With this change, the test run output is clean for me.