### PR TITLE
MAINT: copy clean_filename from Traits

### DIFF
--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -13,12 +13,9 @@ plugin.
 """
 
 # Standard library imports.
-import datetime
 import logging
-import keyword
 import os
 import re
-import sys
 import unicodedata
 
 # Enthought library imports
@@ -723,7 +720,6 @@ class Project(HasTraits):
 
 # Helper functions
 
-# Added so that the dependency on this function from Traits can be removed
 def clean_filename(name, replace_empty=""):
     """
     Make a user-supplied string safe for filename use.
@@ -733,6 +729,7 @@ def clean_filename(name, replace_empty=""):
     '_'.
     This does not give a faithful representation of the original string:
     different input strings can result in the same output string.
+
     Parameters
     ----------
     name : str
@@ -742,6 +739,7 @@ def clean_filename(name, replace_empty=""):
         string ends up being empty. No validation is done on this
         input - it's up to the user to ensure that the default is
         itself safe. The default is to return the empty string.
+
     Returns
     -------
     safe_string : str

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -13,9 +13,13 @@ plugin.
 """
 
 # Standard library imports.
+import datetime
 import logging
+import keyword
 import os
+import re
 import sys
+import unicodedata
 
 # Enthought library imports
 from traits.etsconfig.api import ETSConfig
@@ -24,7 +28,6 @@ from apptools.io.api import File
 from traits.api import Any, Bool, Dict, Directory, HasTraits, \
     Instance, Property, Str
 from traitsui.api import Group, View
-from traits.util.clean_strings import clean_filename
 
 # Local imports.
 #from envisage.ui.single_project.editor.project_editor import \
@@ -717,5 +720,44 @@ class Project(HasTraits):
         # Indicate this project is now dirty
         self.dirty = True
 
+
+# Helper functions
+
+# Added so that the dependency on this function from Traits can be removed
+def clean_filename(name, replace_empty=""):
+    """
+    Make a user-supplied string safe for filename use.
+    Returns an ASCII-encodable string based on the input string that's safe for
+    use as a component of a filename or URL. The returned value is a string
+    containing only lowercase ASCII letters, digits, and the characters '-' and
+    '_'.
+    This does not give a faithful representation of the original string:
+    different input strings can result in the same output string.
+    Parameters
+    ----------
+    name : str
+        The string to be made safe.
+    replace_empty : str, optional
+        The return value to be used in the event that the sanitised
+        string ends up being empty. No validation is done on this
+        input - it's up to the user to ensure that the default is
+        itself safe. The default is to return the empty string.
+    Returns
+    -------
+    safe_string : str
+        A filename-safe version of string.
+    """
+    # Code is based on Django's slugify utility.
+    # https://docs.djangoproject.com/en/1.9/_modules/django/utils/text/#slugify
+    name = (
+        unicodedata.normalize('NFKD', name)
+        .encode('ascii', 'ignore')
+        .decode('ascii')
+    )
+    name = re.sub(r'[^\w\s-]', '', name).strip().lower()
+    safe_name = re.sub(r'[-\s]+', '-', name)
+    if safe_name == "":
+        return replace_empty
+    return safe_name
 
 #### EOF #####################################################################

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -723,6 +723,7 @@ class Project(HasTraits):
 def clean_filename(name, replace_empty=""):
     """
     Make a user-supplied string safe for filename use.
+
     Returns an ASCII-encodable string based on the input string that's safe for
     use as a component of a filename or URL. The returned value is a string
     containing only lowercase ASCII letters, digits, and the characters '-' and

--- a/envisage/ui/single_project/tests/test_clean_strings.py
+++ b/envisage/ui/single_project/tests/test_clean_strings.py
@@ -1,0 +1,87 @@
+# -----------------------------------------------------------------------------
+#
+#  Copyright (c) 2019, Enthought, Inc.
+#  All rights reserved.
+#
+#  This software is provided without warranty under the terms of the BSD
+#  license included in /LICENSE.txt and may be redistributed only
+#  under the conditions described in the aforementioned license.  The license
+#  is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+#  Thanks for using Enthought open source!
+#
+# -----------------------------------------------------------------------------
+from __future__ import unicode_literals
+
+import unittest
+
+import six
+
+from envisage.ui.single_project.project import clean_filename
+
+# Safe strings should only contain the following characters.
+LEGAL_CHARS = set("-0123456789_abcdefghijklmnopqrstuvwxyz0123456789")
+
+
+class TestCleanStrings(unittest.TestCase):
+    def test_clean_filename_default(self):
+        test_strings = [
+            "!!!",
+            "",
+            " ",
+            "\t/\n",
+            "^!+",
+        ]
+        for test_string in test_strings:
+            safe_string = clean_filename(test_string, "default-output")
+            self.check_output(safe_string)
+            self.assertEqual(safe_string, "default-output")
+
+    def test_clean_filename_whitespace_handling(self):
+        # Leading and trailing whitespace stripped.
+        self.assertEqual(clean_filename(" abc "), "abc")
+        self.assertEqual(clean_filename(" \t\tabc    \n"), "abc")
+        # Internal whitespace turned into hyphens.
+        self.assertEqual(clean_filename("well name"), "well-name")
+        self.assertEqual(clean_filename("well \n name"), "well-name")
+        self.assertEqual(clean_filename("well - name"), "well-name")
+
+    def test_clean_filename_conversion_to_lowercase(self):
+        test_string = "ABCdefGHI123"
+        safe_string = clean_filename(test_string)
+        self.assertEqual(safe_string, test_string.lower())
+        self.check_output(safe_string)
+
+    def test_clean_filename_accented_chars(self):
+        test_strings = [
+            "\xe4b\xe7d\xe8f",
+            "a\u0308bc\u0327de\u0300f",
+        ]
+        for test_string in test_strings:
+            safe_string = clean_filename(test_string)
+            self.check_output(safe_string)
+            self.assertEqual(safe_string, "abcdef")
+
+    def test_clean_filename_all_chars(self):
+        chr_ = unichr if six.PY2 else chr
+        test_strings = [
+            "".join(chr_(n) for n in range(10000)),
+            "".join(chr_(n) for n in range(10000)) * 2,
+            "".join(chr_(n) for n in reversed(range(10000))),
+        ]
+        for test_string in test_strings:
+            safe_string = clean_filename(test_string)
+            self.check_output(safe_string)
+
+    def check_output(self, safe_string):
+        """
+        Check that a supposedly safe string is actually safe.
+        """
+        self.assertIsInstance(safe_string, six.text_type)
+        chars_in_string = set(safe_string)
+        self.assertLessEqual(chars_in_string, LEGAL_CHARS)
+
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/envisage/ui/single_project/tests/test_clean_strings.py
+++ b/envisage/ui/single_project/tests/test_clean_strings.py
@@ -20,7 +20,7 @@ import six
 from envisage.ui.single_project.project import clean_filename
 
 # Safe strings should only contain the following characters.
-LEGAL_CHARS = set("-0123456789_abcdefghijklmnopqrstuvwxyz0123456789")
+LEGAL_CHARS = set("-0123456789_abcdefghijklmnopqrstuvwxyz")
 
 
 class TestCleanStrings(unittest.TestCase):
@@ -80,8 +80,3 @@ class TestCleanStrings(unittest.TestCase):
         self.assertIsInstance(safe_string, six.text_type)
         chars_in_string = set(safe_string)
         self.assertLessEqual(chars_in_string, LEGAL_CHARS)
-
-
-if __name__ == '__main__':
-    unittest.main()
-


### PR DESCRIPTION
This PR copies the `clean_filename()` utility function from the `Traits` codebase into Envisage, as it is currently used in the `SingleProject` code and slated to be removed from Traits. Additionally, the test suite from Traits for this function is copied into the `SingleProject` tests.

IIUC, this should finish the work for #245 