### PR TITLE
Remove an unused import and bogus rationale for that import

### DIFF
--- a/envisage/ui/workbench/workbench_application.py
+++ b/envisage/ui/workbench/workbench_application.py
@@ -13,15 +13,6 @@
 import logging
 
 # Enthought library imports.
-#
-# fixme: The ordering of these imports is critical. We don't use traits UI in
-# this module, but it must be imported *before* any 'HasTraits' class whose
-# instances might want to have 'edit_traits' called on them.
-#
-# fixme: Just importing the package is enought (see above).
-import traitsui
-
-# Enthought library imports.
 from envisage.api import Application
 from pyface.api import AboutDialog, Dialog, GUI, ImageResource
 from pyface.api import SplashScreen


### PR DESCRIPTION
There's a heavily commented `import traitsui` in `workbench_application.py`. The comments state that `traitsui` must be imported before other parts of ETS, but don't give any indication why.

Moreover, since `import traitsui` is close to a no-op (all the fun side-effects and content come from `traitsui.api`), it's difficult to see how those comments could be true.

This PR removes the import and rationale.
