### PR TITLE
Trivial flake8 fixes for envisage.ui.single_project

### DIFF
--- a/envisage/ui/single_project/action/api.py
+++ b/envisage/ui/single_project/action/api.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 from .new_project_action import NewProjectAction
 from .open_project_action import OpenProjectAction

--- a/envisage/ui/single_project/action/close_project_action.py
+++ b/envisage/ui/single_project/action/close_project_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action to close the current project.  This is only enabled when
     there is a current project.

--- a/envisage/ui/single_project/action/configure_action.py
+++ b/envisage/ui/single_project/action/configure_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action that configures an item in the project tree. """
 

--- a/envisage/ui/single_project/action/new_project_action.py
+++ b/envisage/ui/single_project/action/new_project_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action that creates a new project. """
 

--- a/envisage/ui/single_project/action/open_project_action.py
+++ b/envisage/ui/single_project/action/open_project_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action that opens a project. """
 

--- a/envisage/ui/single_project/action/rename_action.py
+++ b/envisage/ui/single_project/action/rename_action.py
@@ -36,9 +36,9 @@ class RenameAction(ProjectAction):
     # enabled if there is exactly ONE item in the selection and it is editable.
 
 
-##     ###########################################################################
+##     ########################################################################
 ##     # 'Action' interface.
-##     ###########################################################################
+##     ########################################################################
 
 ##     def refresh(self):
 ##         """ Refresh the enabled/disabled state of the action etc.

--- a/envisage/ui/single_project/action/rename_action.py
+++ b/envisage/ui/single_project/action/rename_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action that renames an item in the project tree. """
 

--- a/envisage/ui/single_project/action/save_as_project_action.py
+++ b/envisage/ui/single_project/action/save_as_project_action.py
@@ -118,7 +118,8 @@ class SaveAsProjectAction(ProjectAction):
 
     def _on_is_save_as_allowed(self, obj, trait_name, old, new):
         """
-        Handle changes to the value of the current project's is_save_as_allowed.
+        Handle changes to the value of the current project's
+        is_save_as_allowed.
 
         """
 

--- a/envisage/ui/single_project/action/save_as_project_action.py
+++ b/envisage/ui/single_project/action/save_as_project_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action that saves the current project to a different location. """
 

--- a/envisage/ui/single_project/action/save_project_action.py
+++ b/envisage/ui/single_project/action/save_project_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action that saves the current project. """
 

--- a/envisage/ui/single_project/action/switch_to_action.py
+++ b/envisage/ui/single_project/action/switch_to_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ An action that switches the project perspective. """
 

--- a/envisage/ui/single_project/api.py
+++ b/envisage/ui/single_project/api.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 # IDs of services provided by this plugin
 from .services import IPROJECT_MODEL, IPROJECT_UI

--- a/envisage/ui/single_project/default_path_preference_page.py
+++ b/envisage/ui/single_project/default_path_preference_page.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ Preference page for default path for a project
 """

--- a/envisage/ui/single_project/default_path_preference_page.py
+++ b/envisage/ui/single_project/default_path_preference_page.py
@@ -11,7 +11,7 @@
 
 # Enthought library imports
 from apptools.preferences.ui.api import PreferencesPage
-from traits.api import Directory, Str
+from traits.api import Directory
 from traitsui.api import View, Item
 
 # Global assignment of ID

--- a/envisage/ui/single_project/editor/project_editor.py
+++ b/envisage/ui/single_project/editor/project_editor.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 A base class for editors that can be tracked by single project plugin projects.

--- a/envisage/ui/single_project/factory_definition.py
+++ b/envisage/ui/single_project/factory_definition.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 # Enthought imports
 from traits.api import HasTraits, Int, Str

--- a/envisage/ui/single_project/model_service.py
+++ b/envisage/ui/single_project/model_service.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 The Envisage service providing the model state for the single

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -23,9 +23,7 @@ from traits.etsconfig.api import ETSConfig
 import apptools.sweet_pickle
 from apptools.io.api import File
 from traits.api import (
-    Any,
     Bool,
-    Dict,
     Directory,
     HasTraits,
     Instance,

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -221,8 +221,8 @@ class Project(HasTraits):
 
         """
 
-        # When unpickling, we don't have a reference to the current application, so we
-        # fallback on application_home.
+        # When unpickling, we don't have a reference to the current
+        # application, so we fallback on application_home.
         if application is None:
             return ETSConfig.application_home
 
@@ -401,7 +401,7 @@ class Project(HasTraits):
                 loc = location
 
         # Ensure all necessary directories exist.  If we're saving a file, then
-        # these are the path upto the file name.  If we're saving to a directory
+        # these are the path upto the file name. If we're saving to a directory
         # then the path is the complete location.
         if self.PROJECTS_ARE_FILES:
             path, filename = os.path.split(loc)

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 A base class for projects that can be displayed by the single_project

--- a/envisage/ui/single_project/project.py
+++ b/envisage/ui/single_project/project.py
@@ -587,7 +587,7 @@ class Project(HasTraits):
             if fh:
                 try:
                     fh.close()
-                except:
+                except Exception:
                     logger.exception(
                         "Unable to close project file [%s]", filename
                     )
@@ -673,7 +673,7 @@ class Project(HasTraits):
             try:
                 if fh is not None:
                     fh.close()
-            except:
+            except Exception:
                 logger.exception(
                     "Unable to close project pickle file [%s]", filename
                 )

--- a/envisage/ui/single_project/project_action.py
+++ b/envisage/ui/single_project/project_action.py
@@ -84,14 +84,6 @@ class ProjectAction(Action):
         # correct because I can't see to get a reference to the current
         # application.  Because of this, I'm not able to setup the listeners
         # yet but this needs to be done eventually!
-        """
-        if 'model_service' in kws:
-            self.model_service = kws['model_service']
-            del kws['model_service']
-        else:
-            self.model_service = self.window.application.get_service(IPROJECT_MODEL)
-        self._update_model_service_listeners(remove=False)
-        """
 
         super().__init__(*args, **kws)
 

--- a/envisage/ui/single_project/project_action.py
+++ b/envisage/ui/single_project/project_action.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 A base class for actions that determine their enabled status based on

--- a/envisage/ui/single_project/project_action.py
+++ b/envisage/ui/single_project/project_action.py
@@ -18,7 +18,6 @@ import inspect
 
 # Enthought library imports
 from envisage.api import Application
-from envisage.ui.workbench.api import WorkbenchWindow
 from pyface.action.api import Action
 from traits.api import Instance, Str
 

--- a/envisage/ui/single_project/project_action.py
+++ b/envisage/ui/single_project/project_action.py
@@ -80,9 +80,10 @@ class ProjectAction(Action):
         # Retrieve the project model service and register ourself to listen
         # for project state changes.  This is done first to avoid errors
         # during any refresh calls triggered by further initialization.
-        # FIXME: I don't think my implementation of the ProjectAction class is correct
-        # because I can't see to get a reference to the current application.  Because of
-        # this, I'm not able to setup the listeners yet but this needs to be done eventually!
+        # FIXME: I don't think my implementation of the ProjectAction class is
+        # correct because I can't see to get a reference to the current
+        # application.  Because of this, I'm not able to setup the listeners
+        # yet but this needs to be done eventually!
         """
         if 'model_service' in kws:
             self.model_service = kws['model_service']

--- a/envisage/ui/single_project/project_action_set.py
+++ b/envisage/ui/single_project/project_action_set.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ Single project action set. """
 # Enthought library imports.

--- a/envisage/ui/single_project/project_factory.py
+++ b/envisage/ui/single_project/project_factory.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 A base class for project factories.

--- a/envisage/ui/single_project/project_factory.py
+++ b/envisage/ui/single_project/project_factory.py
@@ -81,7 +81,7 @@ class ProjectFactory(HasTraits):
 
         try:
             project = self.PROJECT_CLASS.load(location, self.application)
-        except:
+        except Exception:
             logger.exception(
                 "Unable to load Project from location %s", location
             )

--- a/envisage/ui/single_project/project_plugin.py
+++ b/envisage/ui/single_project/project_plugin.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """ The Envisage single project plugin. """
 

--- a/envisage/ui/single_project/project_plugin.py
+++ b/envisage/ui/single_project/project_plugin.py
@@ -432,7 +432,7 @@ class ProjectPlugin(Plugin):
             try:
                 setattr(object, name, model_service.selection)
                 return
-            except:
+            except Exception:
                 pass
 
             # If that didn't work, remove the binding wrappers and try
@@ -441,7 +441,7 @@ class ProjectPlugin(Plugin):
             try:
                 setattr(object, name, selection)
                 return
-            except:
+            except Exception:
                 pass
 
             # If that didn't work, and only a single item is selected,
@@ -450,7 +450,7 @@ class ProjectPlugin(Plugin):
                 try:
                     setattr(object, name, selection[0])
                     return
-                except:
+                except Exception:
                     pass
 
             # The recipient must not be accepting the type of the
@@ -459,7 +459,7 @@ class ProjectPlugin(Plugin):
             # with the declaration of the recipient.
             try:
                 setattr(object, name, None)
-            except:
+            except Exception:
                 logger.debug(
                     "Error informing object [%s] of project "
                     "selection change via attribute [%s]",

--- a/envisage/ui/single_project/project_plugin.py
+++ b/envisage/ui/single_project/project_plugin.py
@@ -244,8 +244,8 @@ class ProjectPlugin(Plugin):
         self.application.register_service(IPROJECT_UI, ui_service)
 
         # Set up any listeners interested in the current project selection
-        # FIXME: Register the selection listeners for the current project selection.
-        # self._register_selection_listeners(model_service)
+        # FIXME: Register the selection listeners for the current project
+        # selection. self._register_selection_listeners(model_service)
 
         return
 

--- a/envisage/ui/single_project/project_plugin.py
+++ b/envisage/ui/single_project/project_plugin.py
@@ -12,7 +12,7 @@
 import logging
 
 # Enthought library imports.
-from envisage.api import ExtensionPoint, Plugin, ServiceOffer
+from envisage.api import ExtensionPoint, Plugin
 from envisage.ui.single_project.api import FactoryDefinition
 from pyface.action.api import MenuManager
 from pyface.workbench.api import Perspective

--- a/envisage/ui/single_project/services.py
+++ b/envisage/ui/single_project/services.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 # IDs of services provided by this plugin
 IPROJECT_MODEL = "envisage.ui.single_project.model_service.ModelService"

--- a/envisage/ui/single_project/tests/test_clean_strings.py
+++ b/envisage/ui/single_project/tests/test_clean_strings.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 
 import unittest

--- a/envisage/ui/single_project/tests/test_project_plugin.py
+++ b/envisage/ui/single_project/tests/test_project_plugin.py
@@ -1,0 +1,21 @@
+# (C) Copyright 2007-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+"""
+Tests for ProjectPlugin
+"""
+import unittest
+
+from envisage.ui.single_project.project_plugin import ProjectPlugin
+
+
+class TestProjectPlugin(unittest.TestCase):
+
+    def test_default_my_preferences_pages(self):
+        plugin = ProjectPlugin()
+        self.assertEqual(len(plugin.my_preferences_pages), 1)

--- a/envisage/ui/single_project/tests/test_project_plugin.py
+++ b/envisage/ui/single_project/tests/test_project_plugin.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 Tests for ProjectPlugin

--- a/envisage/ui/single_project/tests/test_project_view.py
+++ b/envisage/ui/single_project/tests/test_project_view.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 
 import unittest

--- a/envisage/ui/single_project/ui_service.py
+++ b/envisage/ui/single_project/ui_service.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 A service to enable UI interactions with the single project plugin.

--- a/envisage/ui/single_project/ui_service.py
+++ b/envisage/ui/single_project/ui_service.py
@@ -102,7 +102,7 @@ class UiService(HasTraits):
             # single project preferences
             p = self.model_service.preferences
             bind_preference(self, "autosave_interval", 5, p)
-        except:
+        except Exception:
             logger.exception(
                 "Failed to bind autosave_interval in [%s] to "
                 "preferences." % self
@@ -377,7 +377,7 @@ class UiService(HasTraits):
                     project.save(autosave_loc, overwrite=True, autosave=True)
                     msg = "[%s] auto-saved to [%s]" % (project, autosave_loc)
                     logger.debug(msg)
-                except:
+                except Exception:
                     logger.exception(
                         "Error auto-saving project [%s]" % project
                     )
@@ -560,7 +560,7 @@ class UiService(HasTraits):
                     logger.debug(
                         "No usable project found in [%s]." % autosave_loc
                     )
-            except:
+            except Exception:
                 logger.exception(
                     "Unable to restore project from [%s]" % autosave_loc
                 )

--- a/envisage/ui/single_project/ui_service_factory.py
+++ b/envisage/ui/single_project/ui_service_factory.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 The default UI service factory.

--- a/envisage/ui/single_project/view/project_view.py
+++ b/envisage/ui/single_project/view/project_view.py
@@ -2,9 +2,10 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in LICENSE.txt and may be redistributed only
-# under the conditions described in the aforementioned license.  The license
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
+#
 # Thanks for using Enthought open source!
 """
 The single project plugin's project view

--- a/envisage/ui/single_project/view/project_view.py
+++ b/envisage/ui/single_project/view/project_view.py
@@ -15,11 +15,9 @@ The single project plugin's project view
 import logging
 
 # Enthought library imports
-from apptools.naming.api import Binding
-from traits.api import register_factory, Any, HasTraits, Instance, Str
+from traits.api import register_factory, HasTraits, Instance, Str
 from traitsui.api import (
     Item,
-    Group,
     TreeEditor,
     ITreeNode,
     ITreeNodeAdapter,

--- a/envisage/ui/single_project/view/project_view.py
+++ b/envisage/ui/single_project/view/project_view.py
@@ -43,7 +43,7 @@ class EmptyProject(Project):
 class EmptyProjectAdapter(ITreeNodeAdapter):
     """ Adapter for our EmptyProject. """
 
-    # -- ITreeNodeAdapter Method Overrides --------------------------------------
+    # -- ITreeNodeAdapter Method Overrides ------------------------------------
 
     def get_label(self):
         """ Gets the label to display for a specified object.
@@ -57,7 +57,7 @@ register_factory(EmptyProjectAdapter, EmptyProject, ITreeNode)
 class ProjectAdapter(ITreeNodeAdapter):
     """ Base ProjectAdapter for the root of the tree. """
 
-    # -- ITreeNodeAdapter Method Overrides --------------------------------------
+    # -- ITreeNodeAdapter Method Overrides ------------------------------------
 
     def allows_children(self):
         """ Returns whether this object can have children.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,11 @@
 [flake8]
-exclude = examples, envisage/ui/single_project
+exclude = examples
 ignore = E266, W503
-per-file-ignores = */api.py:F401, setup.py:H102,
+per-file-ignores =
+    */api.py:F401
+    setup.py:H102
+    # Some parts of single_project are pretty broken
+    # See enthought/envisage#269
+    envisage/ui/single_project/project_plugin.py:F821
+    envisage/ui/single_project/action/save_as_project_action.py:F821
+    envisage/ui/single_project/action/save_project_action.py:F821


### PR DESCRIPTION
These are all the trivial flake8 fixes I have done before I realized that the package may be scheduled for removal (see #266).

They are pretty easy to do.  If the flake8 fixes don't go in, we might still want to update `setup.cfg` to reference #269 anyway.