### PR TITLE
TST: Switch on default warning flag for CI test command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -304,7 +304,7 @@ def test(edm, runtime, toolkit, environment):
     environ["PYTHONUNBUFFERED"] = "1"
     commands = [
         (
-            "{edm} run -e {environment} -- "
+            "{edm} run -e {environment} -- python -W default -m "
             "coverage run -p -m unittest discover -v envisage"
         ),
     ]


### PR DESCRIPTION
fixes #311 

This PR makes the exact same fix that was done in https://github.com/enthought/traitsui/pull/1059.  It adds the adds the `-W default` flag.