### PR TITLE
Fix CI failures on Linux, Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     - libxkbcommon-x11-0
     - libxcb-icccm4
     - libxcb-image0
+    - libxcb-keysyms1
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     - libxcb-keysyms1
     - libxcb-randr0
     - libxcb-render-util0
+    - libxcb-xinerama0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     packages:
     - libxkbcommon-x11-0
     - libxcb-icccm4
-    - libxcb-image
+    - libxcb-image0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
     - libxcb-icccm4
     - libxcb-image0
     - libxcb-keysyms1
+    - libxcb-randr0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
   apt:
     packages:
     - libxkbcommon-x11-0
+    - libxcb-icccm4
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   global:
     - INSTALL_EDM_VERSION="2.0.0"
       PYTHONUNBUFFERED="1"
+      QT_DEBUG_PLUGINS="1"
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - libxcb-image0
     - libxcb-keysyms1
     - libxcb-randr0
+    - libxcb-render-util0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
     packages:
     - libxkbcommon-x11-0
     - libxcb-icccm4
+    - libxcb-image
 
 env:
   global:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 build: false
+image: Visual Studio 2019
 
 environment:
   global:


### PR DESCRIPTION
This PR fixes independent CI failures on Linux and Windows

- On Windows, force use of VS 2019, to avoid a test hang due to a bluetooth-related popup from PyQt5.
- On Linux, make sure necessary libxcb-* packages are installed.

~The continuous integration is unhappy again on Linux. This is a debugging PR intended to help track down what's wrong.~