### PR TITLE
Document extra dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,20 @@ framework. This project contains no plug-ins. You are free to use:
 Prerequisites
 -------------
 
-The supported versions of Python are Python >= 3.5.
+The supported versions of Python are Python >= 3.5.  Envisage requires:
 
 * `apptools <https://github.com/enthought/apptools>`_
 * `traits <https://github.com/enthought/traits>`_
+
+Envisage has the following optional dependencies:
+
+* `Ipykernel <https://github.com/ipython/ipykernel>`_
+* `Pyface <https://https://github.com/enthought/pyface>`_
+* `TraitsUI <https://https://github.com/enthought/traitsui>`_
+
+To build the full documentation one needs:
+
+* `Sphinx <https://pypi.org/project/Sphinx>`_ version 1.8 or later.
+* The `Enthought Sphinx Theme <https://pypi.org/project/enthought-sphinx-theme>`_.
+  (A version of the documentation can be built without this, but
+  some formatting may be incorrect.)

--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,12 @@ The supported versions of Python are Python >= 3.5.  Envisage requires:
 
 Envisage has the following optional dependencies:
 
-* `Ipykernel <https://github.com/ipython/ipykernel>`_
+* `Ipykernel <https://pypi.org/project/ipykernel/>`_
+* `Tornado <https://pypi.org/project/tornado>`_
 * `Pyface <https://github.com/enthought/pyface>`_
 * `TraitsUI <https://github.com/enthought/traitsui>`_
 
 To build the full documentation one needs:
 
-* `Sphinx <https://pypi.org/project/Sphinx>`_ version 1.8 or later.
+* `Sphinx <https://pypi.org/project/Sphinx>`_ version 2.1 or later.
 * The `Enthought Sphinx Theme <https://pypi.org/project/enthought-sphinx-theme>`_.

--- a/README.rst
+++ b/README.rst
@@ -39,15 +39,15 @@ Prerequisites
 
 The supported versions of Python are Python >= 3.5.  Envisage requires:
 
-* `apptools <https://github.com/enthought/apptools>`_
-* `traits <https://github.com/enthought/traits>`_
+* `apptools <https://pypi.org/project/apptools/>`_
+* `traits <https://pypi.org/project/traits/>`_
 
 Envisage has the following optional dependencies:
 
 * `Ipykernel <https://pypi.org/project/ipykernel/>`_
 * `Tornado <https://pypi.org/project/tornado>`_
-* `Pyface <https://github.com/enthought/pyface>`_
-* `TraitsUI <https://github.com/enthought/traitsui>`_
+* `Pyface <https://pypi.org/project/pyface/>`_
+* `TraitsUI <https://pypi.org/project/traitsui/>`_
 
 To build the full documentation one needs:
 

--- a/README.rst
+++ b/README.rst
@@ -52,5 +52,3 @@ To build the full documentation one needs:
 
 * `Sphinx <https://pypi.org/project/Sphinx>`_ version 1.8 or later.
 * The `Enthought Sphinx Theme <https://pypi.org/project/enthought-sphinx-theme>`_.
-  (A version of the documentation can be built without this, but
-  some formatting may be incorrect.)

--- a/README.rst
+++ b/README.rst
@@ -45,8 +45,8 @@ The supported versions of Python are Python >= 3.5.  Envisage requires:
 Envisage has the following optional dependencies:
 
 * `Ipykernel <https://github.com/ipython/ipykernel>`_
-* `Pyface <https://https://github.com/enthought/pyface>`_
-* `TraitsUI <https://https://github.com/enthought/traitsui>`_
+* `Pyface <https://github.com/enthought/pyface>`_
+* `TraitsUI <https://github.com/enthought/traitsui>`_
 
 To build the full documentation one needs:
 

--- a/setup.py
+++ b/setup.py
@@ -294,6 +294,7 @@ if __name__ == "__main__":
             ]
         },
         install_requires=["apptools", "setuptools", "traits"],
+        extras_require=["ipykernel", "pyface", "tornado", "traitsui"],
         license="BSD",
         packages=find_packages(),
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,9 @@ if __name__ == "__main__":
         },
         install_requires=["apptools", "setuptools", "traits"],
         extras_require={
-            "ipython": ["ipykernel"],
+            "docs": ["enthought-sphinx-theme", "Sphinx>=2.1.0,!=3.2.0"],
+            "ipython": ["ipykernel", "tornado"],
+            "test": ["coverage", "flake8"],
             "ui": ["pyface", "traitsui"],
         },
         license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -295,9 +295,9 @@ if __name__ == "__main__":
         },
         install_requires=["apptools", "setuptools", "traits"],
         extras_require={
-            "ipykernel" : ["ipykernel"],
-            "pyface" : ["pyface"],
-            "traitsui" : ["traitsui"]
+            "ipykernel": ["ipykernel"],
+            "pyface": ["pyface"],
+            "traitsui": ["traitsui"]
         },
         license="BSD",
         packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -295,9 +295,8 @@ if __name__ == "__main__":
         },
         install_requires=["apptools", "setuptools", "traits"],
         extras_require={
-            "ipykernel": ["ipykernel"],
-            "pyface": ["pyface"],
-            "traitsui": ["traitsui"]
+            "ipython": ["ipykernel"],
+            "ui": ["pyface", "traitsui"],
         },
         license="BSD",
         packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
             ]
         },
         install_requires=["apptools", "setuptools", "traits"],
-        extras_require=["ipykernel", "pyface", "tornado", "traitsui"],
+        extras_require=["ipykernel", "pyface", "traitsui"],
         license="BSD",
         packages=find_packages(),
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -294,7 +294,11 @@ if __name__ == "__main__":
             ]
         },
         install_requires=["apptools", "setuptools", "traits"],
-        extras_require=["ipykernel", "pyface", "traitsui"],
+        extras_require={
+            "ipykernel" : ["ipykernel"],
+            "pyface" : ["pyface"],
+            "traitsui" : ["traitsui"]
+        },
         license="BSD",
         packages=find_packages(),
         package_data={


### PR DESCRIPTION
fixes #126 

This PR adds `extras_require` to `setup.py` and also updates the readme to mention the optional dependencies.

The issue originally mentioned `tornado` but I am not sure this is still really needed?  `tornado` is listed as a required dependency of `ipykernel` and the only occurrences of "tornado" in envisage are:
https://github.com/enthought/envisage/blob/8eddfc402f2be38bf8774e48ab31a118d8dcb565/envisage/plugins/ipython_kernel/kernelapp.py#L76-L94
https://github.com/enthought/envisage/blob/1eccd8074c1bc0661b64fba287cc88add446ada4/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py#L29-L35
and
https://github.com/enthought/envisage/blob/1eccd8074c1bc0661b64fba287cc88add446ada4/envisage/plugins/ipython_kernel/tests/test_internal_ipkernel.py#L242-L244

It also may be worth adding more details to the readme about what the optional dependencies are useful for / that the required dependencies are needed for the core envisage package.  I was not sure how much to say here, and other enthought package readmes seem to be pretty brief.