### PR TITLE
Use edm 3.0.1 instead of 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 
 env:
   global:
-    - INSTALL_EDM_VERSION="2.0.0"
+    - INSTALL_EDM_VERSION="3.0.1"
       PYTHONUNBUFFERED="1"
       QT_DEBUG_PLUGINS="1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ image: Visual Studio 2019
 environment:
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "2.0.0"
+    INSTALL_EDM_VERSION: "3.0.1"
 
   matrix:
     - RUNTIME: '3.6'


### PR DESCRIPTION
3.0.1 is the latest version of edm. Note that on edm 3.0.1, the platform used on linux is `rh7-x86_64`, not `rh6-x86_64`. fixes #294 