### PR TITLE
Use mixin instead of having ProviderExtensionRegistryTestCase inherit from ExtensionRegistryTestCase

### DIFF
--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -15,11 +15,15 @@ import unittest
 
 # Enthought library imports.
 from envisage.api import Application, ExtensionPoint
-from envisage.api import ExtensionRegistry, UnknownExtensionPoint
+from envisage.api import ExtensionRegistry
 from traits.api import List
 
+from envisage.tests.test_extension_registry_mixin import (
+    ExtensionRegistryTestMixin
+)
 
-class ExtensionRegistryTestCase(unittest.TestCase):
+
+class ExtensionRegistryTestCase(ExtensionRegistryTestMixin, unittest.TestCase):
     """ Tests for the base extension registry. """
 
     def setUp(self):
@@ -28,64 +32,6 @@ class ExtensionRegistryTestCase(unittest.TestCase):
         # We do all of the testing via the application to make sure it offers
         # the same interface!
         self.registry = Application(extension_registry=ExtensionRegistry())
-
-    def test_empty_registry(self):
-        """ empty registry """
-
-        registry = self.registry
-
-        # Make sure there are no extensions.
-        extensions = registry.get_extensions("my.ep")
-        self.assertEqual(0, len(extensions))
-
-        # Make sure there are no extension points.
-        extension_points = registry.get_extension_points()
-        self.assertEqual(0, len(extension_points))
-
-    def test_add_extension_point(self):
-        """ add extension point """
-
-        registry = self.registry
-
-        # Add an extension *point*.
-        registry.add_extension_point(self._create_extension_point("my.ep"))
-
-        # Make sure there's NO extensions.
-        extensions = registry.get_extensions("my.ep")
-        self.assertEqual(0, len(extensions))
-
-        # Make sure there's one and only one extension point.
-        extension_points = registry.get_extension_points()
-        self.assertEqual(1, len(extension_points))
-        self.assertEqual("my.ep", extension_points[0].id)
-
-    def test_get_extension_point(self):
-        """ get extension point """
-
-        registry = self.registry
-
-        # Add an extension *point*.
-        registry.add_extension_point(self._create_extension_point("my.ep"))
-
-        # Make sure we can get it.
-        extension_point = registry.get_extension_point("my.ep")
-        self.assertNotEqual(None, extension_point)
-        self.assertEqual("my.ep", extension_point.id)
-
-    def test_remove_empty_extension_point(self):
-        """ remove empty_extension point """
-
-        registry = self.registry
-
-        # Add an extension point...
-        registry.add_extension_point(self._create_extension_point("my.ep"))
-
-        # ...and remove it!
-        registry.remove_extension_point("my.ep")
-
-        # Make sure there are no extension points.
-        extension_points = registry.get_extension_points()
-        self.assertEqual(0, len(extension_points))
 
     def test_remove_non_empty_extension_point(self):
         """ remove non-empty extension point """
@@ -107,27 +53,6 @@ class ExtensionRegistryTestCase(unittest.TestCase):
 
         # And that the extensions are gone too.
         self.assertEqual([], registry.get_extensions("my.ep"))
-
-    def test_remove_non_existent_extension_point(self):
-        """ remove non existent extension point """
-
-        registry = self.registry
-
-        with self.assertRaises(UnknownExtensionPoint):
-            registry.remove_extension_point("my.ep")
-
-    def test_remove_non_existent_listener(self):
-        """ remove non existent listener """
-
-        registry = self.registry
-
-        def listener(registry, extension_point, added, removed, index):
-            """ Called when an extension point has changed. """
-
-            self.listener_called = (registry, extension_point, added, removed)
-
-        with self.assertRaises(ValueError):
-            registry.remove_extension_point_listener(listener)
 
     def test_set_extensions(self):
         """ set extensions """

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -39,7 +39,7 @@ class ExtensionRegistryTestCase(ExtensionRegistryTestMixin, unittest.TestCase):
         registry = self.registry
 
         # Add an extension point...
-        registry.add_extension_point(self._create_extension_point("my.ep"))
+        registry.add_extension_point(self.create_extension_point("my.ep"))
 
         # ... with some extensions...
         registry.set_extensions("my.ep", [42])
@@ -60,22 +60,13 @@ class ExtensionRegistryTestCase(ExtensionRegistryTestMixin, unittest.TestCase):
         registry = self.registry
 
         # Add an extension *point*.
-        registry.add_extension_point(self._create_extension_point("my.ep"))
+        registry.add_extension_point(self.create_extension_point("my.ep"))
 
         # Set some extensions.
         registry.set_extensions("my.ep", [1, 2, 3])
 
         # Make sure we can get them.
         self.assertEqual([1, 2, 3], registry.get_extensions("my.ep"))
-
-    ###########################################################################
-    # Private interface.
-    ###########################################################################
-
-    def _create_extension_point(self, id, trait_type=List, desc=""):
-        """ Create an extension point. """
-
-        return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)
 
 
 def make_function_listener(events):

--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -19,14 +19,11 @@ from traits.api import List
 
 
 class ExtensionRegistryTestMixin:
-    """ Base set of tests for extension registry and its subclasses. """
+    """ Base set of tests for extension registry and its subclasses.
 
-    def setUp(self):
-        """ Prepares the test fixture before each test method is called. Test
-        cases inherriting from this mixin should override this method and
-        define self.registry.
-        """
-        pass
+    Test cases inherriting from this mixin should define a setUp method that
+    defines self.registry as an instance of ExtensionPointRegistry.
+    """
 
     def test_empty_registry(self):
         """ empty registry """
@@ -107,11 +104,7 @@ class ExtensionRegistryTestMixin:
         with self.assertRaises(ValueError):
             registry.remove_extension_point_listener(listener)
 
-    ###########################################################################
-    # Private interface.
-    ###########################################################################
-
-    def _create_extension_point(self, id, trait_type=List, desc=""):
+    def create_extension_point(self, id, trait_type=List, desc=""):
         """ Create an extension point. """
 
         return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)

--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -1,0 +1,119 @@
+# (C) Copyright 2007-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" Tests for the base extension registry. """
+
+# Enthought library imports.
+from envisage.api import ExtensionPoint
+from envisage.api import UnknownExtensionPoint
+from traits.api import List
+
+
+class ExtensionRegistryTestMixin:
+    """ Base set of tests for extension registry and its subclasses. """
+
+    def setUp(self):
+        """ Prepares the test fixture before each test method is called. """
+        pass
+
+    def test_empty_registry(self):
+        """ empty registry """
+
+        registry = self.registry
+
+        # Make sure there are no extensions.
+        extensions = registry.get_extensions("my.ep")
+        self.assertEqual(0, len(extensions))
+
+        # Make sure there are no extension points.
+        extension_points = registry.get_extension_points()
+        self.assertEqual(0, len(extension_points))
+
+    def test_add_extension_point(self):
+        """ add extension point """
+
+        registry = self.registry
+
+        # Add an extension *point*.
+        registry.add_extension_point(self._create_extension_point("my.ep"))
+
+        # Make sure there's NO extensions.
+        extensions = registry.get_extensions("my.ep")
+        self.assertEqual(0, len(extensions))
+
+        # Make sure there's one and only one extension point.
+        extension_points = registry.get_extension_points()
+        self.assertEqual(1, len(extension_points))
+        self.assertEqual("my.ep", extension_points[0].id)
+
+    def test_get_extension_point(self):
+        """ get extension point """
+
+        registry = self.registry
+
+        # Add an extension *point*.
+        registry.add_extension_point(self._create_extension_point("my.ep"))
+
+        # Make sure we can get it.
+        extension_point = registry.get_extension_point("my.ep")
+        self.assertNotEqual(None, extension_point)
+        self.assertEqual("my.ep", extension_point.id)
+
+    def test_remove_empty_extension_point(self):
+        """ remove empty_extension point """
+
+        registry = self.registry
+
+        # Add an extension point...
+        registry.add_extension_point(self._create_extension_point("my.ep"))
+
+        # ...and remove it!
+        registry.remove_extension_point("my.ep")
+
+        # Make sure there are no extension points.
+        extension_points = registry.get_extension_points()
+        self.assertEqual(0, len(extension_points))
+
+    def test_remove_non_empty_extension_point(self):
+        """ remove non-empty extension point """
+        pass
+
+    def test_remove_non_existent_extension_point(self):
+        """ remove non existent extension point """
+
+        registry = self.registry
+
+        with self.assertRaises(UnknownExtensionPoint):
+            registry.remove_extension_point("my.ep")
+
+    def test_remove_non_existent_listener(self):
+        """ remove non existent listener """
+
+        registry = self.registry
+
+        def listener(registry, extension_point, added, removed, index):
+            """ Called when an extension point has changed. """
+
+            self.listener_called = (registry, extension_point, added, removed)
+
+        with self.assertRaises(ValueError):
+            registry.remove_extension_point_listener(listener)
+
+    def test_set_extensions(self):
+        """ set extensions """
+        pass
+
+    ###########################################################################
+    # Private interface.
+    ###########################################################################
+
+    def _create_extension_point(self, id, trait_type=List, desc=""):
+        """ Create an extension point. """
+
+        return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)

--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -7,7 +7,10 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the base extension registry. """
+"""
+Base set of tests for extension registry and its subclasses wrapped in a
+mixin class.
+"""
 
 # Enthought library imports.
 from envisage.api import ExtensionPoint
@@ -19,7 +22,10 @@ class ExtensionRegistryTestMixin:
     """ Base set of tests for extension registry and its subclasses. """
 
     def setUp(self):
-        """ Prepares the test fixture before each test method is called. """
+        """ Prepares the test fixture before each test method is called. Test
+        cases inherriting from this mixin should override this method and
+        define self.registry.
+        """
         pass
 
     def test_empty_registry(self):
@@ -80,10 +86,6 @@ class ExtensionRegistryTestMixin:
         extension_points = registry.get_extension_points()
         self.assertEqual(0, len(extension_points))
 
-    def test_remove_non_empty_extension_point(self):
-        """ remove non-empty extension point """
-        pass
-
     def test_remove_non_existent_extension_point(self):
         """ remove non existent extension point """
 
@@ -104,10 +106,6 @@ class ExtensionRegistryTestMixin:
 
         with self.assertRaises(ValueError):
             registry.remove_extension_point_listener(listener)
-
-    def test_set_extensions(self):
-        """ set extensions """
-        pass
 
     ###########################################################################
     # Private interface.

--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -44,7 +44,7 @@ class ExtensionRegistryTestMixin:
         registry = self.registry
 
         # Add an extension *point*.
-        registry.add_extension_point(self._create_extension_point("my.ep"))
+        registry.add_extension_point(self.create_extension_point("my.ep"))
 
         # Make sure there's NO extensions.
         extensions = registry.get_extensions("my.ep")
@@ -61,7 +61,7 @@ class ExtensionRegistryTestMixin:
         registry = self.registry
 
         # Add an extension *point*.
-        registry.add_extension_point(self._create_extension_point("my.ep"))
+        registry.add_extension_point(self.create_extension_point("my.ep"))
 
         # Make sure we can get it.
         extension_point = registry.get_extension_point("my.ep")
@@ -74,7 +74,7 @@ class ExtensionRegistryTestMixin:
         registry = self.registry
 
         # Add an extension point...
-        registry.add_extension_point(self._create_extension_point("my.ep"))
+        registry.add_extension_point(self.create_extension_point("my.ep"))
 
         # ...and remove it!
         registry.remove_extension_point("my.ep")

--- a/envisage/tests/test_provider_extension_registry.py
+++ b/envisage/tests/test_provider_extension_registry.py
@@ -514,15 +514,13 @@ class ProviderExtensionRegistryTestCase(
         with self.assertRaises(ValueError):
             registry.remove_provider(a)
 
-    # Overriden to test differing behavior between the provider registry and
-    # the base class.
     def test_set_extensions(self):
         """ set extensions """
 
         registry = self.registry
 
         # Add an extension *point*.
-        registry.add_extension_point(self._create_extension_point("my.ep"))
+        registry.add_extension_point(self.create_extension_point("my.ep"))
 
         # Set some extensions.
         with self.assertRaises(SystemError):

--- a/envisage/tests/test_provider_extension_registry.py
+++ b/envisage/tests/test_provider_extension_registry.py
@@ -9,16 +9,22 @@
 # Thanks for using Enthought open source!
 """ Tests for the provider extension registry. """
 
+# Standard library imports.
+import unittest
+
 # Enthought library imports.
 from envisage.api import ExtensionPoint, ExtensionProvider
 from envisage.api import ProviderExtensionRegistry
 from traits.api import Int, List
 
 # Local imports.
-from .test_extension_registry import ExtensionRegistryTestCase
+from envisage.tests.test_extension_registry_mixin import (
+    ExtensionRegistryTestMixin
+)
 
 
-class ProviderExtensionRegistryTestCase(ExtensionRegistryTestCase):
+class ProviderExtensionRegistryTestCase(
+        ExtensionRegistryTestMixin, unittest.TestCase):
     """ Tests for the provider extension registry. """
 
     def setUp(self):


### PR DESCRIPTION
fixes #281

This PR pulls out methods from `test_extension_registry.ExtensionRegistryTestCase` into a mixin class called `test_extension_registry_mixin.ExtensionRegistryTestMixin` which both `ExtensionRegistryTestCase` and `ProviderExtensionRegistryTestCase` now inherit from.  

Test methods which were previously in `ExtensionRegistryTestCase` and overridden in `ProviderExtensionRegistryTestCase` have been left in these respective test cases and not included in the mixin.

This should make it easier to add new tests to `ExtensionRegistryTestCase`.


I searched for other TestCase subclassing but the only other occurrence I found was `EggBasedTestCase` being subclassed by `test_egg_plugin_manager.EggPluginManagerTestCase`.  This I felt was fine to leave though because `EggBasedTestCase` actually does not contain any tests, it simply contains helper methods of `setUp`, `_add_egg`, and `_add_eggs_on_path`.


Also, while working on this PR I did not see a test for https://github.com/enthought/envisage/blob/master/envisage/plugin_extension_registry.py
Such a test may want to use this mixin as well.  Such a test case would really only need to additionally test the trait change handlers on the `plugin_manager`.