### PR TITLE
Fix complaints about 'l' as an identifier

### DIFF
--- a/envisage/tests/test_slice.py
+++ b/envisage/tests/test_slice.py
@@ -75,105 +75,105 @@ class SliceTestCase(unittest.TestCase):
         """ Prepares the test fixture before each test method is called. """
 
         class Foo(HasTraits):
-            l = List
+            elts = List
 
-        self.f = Foo(l=TEST_LIST)
-        self.f.on_trait_change(listener, "l_items")
+        self.f = Foo(elts=TEST_LIST)
+        self.f.on_trait_change(listener, "elts_items")
 
     def test_append(self):
         """ append """
 
-        self.f.l.append(99)
+        self.f.elts.append(99)
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_insert(self):
         """ insert """
 
-        self.f.l.insert(3, 99)
+        self.f.elts.insert(3, 99)
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_extend(self):
         """ extend """
 
-        self.f.l.extend([99, 100])
+        self.f.elts.extend([99, 100])
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_remove(self):
         """ remove """
 
-        self.f.l.remove(5)
+        self.f.elts.remove(5)
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_reverse(self):
         """ reverse """
 
-        self.f.l.reverse()
+        self.f.elts.reverse()
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_sort(self):
         """ sort """
 
-        self.f.l.sort()
+        self.f.elts.sort()
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_pop(self):
         """ remove """
 
-        self.f.l.pop()
+        self.f.elts.pop()
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_del_all(self):
         """ del all """
 
-        del self.f.l[:]
+        del self.f.elts[:]
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_assign_item(self):
         """ assign item """
 
-        self.f.l[3] = 99
+        self.f.elts[3] = 99
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_del_item(self):
         """ del item """
 
-        del self.f.l[3]
+        del self.f.elts[3]
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_assign_slice(self):
         """ assign slice """
 
-        self.f.l[2:4] = [88, 99]
+        self.f.elts[2:4] = [88, 99]
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_del_slice(self):
         """ del slice """
 
-        del self.f.l[2:5]
+        del self.f.elts[2:5]
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_assign_extended_slice(self):
         """ assign extended slice """
 
-        self.f.l[2:6:2] = [88, 99]
+        self.f.elts[2:6:2] = [88, 99]
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)
 
     def test_del_extended_slice(self):
         """ del extended slice """
 
-        del self.f.l[2:6:2]
+        del self.f.elts[2:6:2]
         # Make sure we successfully recreated the operation.
-        self.assertEqual(self.f.l, listener.clone)
+        self.assertEqual(self.f.elts, listener.clone)


### PR DESCRIPTION
Fix E741 complaints from flake8.

I'm in two minds about this one: I don't think I've ever been confused by use of `l` as a variable name, but I can see how it might depend on working environment. So let's fix it. 