### PR TITLE
create and fill plugin subpackage api modules

### DIFF
--- a/envisage/plugins/event_manager/api.py
+++ b/envisage/plugins/event_manager/api.py
@@ -7,11 +7,4 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-from envisage.plugins.ipython_kernel.actions import StartQtConsoleAction
-from envisage.plugins.ipython_kernel.internal_ipkernel import InternalIPKernel
-from envisage.plugins.ipython_kernel.ipython_kernel_plugin import (
-    IPythonKernelPlugin, IPYTHON_KERNEL_PROTOCOL,
-)
-from envisage.plugins.ipython_kernel.ipython_kernel_ui_plugin import (
-    IPythonKernelUIPlugin,
-)
+from envisage.plugins.event_manager.plugin import EventManagerPlugin

--- a/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
+++ b/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py
@@ -35,9 +35,7 @@ if ipykernel_available:
     import tornado.ioloop
     import zmq
 
-    from envisage.plugins.ipython_kernel.internal_ipkernel import (
-        InternalIPKernel,
-    )
+    from envisage.plugins.ipython_kernel.api import InternalIPKernel
 
 
 @unittest.skipUnless(

--- a/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
+++ b/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
@@ -31,13 +31,13 @@ else:
     ipykernel_available = True
 
 if ipykernel_available:
-    from envisage.plugins.ipython_kernel.internal_ipkernel import (
+    from envisage.plugins.ipython_kernel.api import (
         InternalIPKernel,
+        IPythonKernelPlugin,
+        IPYTHON_KERNEL_PROTOCOL,
     )
     from envisage.plugins.ipython_kernel.ipython_kernel_plugin import (
-        IPYTHON_KERNEL_PROTOCOL,
         IPYTHON_NAMESPACE,
-        IPythonKernelPlugin,
     )
 
 

--- a/envisage/tests/test_ids.py
+++ b/envisage/tests/test_ids.py
@@ -12,9 +12,7 @@ import unittest
 
 import envisage.ids
 from envisage.core_plugin import CorePlugin
-from envisage.plugins.ipython_kernel.ipython_kernel_plugin import (
-    IPythonKernelPlugin,
-)
+from envisage.plugins.ipython_kernel.api import IPythonKernelPlugin
 from envisage.plugins.python_shell.python_shell_plugin import PythonShellPlugin
 from envisage.ui.tasks.tasks_plugin import TasksPlugin
 

--- a/examples/plugins/tasks/ipython_kernel/example.py
+++ b/examples/plugins/tasks/ipython_kernel/example.py
@@ -4,12 +4,10 @@ import logging
 # Enthought library imports.
 from envisage.api import Plugin
 from envisage.core_plugin import CorePlugin
-from envisage.plugins.ipython_kernel.ipython_kernel_ui_plugin import (
-    IPythonKernelUIPlugin,
-)
 from envisage.plugins.ipython_kernel.api import (
     IPythonKernelPlugin,
     IPYTHON_KERNEL_PROTOCOL,
+    IPythonKernelUIPlugin,
 )
 from envisage.ui.tasks.api import TasksApplication, TaskFactory
 from envisage.ui.tasks.tasks_plugin import TasksPlugin


### PR DESCRIPTION
fixes #306 

This PR creates a new `envisage.plugins.event_manager.api` module and populates it with the relevant plugin class.  It also adds to the existing `envisage.plugins.ipython_kernel.api` module to import all the classes listed in the issue 306 description.  Finally, it imports from the api module in tests/examples.