### PR TITLE
Add a new shell click command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -264,6 +264,23 @@ def install(edm, runtime, toolkit, environment, editable, source):
 @runtime_option
 @toolkit_option
 @environment_option
+def shell(edm, runtime, toolkit, environment):
+    """ Create a shell into the EDM development environment
+    (aka 'activate' it).
+
+    """
+    parameters = get_parameters(edm, runtime, toolkit, environment)
+    commands = [
+        "{edm} shell -e {environment}",
+    ]
+    execute(commands, parameters)
+
+
+@cli.command()
+@edm_option
+@runtime_option
+@toolkit_option
+@environment_option
 def flake8(edm, runtime, toolkit, environment):
     """ Run a flake8 check in a given environment.
 


### PR DESCRIPTION
This PR adds a new `shell` click command - which when run activates the development environment for traits. The usual command line options are available to choose the environment name and the runtime version/toolkit of the development environment. Underneath the hood, the click command just uses the `edm shell` command with the appropriate environment name, which is why the docstring for the click command is _almost_ the same as that of `edm shell`.
