### PR TITLE
Re-export CorePlugin in envisage.api

### DIFF
--- a/envisage/api.py
+++ b/envisage/api.py
@@ -20,6 +20,7 @@ from .i_plugin_manager import IPluginManager
 from .i_service_registry import IServiceRegistry
 
 from .application import Application
+from .core_plugin import CorePlugin
 from .egg_plugin_manager import EggPluginManager
 from .extension_registry import ExtensionRegistry
 from .extension_point import ExtensionPoint, contributes_to

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -11,7 +11,9 @@
 
 
 # Enthought library imports.
-from envisage.api import ExtensionPoint, Plugin, ServiceOffer
+from envisage.extension_point import ExtensionPoint
+from envisage.plugin import Plugin
+from envisage.service_offer import ServiceOffer
 from traits.api import List, on_trait_change, Str
 
 

--- a/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
+++ b/envisage/plugins/ipython_kernel/tests/test_ipython_kernel_plugin.py
@@ -18,8 +18,7 @@ import warnings
 
 from traits.api import List
 
-from envisage.api import Application, Plugin
-from envisage.core_plugin import CorePlugin
+from envisage.api import Application, CorePlugin, Plugin
 from envisage.tests.ets_config_patcher import ETSConfigPatcher
 
 # Skip these tests unless ipykernel is available.

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -37,7 +37,7 @@ class CorePluginTestCase(unittest.TestCase):
     def test_service_offers(self):
         """ service offers """
 
-        from envisage.core_plugin import CorePlugin
+        from envisage.api import CorePlugin
 
         class IMyService(Interface):
             pass
@@ -81,7 +81,7 @@ class CorePluginTestCase(unittest.TestCase):
     def test_dynamically_added_service_offer(self):
         """ dynamically added service offer """
 
-        from envisage.core_plugin import CorePlugin
+        from envisage.api import CorePlugin
 
         class IMyService(Interface):
             pass
@@ -139,7 +139,7 @@ class CorePluginTestCase(unittest.TestCase):
 
         # The core plugin is the plugin that offers the preferences extension
         # point.
-        from envisage.core_plugin import CorePlugin
+        from envisage.api import CorePlugin
 
         class PluginA(Plugin):
             id = "A"
@@ -164,7 +164,7 @@ class CorePluginTestCase(unittest.TestCase):
 
         # The core plugin is the plugin that offers the preferences extension
         # point.
-        from envisage.core_plugin import CorePlugin
+        from envisage.api import CorePlugin
 
         class PluginA(Plugin):
             id = "A"

--- a/envisage/tests/test_ids.py
+++ b/envisage/tests/test_ids.py
@@ -11,7 +11,7 @@
 import unittest
 
 import envisage.ids
-from envisage.core_plugin import CorePlugin
+from envisage.api import CorePlugin
 from envisage.plugins.ipython_kernel.api import IPythonKernelPlugin
 from envisage.plugins.python_shell.python_shell_plugin import PythonShellPlugin
 from envisage.ui.tasks.api import TasksPlugin

--- a/examples/MOTD/run.py
+++ b/examples/MOTD/run.py
@@ -5,11 +5,7 @@
 import logging
 
 # Enthought library imports.
-from envisage.api import Application
-
-
-# Enthought plugins.
-from envisage.core_plugin import CorePlugin
+from envisage.api import Application, CorePlugin
 
 # Example plugins.
 from acme.motd.motd_plugin import MOTDPlugin

--- a/examples/plugins/tasks/attractors/run.py
+++ b/examples/plugins/tasks/attractors/run.py
@@ -2,7 +2,7 @@
 import logging
 
 # Plugin imports.
-from envisage.core_plugin import CorePlugin
+from envisage.api import CorePlugin
 from envisage.ui.tasks.api import TasksPlugin
 from attractors.attractors_plugin import AttractorsPlugin
 

--- a/examples/plugins/tasks/ipython_kernel/example.py
+++ b/examples/plugins/tasks/ipython_kernel/example.py
@@ -2,8 +2,7 @@
 import logging
 
 # Enthought library imports.
-from envisage.api import Plugin
-from envisage.core_plugin import CorePlugin
+from envisage.api import CorePlugin, Plugin
 from envisage.plugins.ipython_kernel.api import (
     IPythonKernelPlugin,
     IPYTHON_KERNEL_PROTOCOL,

--- a/examples/plugins/workbench/AcmeLab/run.py
+++ b/examples/plugins/workbench/AcmeLab/run.py
@@ -8,7 +8,7 @@ import logging
 from acme.acmelab.api import Acmelab
 
 # Enthought plugins.
-from envisage.core_plugin import CorePlugin
+from envisage.api import CorePlugin
 from envisage.ui.workbench.workbench_plugin import WorkbenchPlugin
 
 # Example plugins.

--- a/examples/plugins/workbench/Lorenz/run.py
+++ b/examples/plugins/workbench/Lorenz/run.py
@@ -5,7 +5,7 @@
 import logging
 
 # Enthought plugins.
-from envisage.core_plugin import CorePlugin
+from envisage.api import CorePlugin
 from envisage.ui.workbench.workbench_plugin import WorkbenchPlugin
 
 # Example imports.


### PR DESCRIPTION
fixes #308 

The issue was originally framed as a question, but this PR assumes that re-exporting `CorePlugin` via `envisage.api` is the correct solution.  (Maybe instead it should be moved to `envisage/plugins/core/core_plugin.py` and be placed in an `envisage.plugins.core.api` module? but since it is `core` that probably is not the right approach and I think including it in `envisage.api`, as is done in this PR, makes more sense.

This PR simply re-exports `CorePlugin` in `envisage.api`, adjusts `core_plugin.py` to not import from `envisage.api` to avoid circular imports, and has tests/examples import `CorePlugin` from the api now instead.