### PR TITLE
Import unittest directly instead of from unittest_tools

### DIFF
--- a/envisage/tests/test_class_load_hook.py
+++ b/envisage/tests/test_class_load_hook.py
@@ -8,10 +8,10 @@
 # Thanks for using Enthought open source!
 """ Tests for class load hooks. """
 
+import unittest
 
 from envisage.api import ClassLoadHook
 from traits.api import HasTraits
-from traits.testing.unittest_tools import unittest
 
 
 # This module's package.

--- a/envisage/tests/test_composite_plugin_manager.py
+++ b/envisage/tests/test_composite_plugin_manager.py
@@ -8,13 +8,13 @@
 # Thanks for using Enthought open source!
 """ Tests for the composite plugin manager. """
 
+import unittest
 
 from envisage.application import Application
 from envisage.composite_plugin_manager import CompositePluginManager
 from envisage.plugin_manager import PluginManager
 from envisage.plugin import Plugin
 from traits.api import Bool
-from traits.testing.unittest_tools import unittest
 
 
 class SimplePlugin(Plugin):

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -8,6 +8,8 @@
 # Thanks for using Enthought open source!
 """ Tests for the core plugin. """
 
+# Standard library imports
+import unittest
 
 # Major package imports.
 from pkg_resources import resource_filename
@@ -16,7 +18,6 @@ from pkg_resources import resource_filename
 from envisage.api import Application, ClassLoadHook, Plugin
 from envisage.api import ServiceOffer
 from traits.api import HasTraits, Int, Interface, List
-from traits.testing.unittest_tools import unittest
 
 
 # This module's package.

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -8,7 +8,7 @@
 # Thanks for using Enthought open source!
 """ Tests for the core plugin. """
 
-# Standard library imports
+# Standard library imports.
 import unittest
 
 # Major package imports.

--- a/envisage/tests/test_egg_based.py
+++ b/envisage/tests/test_egg_based.py
@@ -10,10 +10,9 @@
 
 
 from os.path import dirname, join
+import unittest
 
 import pkg_resources
-
-from traits.testing.unittest_tools import unittest
 
 
 class EggBasedTestCase(unittest.TestCase):

--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -13,11 +13,11 @@ from os.path import basename, dirname, join
 import shutil
 import tempfile
 import sys
+import unittest
 
 import pkg_resources
 
 from envisage.egg_basket_plugin_manager import EggBasketPluginManager
-from traits.testing.unittest_tools import unittest
 
 
 class EggBasketPluginManagerTestCase(unittest.TestCase):

--- a/envisage/tests/test_egg_plugin_manager.py
+++ b/envisage/tests/test_egg_plugin_manager.py
@@ -8,7 +8,7 @@
 # Thanks for using Enthought open source!
 """ Tests for the Egg plugin manager. """
 
-# Standard library imports
+# Standard library imports.
 import unittest
 
 # Enthought library imports.

--- a/envisage/tests/test_egg_plugin_manager.py
+++ b/envisage/tests/test_egg_plugin_manager.py
@@ -8,13 +8,14 @@
 # Thanks for using Enthought open source!
 """ Tests for the Egg plugin manager. """
 
+# Standard library imports
+import unittest
 
 # Enthought library imports.
 from envisage.api import EggPluginManager
 
 # Local imports.
 from .test_egg_based import EggBasedTestCase
-from traits.testing.unittest_tools import unittest
 
 
 class EggPluginManagerTestCase(EggBasedTestCase):

--- a/envisage/tests/test_extension_point.py
+++ b/envisage/tests/test_extension_point.py
@@ -8,12 +8,13 @@
 # Thanks for using Enthought open source!
 """ Tests for extension points. """
 
+# Standard library imports.
+import unittest
 
 # Enthought library imports.
 from envisage.api import Application, ExtensionPoint
 from envisage.api import ExtensionRegistry
 from traits.api import HasTraits, Int, List, TraitError
-from traits.testing.unittest_tools import unittest
 
 
 class TestBase(HasTraits):

--- a/envisage/tests/test_extension_point_binding.py
+++ b/envisage/tests/test_extension_point_binding.py
@@ -8,12 +8,13 @@
 # Thanks for using Enthought open source!
 """ Tests for extension point bindings. """
 
+# Standard library imports.
+import unittest
 
 # Enthought library imports.
 from envisage.api import ExtensionPoint
 from envisage.api import bind_extension_point
 from traits.api import HasTraits, List
-from traits.testing.unittest_tools import unittest
 
 # Local imports.
 from envisage.tests.mutable_extension_registry import MutableExtensionRegistry

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -8,9 +8,8 @@
 # Thanks for using Enthought open source!
 """ Tests for the events fired when extension points are changed. """
 
-
-# Enthought library imports.
-from traits.testing.unittest_tools import unittest
+# Standard library imports.
+import unittest
 
 # Local imports.
 from envisage.tests.test_application import (

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -8,12 +8,13 @@
 # Thanks for using Enthought open source!
 """ Tests for the base extension registry. """
 
+# Standard library imports
+import unittest
 
 # Enthought library imports.
 from envisage.api import Application, ExtensionPoint
 from envisage.api import ExtensionRegistry, UnknownExtensionPoint
 from traits.api import List
-from traits.testing.unittest_tools import unittest
 
 
 class ExtensionRegistryTestCase(unittest.TestCase):

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -8,7 +8,7 @@
 # Thanks for using Enthought open source!
 """ Tests for the base extension registry. """
 
-# Standard library imports
+# Standard library imports.
 import unittest
 
 # Enthought library imports.

--- a/envisage/tests/test_import_manager.py
+++ b/envisage/tests/test_import_manager.py
@@ -8,10 +8,11 @@
 # Thanks for using Enthought open source!
 """ Tests for the import manager. """
 
+# Standard library imports.
+import unittest
 
 # Enthought library imports.
 from envisage.api import Application, ImportManager
-from traits.testing.unittest_tools import unittest
 
 
 class ImportManagerTestCase(unittest.TestCase):

--- a/envisage/tests/test_package_plugin_manager.py
+++ b/envisage/tests/test_package_plugin_manager.py
@@ -10,9 +10,9 @@
 
 
 from os.path import dirname, join
+import unittest
 
 from envisage.package_plugin_manager import PackagePluginManager
-from traits.testing.unittest_tools import unittest
 
 
 class PackagePluginManagerTestCase(unittest.TestCase):

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -11,6 +11,7 @@
 
 # Standard library imports.
 from os.path import exists, join
+import unittest
 
 # Enthought library imports.
 from envisage.api import Application, ExtensionPoint
@@ -18,7 +19,6 @@ from envisage.api import IPluginActivator, Plugin, contributes_to
 from envisage.tests.ets_config_patcher import ETSConfigPatcher
 from traits.api import HasTraits, Instance, Int, Interface, List
 from traits.api import provides
-from traits.testing.unittest_tools import unittest
 
 
 def listener(obj, trait_name, old, new):

--- a/envisage/tests/test_plugin_manager.py
+++ b/envisage/tests/test_plugin_manager.py
@@ -9,10 +9,12 @@
 """ Tests for the plugin manager. """
 
 
+# Standard library imports.
+import unittest
+
 # Enthought library imports.
 from envisage.api import Plugin, PluginManager
 from traits.api import Bool
-from traits.testing.unittest_tools import unittest
 
 
 class SimplePlugin(Plugin):

--- a/envisage/tests/test_safeweakref.py
+++ b/envisage/tests/test_safeweakref.py
@@ -10,12 +10,12 @@
 
 
 # Standard library imports.
+import unittest
 import weakref
 
 # Enthought library imports.
 from envisage.safeweakref import ref
 from traits.api import HasTraits
-from traits.testing.unittest_tools import unittest
 
 
 class SafeWeakrefTestCase(unittest.TestCase):

--- a/envisage/tests/test_service.py
+++ b/envisage/tests/test_service.py
@@ -8,11 +8,12 @@
 # Thanks for using Enthought open source!
 """ Tests for the 'Service' trait type. """
 
+# Standard library imports.
+import unittest
 
 # Enthought library imports.
 from envisage.api import Application, Plugin, Service
 from traits.api import HasTraits, Instance
-from traits.testing.unittest_tools import unittest
 
 
 class TestApplication(Application):

--- a/envisage/tests/test_service_registry.py
+++ b/envisage/tests/test_service_registry.py
@@ -11,11 +11,11 @@
 
 # Standard library imports.
 import sys
+import unittest
 
 # Enthought library imports.
 from envisage.api import Application, ServiceRegistry, NoSuchServiceError
 from traits.api import HasTraits, Int, Interface, provides
-from traits.testing.unittest_tools import unittest
 
 
 # This module's package.

--- a/envisage/tests/test_slice.py
+++ b/envisage/tests/test_slice.py
@@ -13,10 +13,11 @@ we try to mimic trait list events when extensions are added or removed.
 
 """
 
+# Standard library imports.
+import unittest
 
 # Enthought library imports.
 from traits.api import HasTraits, List
-from traits.testing.unittest_tools import unittest
 
 
 # The starting list for all tests.

--- a/envisage/ui/action/tests/dummy_action_manager_builder.py
+++ b/envisage/ui/action/tests/dummy_action_manager_builder.py
@@ -8,12 +8,13 @@
 # Thanks for using Enthought open source!
 """ A menu builder that doesn't build real actions! """
 
+# Standard library imports.
+import unittest
 
 # Enthought library imports.
 from envisage.ui.action.api import AbstractActionManagerBuilder
 from pyface.action.api import Action, Group, MenuManager
 from pyface.action.api import MenuBarManager
-from traits.testing.unittest_tools import unittest
 
 
 class DummyActionManagerBuilder(AbstractActionManagerBuilder):

--- a/envisage/ui/action/tests/test_action_manager_builder.py
+++ b/envisage/ui/action/tests/test_action_manager_builder.py
@@ -8,9 +8,11 @@
 # Thanks for using Enthought open source!
 """ Tests for the action manager builder. """
 
+# Standard library imports.
+import unittest
+
 # Enthought library imports.
 from envisage.ui.action.api import Action, ActionSet, Group, Menu
-from traits.testing.unittest_tools import unittest
 
 # Local imports.
 from .dummy_action_manager_builder import DummyActionManagerBuilder


### PR DESCRIPTION
The `unittest_tools` imports dated from the days of Python 2.6 support, which was dropped long ago: they were needed for various `TestCase` features that were only added in Python 2.7.

This PR removes them.