### PR TITLE
Bump the version for the 4.9.1 release.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup, find_packages
 # into the package source.
 MAJOR = 4
 MINOR = 9
-MICRO = 0
+MICRO = 1
 IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",


### PR DESCRIPTION
This PR, against the 4.9.x release branch, bumps the version in preparation for the 4.9.1 bugfix release.

Note: do not merge until after merging #258 