### PR TITLE
Add more meaningful reprs for Plugin / Service classes

### DIFF
--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -154,7 +154,7 @@ class ExtensionPoint(TraitType):
 
     def __repr__(self):
         """ String representation of an ExtensionPoint object """
-        return "ExtensionPoint(id={})".format(self.id)
+        return "ExtensionPoint(id={!r})".format(self.id)
 
     ###########################################################################
     # 'TraitType' interface.

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -440,4 +440,4 @@ class Plugin(ExtensionProvider):
 
     def __repr__(self):
         """ String representation of a Plugin object """
-        return "Plugin(id={}, name={})".format(self.id, self.name)
+        return "Plugin(id={!r}, name={!r})".format(self.id, self.name)

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -188,7 +188,9 @@ class Plugin(ExtensionProvider):
         """ Trait initializer. """
 
         id = "%s.%s" % (type(self).__module__, type(self).__name__)
-        logger.warning("plugin %s has no Id - using <%s>" % (self, id))
+        logger.warning(
+            "plugin %s has no Id - using <%s>" % (object.__repr__(self), id)
+        )
 
         return id
 
@@ -196,7 +198,9 @@ class Plugin(ExtensionProvider):
         """ Trait initializer. """
 
         name = camel_case_to_words(type(self).__name__)
-        logger.warning("plugin %s has no name - using <%s>" % (self, name))
+        logger.warning(
+            "plugin %s has no name - using <%s>" % (object.__repr__(self), name)
+        )
 
         return name
 
@@ -427,3 +431,11 @@ class Plugin(ExtensionProvider):
             return getattr(self, trait_name)
 
         return self.application.register_service(protocol, factory)
+
+    ###########################################################################
+    # 'object' interface.
+    ###########################################################################
+
+    def __repr__(self):
+        """ String representation of a Plugin object """
+        return "Plugin(id={}, name={})".format(self.id, self.name)

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -189,7 +189,8 @@ class Plugin(ExtensionProvider):
 
         id = "%s.%s" % (type(self).__module__, type(self).__name__)
         logger.warning(
-            "plugin %s has no Id - using <%s>" % (object.__repr__(self), id)
+            "plugin {} has no Id - using <{}>".format(
+                object.__repr__(self), id)
         )
 
         return id
@@ -199,7 +200,8 @@ class Plugin(ExtensionProvider):
 
         name = camel_case_to_words(type(self).__name__)
         logger.warning(
-            "plugin %s has no name - using <%s>" % (object.__repr__(self), name)
+            "plugin {} has no name - using <{}>".format(
+                object.__repr__(self), name)
         )
 
         return name

--- a/envisage/service.py
+++ b/envisage/service.py
@@ -56,7 +56,7 @@ class Service(TraitType):
 
     def __repr__(self):
         """ String representation of a Service object """
-        return "Service(protocol={})".format(self._protocol)
+        return "Service(protocol={!r})".format(self._protocol)
 
     ###########################################################################
     # 'TraitType' interface.

--- a/envisage/service.py
+++ b/envisage/service.py
@@ -54,6 +54,10 @@ class Service(TraitType):
 
         return
 
+    def __repr__(self):
+        """ String representation of a Service object """
+        return "Service(protocol={})".format(self._protocol)
+
     ###########################################################################
     # 'TraitType' interface.
     ###########################################################################

--- a/envisage/tests/test_extension_point.py
+++ b/envisage/tests/test_extension_point.py
@@ -230,7 +230,7 @@ class ExtensionPointTestCase(unittest.TestCase):
 
     def test_extension_point_str_representation(self):
         """ test the string representation of the extension point """
-        ep_repr = "ExtensionPoint(id={})"
+        ep_repr = "ExtensionPoint(id={!r})"
         ep = self._create_extension_point("my.ep")
         self.assertEqual(ep_repr.format("my.ep"), str(ep))
         self.assertEqual(ep_repr.format("my.ep"), repr(ep))

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -423,3 +423,10 @@ class PluginTestCase(unittest.TestCase):
 
         application = Application(plugins=[PluginA()])
         application.get_extensions("bob")
+
+    def test_plugin_str_representation(self):
+        """ test the string representation of the plugin """
+        plugin_repr = "Plugin(id={}, name={})"
+        plugin = Plugin(id="Fred", name="Wilma")
+        self.assertEqual(plugin_repr.format("Fred", "Wilma"), str(plugin))
+        self.assertEqual(plugin_repr.format("Fred", "Wilma"), repr(plugin))

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -426,7 +426,7 @@ class PluginTestCase(unittest.TestCase):
 
     def test_plugin_str_representation(self):
         """ test the string representation of the plugin """
-        plugin_repr = "Plugin(id={}, name={})"
+        plugin_repr = "Plugin(id={!r}, name={!r})"
         plugin = Plugin(id="Fred", name="Wilma")
         self.assertEqual(plugin_repr.format("Fred", "Wilma"), str(plugin))
         self.assertEqual(plugin_repr.format("Fred", "Wilma"), repr(plugin))

--- a/envisage/tests/test_service.py
+++ b/envisage/tests/test_service.py
@@ -73,3 +73,14 @@ class ServiceTestCase(unittest.TestCase):
         b = Bar()
         with self.assertRaises(ValueError):
             getattr(b, "foo")
+
+    def test_service_str_representation(self):
+        """ test the string representation of the service """
+
+        class Foo(HasTraits):
+            pass
+
+        service_repr = "Service(protocol={})"
+        service = Service(Foo)
+        self.assertEqual(service_repr.format(Foo), str(service))
+        self.assertEqual(service_repr.format(Foo), repr(service))

--- a/envisage/tests/test_service.py
+++ b/envisage/tests/test_service.py
@@ -80,7 +80,7 @@ class ServiceTestCase(unittest.TestCase):
         class Foo(HasTraits):
             pass
 
-        service_repr = "Service(protocol={})"
+        service_repr = "Service(protocol={!r})"
         service = Service(Foo)
         self.assertEqual(service_repr.format(Foo), str(service))
         self.assertEqual(service_repr.format(Foo), repr(service))


### PR DESCRIPTION
fixes #208 

This PR follows the lead of #142 by making the reprs for `Plugin` and `Service` be
`"Plugin(id={!r}, name={!r})".format(self.id, self.name)` and `"Service(protocol={!r})".format(self._protocol)` respectively.  It also adds simple tests to verify these work as expected.  It is very possible that something other than `self.id` and `self.name` for `Plugin` and `self._protocol` for `Service` may be more meaningful / useful for debugging envisage applications.  If a reviewer finds that to be the case I am happy to modify.

Also, the `Service` repr is a little ugly now (although more informative) as it uses the repr of the protocol inside its own repr.  Especially in cases where protocol has a noisy/long repr.  For example in the test case added this becomes `Service(protocol=<class 'test_service.ServiceTestCase.test_service_str_representation.<locals>.Foo'>)`.  Maybe it is better to change this so the repr would just be: `Service(protocol=Foo)`? But then again sometimes having the full object path maybe useful?  I'm not sure, and any advice is welcome!

Also, note that the default methods for `name` and `id` issue a warning, e.g.
`logger.warning("plugin %s has no Id - using <%s>" % (self, id))` but this attempts to use `self` in the string, which triggers an infinite recursion loop as now `__repr__` is overridden to use `name` and `id`.  So this warning is updated to use the default repr: `object.__repr__(self)`