### PR TITLE
FIX: single project bytes/str compat

### DIFF
--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -213,6 +213,8 @@ class Project(HasTraits):
 
         path = self.get_default_path(application)
         name = clean_filename(self.get_default_name())
+        enc = sys.getfilesystemencoding()
+        name = name.decode(enc)
         location = os.path.join(path, name)
         location = self._make_location_unique(location)
 

--- a/envisage/ui/single_project/tests/test_project.py
+++ b/envisage/ui/single_project/tests/test_project.py
@@ -1,0 +1,28 @@
+# (C) Copyright 2007-2019 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+
+import unittest
+
+from envisage.ui.single_project.api import Project
+
+class MyProject(Project):
+    pass
+
+class TestProject(unittest.TestCase):
+
+    def test_get_project_location(self):
+        # Given
+        prj = MyProject(application=None)
+
+        # When
+        loc = prj.get_default_project_location(prj.application)
+
+        # Then
+        self.assertIsNotNone(loc)
+        self.assertIsInstance(loc, str)


### PR DESCRIPTION
This PR introduces a small fix for a bytes/str incompatibility in the `envisage.ui.single_project` codebase. To reproduce the error, see #245 

@mdickinson Is this an acceptable way to tackle this issue? I wasn't sure if defaulting to the system file encoding was correct.

closes #245 