### PR TITLE
Make 4.9.2 release containing fix for tests that depend on Categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,21 @@
  Envisage CHANGELOG
 ====================
 
+Version 4.9.2
+=============
+
+Released: 2020-02-17
+
+This is a bugfix release that fixes tests that assumed the existence
+of categories machinery (which is removed in Traits 6.0.0).
+
+Fixes
+-----
+
+- Conditionally skip tests that fail against Traits 6.0.0 due to the removal
+  of Categories. (#263)
+
+
 Version 4.9.1
 =============
 

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -18,6 +18,14 @@ from envisage.api import ServiceOffer
 from traits.api import HasTraits, Int, Interface, List
 from traits.testing.unittest_tools import unittest
 
+# Categories were removed in Traits 6.0
+try:
+    from traits.api import Category as traits_category  # noqa: F401
+except ImportError:
+    categories_available = False
+else:
+    categories_available = True
+
 
 # This module's package.
 PKG = 'envisage.tests'
@@ -137,6 +145,8 @@ class CorePluginTestCase(unittest.TestCase):
         service = application.get_service(IMyService)
         self.assertEqual(42, service)
 
+    @unittest.skipUnless(
+        categories_available, "Traits categories not available")
     def test_categories(self):
         """ categories """
 
@@ -176,6 +186,8 @@ class CorePluginTestCase(unittest.TestCase):
         # place! This test works for me on Python 2.4!
         self.assertTrue('y' in Bar.class_traits())
 
+    @unittest.skipUnless(
+        categories_available, "Traits categories not available")
     def test_dynamically_added_category(self):
         """ dynamically added category """
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup, find_packages
 # into the package source.
 MAJOR = 4
 MINOR = 9
-MICRO = 1
+MICRO = 2
 IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",


### PR DESCRIPTION
The test suite for Envisage 4.9.1 fails against the latest release of Traits (Traits 6.0.0), due to the removal of Traits categories. (Envisage master no longer depends on Traits categories; so this is only an issue in this release series.)

This PR "fixes" the issue by skipping the relevant tests if Traits categories are not available.

Also bumps the version number and updates the changelog in preparation for a 4.9.2 release.