### PR TITLE
Add Slack notification for Travis CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,7 @@ after_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov
   - edm run -- codecov
+
+notifications:
+  slack:
+    secure: XOXbiCa2wjxwYpRPPfib863y1jE2PiDBtsCZQUDPh3IrJhHAAGEPgcICbMYPkgKz3+6rqVvfwwj1Xictw4wI8dtvcqROz5iZek/14V3tDhPAp0iHBEvOibSFZP7VK6tZgVp7uTSc1p4bJd2GEX0yKMyaOdXCYQf42y6YYV97xNA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,5 @@ after_success:
 notifications:
   slack:
     secure: XOXbiCa2wjxwYpRPPfib863y1jE2PiDBtsCZQUDPh3IrJhHAAGEPgcICbMYPkgKz3+6rqVvfwwj1Xictw4wI8dtvcqROz5iZek/14V3tDhPAp0iHBEvOibSFZP7VK6tZgVp7uTSc1p4bJd2GEX0yKMyaOdXCYQf42y6YYV97xNA=
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This PR adds Slack notification to the Enthought internal #ets-bots Slack channel.

cf. enthought/traits#1074