### PR TITLE
Deprecate safeweakref and replace its uses

### DIFF
--- a/envisage/extension_registry.py
+++ b/envisage/extension_registry.py
@@ -11,6 +11,8 @@
 
 # Standard library imports.
 import logging
+import types
+import weakref
 
 # Enthought library imports.
 from traits.api import Dict, HasTraits, provides
@@ -18,12 +20,30 @@ from traits.api import Dict, HasTraits, provides
 # Local imports.
 from .extension_point_changed_event import ExtensionPointChangedEvent
 from .i_extension_registry import IExtensionRegistry
-from . import safeweakref
 from .unknown_extension_point import UnknownExtensionPoint
 
 
 # Logging.
 logger = logging.getLogger(__name__)
+
+
+def _saferef(listener):
+    """
+    Weak reference for a (possibly bound method) listener.
+
+    Returns a weakref.WeakMethod reference for bound methods,
+    and a regular weakref.ref otherwise.
+
+    This means that for example ``_saferef(myobj.mymethod)``
+    returns a reference whose lifetime is connected to the
+    lifetime of the object ``myobj``, rather than the lifetime
+    of the temporary method ``myobj.mymethod``.
+
+    """
+    if isinstance(listener, types.MethodType):
+        return weakref.WeakMethod(listener)
+    else:
+        return weakref.ref(listener)
 
 
 @provides(IExtensionRegistry)
@@ -61,9 +81,7 @@ class ExtensionRegistry(HasTraits):
         """ Add a listener for extensions being added or removed. """
 
         listeners = self._listeners.setdefault(extension_point_id, [])
-        listeners.append(safeweakref.ref(listener))
-
-        return
+        listeners.append(_saferef(listener))
 
     def add_extension_point(self, extension_point):
         """ Add an extension point. """
@@ -94,9 +112,7 @@ class ExtensionRegistry(HasTraits):
         """ Remove a listener for extensions being added or removed. """
 
         listeners = self._listeners.setdefault(extension_point_id, [])
-        listeners.remove(safeweakref.ref(listener))
-
-        return
+        listeners.remove(_saferef(listener))
 
     def remove_extension_point(self, extension_point_id):
         """ Remove an extension point. """

--- a/envisage/extension_registry.py
+++ b/envisage/extension_registry.py
@@ -39,6 +39,20 @@ def _saferef(listener):
     lifetime of the object ``myobj``, rather than the lifetime
     of the temporary method ``myobj.mymethod``.
 
+    Parameters
+    ----------
+    listener : callable
+        Listener to return a weak reference for. This can be
+        either a plain function, a bound method, or some other
+        form of callable.
+
+    Returns
+    -------
+    weakref.ref
+        A weak reference to the listener. This will be a ``weakref.WeakMethod``
+        object if the listener is an instance of ``types.MethodType``, and a
+        plain ``weakref.ref`` otherwise.
+
     """
     if isinstance(listener, types.MethodType):
         return weakref.WeakMethod(listener)

--- a/envisage/extension_registry.py
+++ b/envisage/extension_registry.py
@@ -83,6 +83,8 @@ class ExtensionRegistry(HasTraits):
         listeners = self._listeners.setdefault(extension_point_id, [])
         listeners.append(_saferef(listener))
 
+        return
+
     def add_extension_point(self, extension_point):
         """ Add an extension point. """
 
@@ -113,6 +115,8 @@ class ExtensionRegistry(HasTraits):
 
         listeners = self._listeners.setdefault(extension_point_id, [])
         listeners.remove(_saferef(listener))
+
+        return
 
     def remove_extension_point(self, extension_point_id):
         """ Remove an extension point. """

--- a/envisage/safeweakref.py
+++ b/envisage/safeweakref.py
@@ -24,7 +24,15 @@ import weakref
 
 class ref(object):
     """An implementation of weak references that works for bound methods and
-    caches them."""
+    caches them.
+
+    If ``object`` is a bound method, returns a ``weakref.WeakMethod`` for that
+    method. This ensures that the method is kept alive for the lifetime of the
+    object that it's bound to.
+
+    For any other ``object``, a normal ``weakref.ref`` is returned.
+
+    """
 
     _cache = weakref.WeakKeyDictionary()
 

--- a/envisage/safeweakref.py
+++ b/envisage/safeweakref.py
@@ -19,6 +19,7 @@ used as a drop-in replacement for 'weakref.ref'.
 """
 
 # Standard library imports.
+import warnings
 import weakref
 
 
@@ -33,10 +34,19 @@ class ref(object):
     For any other ``object``, a normal ``weakref.ref`` is returned.
 
     """
-
     _cache = weakref.WeakKeyDictionary()
 
     def __new__(cls, obj, callback=None):
+        warnings.warn(
+            message = (
+                "safeweakref.ref is deprecated, and will be removed in a "
+                "future version of Envisage"
+            ),
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+
+
         if getattr(obj, "__self__", None) is not None:  # Bound method
             # Caching
             func_cache = cls._cache.setdefault(obj.__self__, {})

--- a/envisage/safeweakref.py
+++ b/envisage/safeweakref.py
@@ -19,89 +19,12 @@ used as a drop-in replacement for 'weakref.ref'.
 """
 
 # Standard library imports.
-import sys
 import weakref
-
-# Because this module is intended as a drop-in replacement for weakref, we
-# import everything from that module here (so the user can do things like
-# "import safeweakref as weakref" etc).
-
-from weakref import *  # noqa: F403
-
-__all__ = weakref.__all__
-
-if hasattr(weakref, "WeakMethod"):
-    pass
-else:
-    # Backport WeakMethod from Python 3
-    class WeakMethod(weakref.ref):
-        """
-        A custom `weakref.ref` subclass which simulates a weak reference to
-        a bound method, working around the lifetime problem of bound methods.
-        """
-
-        __slots__ = "_func_ref", "_meth_type", "_alive", "__weakref__"
-
-        def __new__(cls, meth, callback=None):
-            try:
-                obj = meth.__self__
-                func = meth.__func__
-            except AttributeError:
-                raise TypeError(
-                    "argument should be a bound method, not {}".format(
-                        type(meth)
-                    )
-                )
-
-            def _cb(arg):
-                # The self-weakref trick is needed to avoid creating a
-                # reference cycle.
-                self = self_wr()
-                if self._alive:
-                    self._alive = False
-                    if callback is not None:
-                        callback(self)
-
-            self = weakref.ref.__new__(cls, obj, _cb)
-            self._func_ref = weakref.ref(func, _cb)
-            self._meth_type = type(meth)
-            self._alive = True
-            self_wr = weakref.ref(self)
-            return self
-
-        def __call__(self):
-            obj = weakref.ref.__call__(self)
-            func = self._func_ref()
-            if obj is None or func is None:
-                return None
-            return self._meth_type(func, obj)
-
-        def __eq__(self, other):
-            if isinstance(other, WeakMethod):
-                if not self._alive or not other._alive:
-                    return self is other
-                return (
-                    weakref.ref.__eq__(self, other)
-                    and self._func_ref == other._func_ref
-                )
-            return False
-
-        def __ne__(self, other):
-            if isinstance(other, WeakMethod):
-                if not self._alive or not other._alive:
-                    return self is not other
-                return (
-                    weakref.ref.__ne__(self, other)
-                    or self._func_ref != other._func_ref
-                )
-            return True
-
-        __hash__ = weakref.ref.__hash__
 
 
 class ref(object):
-    """ An implementation of weak references that works for bound methods and \
-    caches them. """
+    """An implementation of weak references that works for bound methods and
+    caches them."""
 
     _cache = weakref.WeakKeyDictionary()
 
@@ -111,7 +34,7 @@ class ref(object):
             func_cache = cls._cache.setdefault(obj.__self__, {})
             self = func_cache.get(obj.__func__)
             if self is None:
-                self = WeakMethod(obj, callback)
+                self = weakref.WeakMethod(obj, callback)
                 func_cache[obj.__func__] = self
             return self
         else:

--- a/envisage/safeweakref.py
+++ b/envisage/safeweakref.py
@@ -33,19 +33,20 @@ class ref(object):
 
     For any other ``object``, a normal ``weakref.ref`` is returned.
 
+    .. deprecated:: 5.0.0
+
     """
     _cache = weakref.WeakKeyDictionary()
 
     def __new__(cls, obj, callback=None):
         warnings.warn(
-            message = (
+            message=(
                 "safeweakref.ref is deprecated, and will be removed in a "
                 "future version of Envisage"
             ),
             category=DeprecationWarning,
             stacklevel=2,
         )
-
 
         if getattr(obj, "__self__", None) is not None:  # Bound method
             # Caching

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -216,7 +216,7 @@ class ExtensionPointListenerLifetimeTestCase(unittest.TestCase):
         obj = ListensToExtensionPoint(self.events)
         self.registry.add_extension_point_listener(obj.listener, "my.ep")
 
-        # At this point, the bound method 'obj.method_listener' no longer
+        # At this point, the bound method 'obj.listener' no longer
         # exists; it's already been garbage collected. Nevertheless, the
         # listener should still fire.
         with self.assertAppendsTo(self.events):
@@ -236,9 +236,9 @@ class ExtensionPointListenerLifetimeTestCase(unittest.TestCase):
         with self.assertAppendsTo(self.events):
             self.registry.set_extensions("my.ep", [1, 2, 3])
 
-        # 'obj.method_listener' here is a different object from the previous
-        # 'obj.method_listener'. But it compares equal to the original, and
-        # that should be enough for removing the listener to work.
+        # 'obj.listener' here is a different object from the previous
+        # 'obj.listener'. But it compares equal to the original, and that
+        # should be enough for removing the listener to work.
         self.registry.remove_extension_point_listener(obj.listener, "my.ep")
 
         with self.assertDoesNotModify(self.events):

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -141,6 +141,24 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         # Make sure we can get them.
         self.assertEqual([1, 2, 3], registry.get_extensions("my.ep"))
 
+    ###########################################################################
+    # Private interface.
+    ###########################################################################
+
+    def _create_extension_point(self, id, trait_type=List, desc=""):
+        """ Create an extension point. """
+
+        return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)
+
+
+class ExtensionPointListenerLifetimeTestCase(unittest.TestCase):
+    def setUp(self):
+        """ Prepares the test fixture before each test method is called. """
+
+        # We do all of the testing via the application to make sure it offers
+        # the same interface!
+        self.registry = Application(extension_registry=ExtensionRegistry())
+
     def test_nonmethod_listener_lifetime(self):
 
         self.events = []

--- a/envisage/tests/test_safeweakref.py
+++ b/envisage/tests/test_safeweakref.py
@@ -29,7 +29,8 @@ class SafeWeakrefTestCase(unittest.TestCase):
         f = Foo()
 
         # Get a weak reference to a bound method.
-        r = ref(f.method)
+        with self.assertWarns(DeprecationWarning):
+            r = ref(f.method)
         self.assertNotEqual(None, r())
 
         # Make sure we can call it.
@@ -49,7 +50,11 @@ class SafeWeakrefTestCase(unittest.TestCase):
 
         f = Foo()
 
-        self.assertIs(ref(f.method), ref(f.method))
+        with self.assertWarns(DeprecationWarning):
+            ref1 = ref(f.method)
+            ref2 = ref(f.method)
+
+        self.assertIs(ref1, ref2)
 
     def test_internal_cache_is_weak_too(self):
         # smell: Fragile test because we are reaching into the internals of the
@@ -72,7 +77,8 @@ class SafeWeakrefTestCase(unittest.TestCase):
 
         # Create a weak reference to the bound method and make sure that
         # exactly one item has been added to the cache.
-        r = ref(f.method)
+        with self.assertWarns(DeprecationWarning):
+            r = ref(f.method)
         self.assertEqual(len_cache + 1, len(cache))
 
         # Delete the instance!
@@ -92,8 +98,9 @@ class SafeWeakrefTestCase(unittest.TestCase):
         f = Foo()
 
         # Make sure that two references to the same method compare as equal.
-        r1 = ref(f.method)
-        r2 = ref(f.method)
+        with self.assertWarns(DeprecationWarning):
+            r1 = ref(f.method)
+            r2 = ref(f.method)
         self.assertEqual(r1, r2)
 
         # Make sure that a reference compares as unequal to non-references!
@@ -107,14 +114,16 @@ class SafeWeakrefTestCase(unittest.TestCase):
         f = Foo()
 
         # Make sure we can hash the references.
-        r1 = ref(f.method)
-        r2 = ref(f.method)
+        with self.assertWarns(DeprecationWarning):
+            r1 = ref(f.method)
+            r2 = ref(f.method)
 
         self.assertEqual(hash(r1), hash(r2))
 
         # Make sure we can hash non-bound methods.
-        r1 = ref(Foo)
-        r2 = ref(Foo)
+        with self.assertWarns(DeprecationWarning):
+            r1 = ref(Foo)
+            r2 = ref(Foo)
 
         self.assertEqual(hash(r1), hash(r2))
 
@@ -125,5 +134,19 @@ class SafeWeakrefTestCase(unittest.TestCase):
         f = Foo()
 
         # Get a weak reference to something that is not a bound method.
-        r = ref(f)
+        with self.assertWarns(DeprecationWarning):
+            r = ref(f)
         self.assertEqual(weakref.ref, type(r))
+
+    def test_deprecated(self):
+        class Foo(HasTraits):
+            def method(self):
+                pass
+
+        f = Foo()
+
+        with self.assertWarns(DeprecationWarning):
+            ref(f.method)
+
+        with self.assertWarns(DeprecationWarning):
+            ref(f)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
-exclude = examples, envisage/ui/single_project, envisage/safeweakref.py
+exclude = examples, envisage/ui/single_project
 ignore = E266, W503
 per-file-ignores = */api.py:F401


### PR DESCRIPTION
Some `safeweakref`-related cleanup, aimed at eventual removal of the `safeweakref` module.

- Don't try to make `safeweakref` a drop-in replacement for `weakref`: `safeweakref` no longer does `from weakref import *`
- Deprecate the existing `safeweakref.ref`
- Replace existing uses of `safeweakref` with a simpler, private version that still handles bound methods specially, but doesn't do the caching that `safeweakref` does
- Add tests for the deprecation of `safeweakref.ref`
- Add tests to cover the uses of that simpler replacement.
- Make `safeweakref` flake8-clean, and remove it from the flake8 exclusion list.

Closes #271