### PR TITLE
Replace uses of the semi-deprecated Unicode with Str

### DIFF
--- a/docs/source/tasks_user_manual/extensibility.rst
+++ b/docs/source/tasks_user_manual/extensibility.rst
@@ -259,7 +259,7 @@ above, exposes a Traits UI view for this helper object::
 
         #### 'AttractorsPreferencesPane' interface ############################
 
-        task_map = Dict(Str, Unicode)
+        task_map = Dict(Str, Str)
 
         # Notice that the default context for trait names is that of the model
         # object, and that we must prefix names for this object with 'handler.'.

--- a/envisage/ui/tasks/action/task_window_toggle_group.py
+++ b/envisage/ui/tasks/action/task_window_toggle_group.py
@@ -8,8 +8,7 @@
 # Thanks for using Enthought open source!
 # Enthought library imports.
 from pyface.action.api import Action, ActionItem, Group
-from traits.api import Any, Instance, List, Property, Unicode, \
-     on_trait_change
+from traits.api import Any, Instance, List, Property, Str, on_trait_change
 
 
 class TaskWindowToggleAction(Action):
@@ -18,7 +17,7 @@ class TaskWindowToggleAction(Action):
 
     #### 'Action' interface ###################################################
 
-    name = Property(Unicode, depends_on='window.active_task.name')
+    name = Property(Str, depends_on='window.active_task.name')
     style = 'toggle'
 
     #### 'TaskWindowToggleAction' interface ###################################

--- a/envisage/ui/tasks/preferences_category.py
+++ b/envisage/ui/tasks/preferences_category.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!
 # Enthought library imports.
-from traits.api import HasTraits, Str, Unicode
+from traits.api import HasTraits, Str
 
 
 class PreferencesCategory(HasTraits):
@@ -18,7 +18,7 @@ class PreferencesCategory(HasTraits):
     id = Str
 
     # The user-visible name of the category.
-    name = Unicode
+    name = Str
 
     # The category appears after the category with this ID.
     before = Str

--- a/envisage/ui/tasks/preferences_dialog.py
+++ b/envisage/ui/tasks/preferences_dialog.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!
 # Enthought library imports.
-from traits.api import Bool, HasTraits, Instance, List, Unicode, \
-    on_trait_change
+from traits.api import Bool, HasTraits, Instance, List, Str, on_trait_change
 from traitsui.api import Item, Handler, ListEditor, View
 from pyface.tasks.topological_sort import before_after_sort
 
@@ -21,7 +20,7 @@ class PreferencesTab(HasTraits):
     """ An object used internally by PreferencesDialog.
     """
 
-    name = Unicode
+    name = Str
     panes = List(PreferencesPane)
 
     view = View(Item('panes',

--- a/envisage/ui/tasks/task_factory.py
+++ b/envisage/ui/tasks/task_factory.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!
 # Enthought library imports.
-from traits.api import Callable, HasTraits, Str, Unicode
+from traits.api import Callable, HasTraits, Str
 
 
 class TaskFactory(HasTraits):
@@ -19,7 +19,7 @@ class TaskFactory(HasTraits):
     id = Str
 
     # The task factory's user-visible name.
-    name = Unicode
+    name = Str
 
     # A callable with the following signature:
     #

--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -15,7 +15,7 @@ import os.path
 from envisage.api import Application, ExtensionPoint
 from traits.api import (
     Bool, Callable, Directory, Event, HasStrictTraits,
-    Instance, Int, List, Unicode, Vetoable)
+    Instance, Int, List, Str, Vetoable)
 from traits.etsconfig.api import ETSConfig
 
 
@@ -57,7 +57,7 @@ class TasksApplication(Application):
     icon = Instance('pyface.image_resource.ImageResource', allow_none=True)
 
     # The name of the application (also used on window title bars).
-    name = Unicode
+    name = Str
 
     # The splash screen for the application. By default, there is no splash
     # screen.
@@ -69,7 +69,7 @@ class TasksApplication(Application):
 
     # The filename that the application uses to persist window layout
     # information.
-    state_filename = Unicode(DEFAULT_STATE_FILENAME)
+    state_filename = Str(DEFAULT_STATE_FILENAME)
 
     # Contributed task factories. This attribute is primarily for run-time
     # inspection; to instantiate a task, use the 'create_task' method.

--- a/examples/plugins/tasks/attractors/attractors_preferences.py
+++ b/examples/plugins/tasks/attractors/attractors_preferences.py
@@ -1,9 +1,8 @@
 # Enthought library imports.
 from envisage.ui.tasks.api import PreferencesPane, TaskFactory
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Bool, Dict, Enum, List, Str, Unicode
-from traitsui.api import EnumEditor, HGroup, VGroup, Item, Label, \
-    View
+from traits.api import Bool, Dict, Enum, List, Str
+from traitsui.api import EnumEditor, HGroup, VGroup, Item, Label, View
 
 
 class AttractorsPreferences(PreferencesHelper):
@@ -36,7 +35,7 @@ class AttractorsPreferencesPane(PreferencesPane):
 
     #### 'AttractorsPreferencesPane' interface ################################
 
-    task_map = Dict(Str, Unicode)
+    task_map = Dict(Str, Str)
 
     view = View(
         VGroup(HGroup(Item('always_use_default_layout'),

--- a/examples/plugins/tasks/attractors/model/henon.py
+++ b/examples/plugins/tasks/attractors/model/henon.py
@@ -3,7 +3,7 @@ from scipy import array, zeros
 
 # Enthought library imports.
 from traits.api import Array, Float, HasTraits, Int, Property, Str, \
-     Unicode, cached_property, provides
+    cached_property, provides
 from traitsui.api import Item, View
 
 # Local imports.
@@ -37,12 +37,12 @@ class Henon(HasTraits):
 
     #### 'IPlottable2D' interface #############################################
 
-    name = Unicode('Henon Map')
+    name = Str('Henon Map')
     plot_type = Str('scatter')
     x_data = Property(Array, depends_on='points')
     y_data = Property(Array, depends_on='points')
-    x_label = Unicode('x')
-    y_label = Unicode('y')
+    x_label = Str('x')
+    y_label = Str('y')
 
     ###########################################################################
     # Protected interface.

--- a/examples/plugins/tasks/attractors/model/i_model_2d.py
+++ b/examples/plugins/tasks/attractors/model/i_model_2d.py
@@ -1,11 +1,11 @@
 # Enthought library imports.
-from traits.api import Array, Interface, Unicode
+from traits.api import Array, Interface, Str
 
 
 class IModel2d(Interface):
 
     # The user-visible name of the model.
-    name = Unicode
+    name = Str
 
     x_data = Array
     y_data = Array

--- a/examples/plugins/tasks/attractors/model/i_model_3d.py
+++ b/examples/plugins/tasks/attractors/model/i_model_3d.py
@@ -1,6 +1,6 @@
 # Enthought library imports.
 from traits.api import Array, DelegatesTo, HasTraits, Interface, \
-    Instance, Property, Trait, Unicode, cached_property
+    Instance, Property, Str, Trait, cached_property
 from traitsui.api import Group, Item, View
 
 
@@ -9,7 +9,7 @@ class IModel3d(Interface):
     """
 
     # The user-visible name of the model.
-    name = Unicode
+    name = Str
 
     # An n-by-3 array.
     points = Array

--- a/examples/plugins/tasks/attractors/model/i_plottable_2d.py
+++ b/examples/plugins/tasks/attractors/model/i_plottable_2d.py
@@ -1,5 +1,5 @@
 # Enthought library imports.
-from traits.api import Enum, Unicode
+from traits.api import Enum, Str
 
 # Local imports.
 from i_model_2d import IModel2d
@@ -9,5 +9,5 @@ class IPlottable2d(IModel2d):
 
     plot_type = Enum('line', 'scatter')
 
-    x_label = Unicode
-    y_label = Unicode
+    x_label = Str
+    y_label = Str

--- a/examples/plugins/tasks/attractors/model/lorenz.py
+++ b/examples/plugins/tasks/attractors/model/lorenz.py
@@ -4,7 +4,7 @@ from scipy.integrate import odeint
 
 # Enthought libary imports.
 from traits.api import Adapter, Array, Float, HasTraits, Instance, \
-     Property, Str, Unicode, cached_property, provides, register_factory
+     Property, Str, cached_property, provides, register_factory
 from traitsui.api import View, Item
 
 # Local imports
@@ -19,7 +19,7 @@ class Lorenz(HasTraits):
 
     #### 'IModel3d' interface #################################################
 
-    name = Unicode('Lorenz Attractor')
+    name = Str('Lorenz Attractor')
     points = Property(Array, depends_on=['prandtl', 'rayleigh', 'beta',
                                          'initial_point', 'times'])
 

--- a/examples/plugins/tasks/attractors/model/rossler.py
+++ b/examples/plugins/tasks/attractors/model/rossler.py
@@ -4,7 +4,7 @@ from scipy.integrate import odeint
 
 # Enthought libary imports.
 from traits.api import Adapter, Array, Float, HasTraits, Instance, \
-     Property, Str, Unicode, cached_property, provides, register_factory
+     Property, Str, cached_property, provides, register_factory
 from traitsui.api import View, Item
 
 # Local imports
@@ -19,7 +19,7 @@ class Rossler(HasTraits):
 
     #### 'IModel3d' interface #################################################
 
-    name = Unicode('Rossler Attractor')
+    name = Str('Rossler Attractor')
     points = Property(Array, depends_on=['a, b, c, initial_point, times'])
 
     #### 'Rossler' interface ##################################################

--- a/examples/plugins/tasks/attractors/model_help_pane.py
+++ b/examples/plugins/tasks/attractors/model_help_pane.py
@@ -4,8 +4,7 @@ import os.path
 
 # Enthought library imports.
 from pyface.tasks.api import TraitsDockPane
-from traits.api import HasTraits, Instance, Property, Unicode, \
-     cached_property
+from traits.api import HasTraits, Instance, Property, Str, cached_property
 from traitsui.api import HTMLEditor, Item, View
 
 # Constants.
@@ -25,7 +24,7 @@ class ModelHelpPane(TraitsDockPane):
 
     model = Instance(HasTraits)
 
-    html = Property(Unicode, depends_on='model')
+    html = Property(Str, depends_on='model')
 
     view = View(Item('pane.html',
                      editor = HTMLEditor(base_url=HELP_PATH,
@@ -58,4 +57,3 @@ class ModelHelpPane(TraitsDockPane):
                 return f.read()
         else:
             return 'No information available for model.'
-

--- a/examples/plugins/tasks/attractors/plot_2d_pane.py
+++ b/examples/plugins/tasks/attractors/plot_2d_pane.py
@@ -1,8 +1,8 @@
 # Enthought library imports.
 from chaco.chaco_plot_editor import ChacoPlotItem
 from pyface.tasks.api import TraitsTaskPane
-from traits.api import Dict, Enum, Instance, List, Property, \
-     Unicode, on_trait_change
+from traits.api import Dict, Enum, Instance, List, Property, Str, \
+    on_trait_change
 from traitsui.api import EnumEditor, HGroup, Item, Label, View
 
 # Local imports.
@@ -21,12 +21,12 @@ class Plot2dPane(TraitsTaskPane):
     active_model = Instance(IPlottable2d)
     models = List(IPlottable2d)
 
-    plot_type = Property(Unicode, depends_on='active_model.plot_type')
-    title = Property(Unicode, depends_on='active_model.name')
+    plot_type = Property(Str, depends_on='active_model.plot_type')
+    title = Property(Str, depends_on='active_model.name')
     x_data = Property(depends_on='active_model.x_data')
     y_data = Property(depends_on='active_model.y_data')
-    x_label = Property(Unicode, depends_on='active_model.x_label')
-    y_label = Property(Unicode, depends_on='active_model.y_label')
+    x_label = Property(Str, depends_on='active_model.x_label')
+    y_label = Property(Str, depends_on='active_model.y_label')
 
     view = View(HGroup(Label('Model: '),
                        Item('active_model',
@@ -50,7 +50,7 @@ class Plot2dPane(TraitsTaskPane):
 
     #### Private traits #######################################################
 
-    _enum_map = Dict(IPlottable2d, Unicode)
+    _enum_map = Dict(IPlottable2d, Str)
 
     ###########################################################################
     # Protected interface.

--- a/examples/plugins/tasks/attractors/plot_3d_pane.py
+++ b/examples/plugins/tasks/attractors/plot_3d_pane.py
@@ -2,8 +2,8 @@
 from mayavi.tools.mlab_scene_model import MlabSceneModel
 from mayavi.core.ui.mayavi_scene import MayaviScene
 from pyface.tasks.api import TraitsTaskPane
-from traits.api import Dict, Enum, Instance, List, Property, \
-     Unicode, on_trait_change
+from traits.api import Dict, Enum, Instance, List, Property, Str, \
+    on_trait_change
 from traitsui.api import EnumEditor, HGroup, Item, Label, View
 from tvtk.pyface.scene_editor import SceneEditor
 
@@ -36,7 +36,7 @@ class Plot3dPane(TraitsTaskPane):
 
     #### Private traits #######################################################
 
-    _enum_map = Dict(IModel3d, Unicode)
+    _enum_map = Dict(IModel3d, Str)
 
     ###########################################################################
     # Protected interface.

--- a/examples/plugins/tasks/ipython_kernel/i_python_editor.py
+++ b/examples/plugins/tasks/ipython_kernel/i_python_editor.py
@@ -2,7 +2,7 @@
 
 
 # Enthought library imports.
-from traits.api import Bool, Event, Instance, File, Unicode
+from traits.api import Bool, Event, Instance, File, Str
 from pyface.tasks.i_editor import IEditor
 
 # Local imports.
@@ -18,7 +18,7 @@ class IPythonEditor(IEditor):
     obj = Instance(File)
 
     # The pathname of the file being edited.
-    path = Unicode
+    path = Str
 
     # Should line numbers be shown in the margin?
     show_line_numbers = Bool(True)

--- a/examples/plugins/tasks/ipython_kernel/python_editor.py
+++ b/examples/plugins/tasks/ipython_kernel/python_editor.py
@@ -5,7 +5,7 @@ from os.path import basename
 from pyface.qt import QtCore, QtGui
 
 # Enthought library imports.
-from traits.api import Bool, Event, Instance, File, Unicode, Property, provides
+from traits.api import Bool, Event, Instance, File, Property, provides, Str
 from pyface.tasks.api import Editor
 
 # Local imports.
@@ -23,13 +23,13 @@ class PythonEditor(Editor):
 
     obj = Instance(File)
 
-    path = Unicode
+    path = Str
 
     dirty = Bool(False)
 
-    name = Property(Unicode, depends_on='path')
+    name = Property(Str, depends_on='path')
 
-    tooltip = Property(Unicode, depends_on='path')
+    tooltip = Property(Str, depends_on='path')
 
     show_line_numbers = Bool(True)
 

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ GIT = "git"
 
 def _git_output(args):
     """
-    Call Git with the given arguments and return the output as (Unicode) text.
+    Call Git with the given arguments and return the output as text.
     """
     return subprocess.check_output([GIT] + args).decode("utf-8")
 


### PR DESCRIPTION
More Python 2 / Python 3 cleanup: replace uses of the `Unicode` trait with `Str`.