### PR TITLE
Make TasksApplication.gui expect an IGUI interface, not a GUI instance

### DIFF
--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -24,7 +24,6 @@ from traits.api import (
     Int,
     List,
     Str,
-    Supports,
     Vetoable,
 )
 from traits.etsconfig.api import ETSConfig
@@ -61,7 +60,7 @@ class TasksApplication(Application):
     active_window = Instance("envisage.ui.tasks.task_window.TaskWindow")
 
     # The Pyface GUI for the application.
-    gui = Supports("pyface.i_gui.IGUI")
+    gui = Instance("pyface.i_gui.IGUI")
 
     # Icon for the whole application. Will be used to override all taskWindows
     # icons to have the same.

--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -24,6 +24,7 @@ from traits.api import (
     Int,
     List,
     Str,
+    Supports,
     Vetoable,
 )
 from traits.etsconfig.api import ETSConfig
@@ -60,7 +61,7 @@ class TasksApplication(Application):
     active_window = Instance("envisage.ui.tasks.task_window.TaskWindow")
 
     # The Pyface GUI for the application.
-    gui = Instance("pyface.gui.GUI")
+    gui = Supports("pyface.i_gui.IGUI")
 
     # Icon for the whole application. Will be used to override all taskWindows
     # icons to have the same.

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -32,7 +32,7 @@ class DummyGUI(HasTraits):
     pass
 
 
-@requires_gui
+
 class TestTasksApplication(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
@@ -128,6 +128,7 @@ class TestTasksApplication(unittest.TestCase):
         self.assertEqual(state.previous_window_layouts[0].size, (492, 743))
 
     def test_gui_needs_GUI_instance(self):
-        with self.assertRaises(TraitError):
-            app = TasksApplication()
-            app.gui = DummyGUI()
+        # Trivial test where we simply set the trait
+        # and the test passes because no errors are raised.
+        app = TasksApplication()
+        app.gui = DummyGUI()

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -18,11 +18,18 @@ import pkg_resources
 
 from envisage.ui.tasks.api import TasksApplication
 from envisage.ui.tasks.tasks_application import DEFAULT_STATE_FILENAME
+from pyface.i_gui import IGUI
+from traits.api import HasTraits, provides, TraitError
 
 requires_gui = unittest.skipIf(
     os.environ.get("ETS_TOOLKIT", "none") in {"null", "none"},
     "Test requires a non-null GUI backend",
 )
+
+
+@provides(IGUI)
+class DummyGUI(HasTraits):
+    pass
 
 
 @requires_gui
@@ -119,3 +126,8 @@ class TestTasksApplication(unittest.TestCase):
 
         state = app._state
         self.assertEqual(state.previous_window_layouts[0].size, (492, 743))
+
+    def test_gui_needs_GUI_instance(self):
+        with self.assertRaises(TraitError):
+            app = TasksApplication()
+            app.gui = DummyGUI()

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -19,7 +19,7 @@ import pkg_resources
 from envisage.ui.tasks.api import TasksApplication
 from envisage.ui.tasks.tasks_application import DEFAULT_STATE_FILENAME
 from pyface.i_gui import IGUI
-from traits.api import HasTraits, provides, TraitError
+from traits.api import HasTraits, provides
 
 requires_gui = unittest.skipIf(
     os.environ.get("ETS_TOOLKIT", "none") in {"null", "none"},
@@ -32,7 +32,7 @@ class DummyGUI(HasTraits):
     pass
 
 
-
+@requires_gui
 class TestTasksApplication(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -127,7 +127,7 @@ class TestTasksApplication(unittest.TestCase):
         state = app._state
         self.assertEqual(state.previous_window_layouts[0].size, (492, 743))
 
-    def test_gui_needs_GUI_instance(self):
+    def test_gui_trait_expects_IGUI_interface(self):
         # Trivial test where we simply set the trait
         # and the test passes because no errors are raised.
         app = TasksApplication()


### PR DESCRIPTION
Note that this is already how the `GUIApplication` behaves. I'm not sure why the `TasksApplication` behaved differently earlier. https://github.com/enthought/envisage/blob/8eddfc402f2be38bf8774e48ab31a118d8dcb565/envisage/ui/gui_application.py#L43-L44