### PR TITLE
Fix the attractors tasks application example

### DIFF
--- a/examples/plugins/tasks/attractors/README.txt
+++ b/examples/plugins/tasks/attractors/README.txt
@@ -1,0 +1,12 @@
+Welcome to the attractors example.
+
+To run the application::
+
+  ``python -m attractors.run``
+
+from the ``tasks/`` directory.
+
+Note that this example application depends on the following additional
+packages::
+
+  numpy, scipy, chaco, mayavi

--- a/examples/plugins/tasks/attractors/attractors_application.py
+++ b/examples/plugins/tasks/attractors/attractors_application.py
@@ -4,7 +4,7 @@ from pyface.tasks.api import TaskWindowLayout
 from traits.api import Bool, Instance, List, Property
 
 # Local imports.
-from attractors_preferences import (
+from attractors.attractors_preferences import (
     AttractorsPreferences,
     AttractorsPreferencesPane,
 )

--- a/examples/plugins/tasks/attractors/attractors_plugin.py
+++ b/examples/plugins/tasks/attractors/attractors_plugin.py
@@ -39,13 +39,13 @@ class AttractorsPlugin(Plugin):
         return ["file://" + filename]
 
     def _preferences_panes_default(self):
-        from attractors_preferences import AttractorsPreferencesPane
+        from attractors.attractors_preferences import AttractorsPreferencesPane
 
         return [AttractorsPreferencesPane]
 
     def _tasks_default(self):
-        from visualize_2d_task import Visualize2dTask
-        from visualize_3d_task import Visualize3dTask
+        from attractors.visualize_2d_task import Visualize2dTask
+        from attractors.visualize_3d_task import Visualize3dTask
 
         return [
             TaskFactory(

--- a/examples/plugins/tasks/attractors/model/henon.py
+++ b/examples/plugins/tasks/attractors/model/henon.py
@@ -15,7 +15,7 @@ from traits.api import (
 from traitsui.api import Item, View
 
 # Local imports.
-from i_plottable_2d import IPlottable2d
+from attractors.model.i_plottable_2d import IPlottable2d
 
 
 @provides(IPlottable2d)
@@ -62,7 +62,7 @@ class Henon(HasTraits):
     def _get_points(self):
         point = self.initial_point
         points = zeros((self.steps, 2))
-        for i in xrange(self.steps):
+        for i in range(self.steps):
             x, y = points[i] = point
             point = array([y + 1 - self.a * x ** 2, self.b * x])
         return points

--- a/examples/plugins/tasks/attractors/model/i_plottable_2d.py
+++ b/examples/plugins/tasks/attractors/model/i_plottable_2d.py
@@ -2,7 +2,7 @@
 from traits.api import Enum, Str
 
 # Local imports.
-from i_model_2d import IModel2d
+from attractors.model.i_model_2d import IModel2d
 
 
 class IPlottable2d(IModel2d):

--- a/examples/plugins/tasks/attractors/model/lorenz.py
+++ b/examples/plugins/tasks/attractors/model/lorenz.py
@@ -18,8 +18,8 @@ from traits.api import (
 from traitsui.api import View, Item
 
 # Local imports
-from i_model_3d import IModel3d, IModel3dIPlottable2dMixin
-from i_plottable_2d import IPlottable2d
+from attractors.model.i_model_3d import IModel3d, IModel3dIPlottable2dMixin
+from attractors.model.i_plottable_2d import IPlottable2d
 
 
 @provides(IModel3d)

--- a/examples/plugins/tasks/attractors/model/rossler.py
+++ b/examples/plugins/tasks/attractors/model/rossler.py
@@ -18,8 +18,8 @@ from traits.api import (
 from traitsui.api import View, Item
 
 # Local imports
-from i_model_3d import IModel3d, IModel3dIPlottable2dMixin
-from i_plottable_2d import IPlottable2d
+from attractors.model.i_model_3d import IModel3d, IModel3dIPlottable2dMixin
+from attractors.model.i_plottable_2d import IPlottable2d
 
 
 @provides(IModel3d)

--- a/examples/plugins/tasks/attractors/plot_2d_pane.py
+++ b/examples/plugins/tasks/attractors/plot_2d_pane.py
@@ -13,7 +13,7 @@ from traits.api import (
 from traitsui.api import EnumEditor, HGroup, Item, Label, View
 
 # Local imports.
-from model.i_plottable_2d import IPlottable2d
+from attractors.model.i_plottable_2d import IPlottable2d
 
 
 class Plot2dPane(TraitsTaskPane):

--- a/examples/plugins/tasks/attractors/plot_3d_pane.py
+++ b/examples/plugins/tasks/attractors/plot_3d_pane.py
@@ -15,7 +15,7 @@ from traitsui.api import EnumEditor, HGroup, Item, Label, View
 from tvtk.pyface.scene_editor import SceneEditor
 
 # Local imports.
-from model.i_model_3d import IModel3d
+from attractors.model.i_model_3d import IModel3d
 
 
 class Plot3dPane(TraitsTaskPane):

--- a/examples/plugins/tasks/attractors/run.py
+++ b/examples/plugins/tasks/attractors/run.py
@@ -4,10 +4,10 @@ import logging
 # Plugin imports.
 from envisage.core_plugin import CorePlugin
 from envisage.ui.tasks.tasks_plugin import TasksPlugin
-from attractors_plugin import AttractorsPlugin
+from attractors.attractors_plugin import AttractorsPlugin
 
 # Local imports.
-from attractors_application import AttractorsApplication
+from attractors.attractors_application import AttractorsApplication
 
 
 def main(argv):

--- a/examples/plugins/tasks/attractors/visualize_2d_task.py
+++ b/examples/plugins/tasks/attractors/visualize_2d_task.py
@@ -4,10 +4,10 @@ from pyface.tasks.api import Task, TaskLayout, Tabbed, PaneItem
 from traits.api import Any, Instance, List, adapt
 
 # Local imports.
-from model.i_plottable_2d import IPlottable2d
-from model_config_pane import ModelConfigPane
-from model_help_pane import ModelHelpPane
-from plot_2d_pane import Plot2dPane
+from attractors.model.i_plottable_2d import IPlottable2d
+from attractors.model_config_pane import ModelConfigPane
+from attractors.model_help_pane import ModelHelpPane
+from attractors.plot_2d_pane import Plot2dPane
 
 
 class Visualize2dTask(Task):
@@ -70,9 +70,9 @@ class Visualize2dTask(Task):
         )
 
     def _models_default(self):
-        from model.henon import Henon
-        from model.lorenz import Lorenz
-        from model.rossler import Rossler
+        from attractors.model.henon import Henon
+        from attractors.model.lorenz import Lorenz
+        from attractors.model.rossler import Rossler
 
         models = [Henon(), Lorenz(), Rossler()]
 

--- a/examples/plugins/tasks/attractors/visualize_3d_task.py
+++ b/examples/plugins/tasks/attractors/visualize_3d_task.py
@@ -4,9 +4,9 @@ from pyface.tasks.api import Task, TaskLayout, Tabbed, PaneItem
 from traits.api import Any, List
 
 # Local imports.
-from model_config_pane import ModelConfigPane
-from model_help_pane import ModelHelpPane
-from plot_3d_pane import Plot3dPane
+from attractors.model_config_pane import ModelConfigPane
+from attractors.model_help_pane import ModelHelpPane
+from attractors.plot_3d_pane import Plot3dPane
 
 
 class Visualize3dTask(Task):
@@ -69,8 +69,8 @@ class Visualize3dTask(Task):
         )
 
     def _models_default(self):
-        from model.lorenz import Lorenz
-        from model.rossler import Rossler
+        from attractors.model.lorenz import Lorenz
+        from attractors.model.rossler import Rossler
 
         return [Lorenz(), Rossler()]
 

--- a/examples/plugins/tasks/index.rst
+++ b/examples/plugins/tasks/index.rst
@@ -4,7 +4,7 @@ To run the application::
 
   python -m attractors.run
 
-from the ``tasks/`` directory.
+from this directory.
 
 Note that this example application depends on the following additional
 packages::

--- a/examples/plugins/tasks/index.rst
+++ b/examples/plugins/tasks/index.rst
@@ -2,7 +2,7 @@ Welcome to the attractors example.
 
 To run the application::
 
-  ``python -m attractors.run``
+  python -m attractors.run
 
 from the ``tasks/`` directory.
 


### PR DESCRIPTION
The fixes are mostly trivial - involving updating implicit imports to explicit imports.

To be able to run this example, you will need to install `numpy`, `scipy`, `mayavi` and `chaco` in the envisage devenv and then do `python -m attractors.run` from the `examples/plugins/tasks` directory.