### PR TITLE
Add wx as being supported in etstool, add it back to CI, and test against wxPython v4.x 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ addons:
     - libxcb-randr0
     - libxcb-render-util0
     - libxcb-xinerama0
+    # Wx dependencies
+    - libsdl2-2.0-0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyside2"
+    - env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyside2 wx"
     - os: osx
-      env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyside2"
+      env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyside2 wx"
 
 cache:
   directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "null pyqt5 pyside2"
+      TOOLKITS: "null pyqt5 pyside2 wx"
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt

--- a/etstool.py
+++ b/etstool.py
@@ -224,14 +224,18 @@ def install(edm, runtime, toolkit, environment, editable, source):
         )
     # install wxPython with pip, because we don't have it in EDM yet
     elif toolkit == "wx":
-        if sys.platform != 'linux':
+        if sys.platform == "darwin":
             commands.append(
-                "{edm} run -e {environment} -- pip install wxPython"
+                "{edm} run -e {environment} -- python -m pip install wxPython<4.1"  # noqa: E501
             )
-        else:
+        elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"  # noqa: E501
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython<4.1"  # noqa: E501
+            )
+        else:
+            commands.append(
+                "{edm} run -e {environment} -- python -m pip install wxPython"
             )
 
     if editable:

--- a/etstool.py
+++ b/etstool.py
@@ -231,8 +231,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
         else:
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f "
-                "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"  # noqa: E501
             )
 
     if editable:

--- a/etstool.py
+++ b/etstool.py
@@ -98,7 +98,7 @@ available_toolkits = ["pyside2", "pyqt5", "wx", "null"]
 default_toolkit = "null"
 
 supported_combinations = {
-    "3.6": {"pyside2", "pyqt5", "null"},
+    "3.6": {"pyside2", "pyqt5", "wx", "null"},
 }
 
 dependencies = {
@@ -125,8 +125,8 @@ toolkit_dependencies = {
     # we do a pip install.
     "pyside2": set(),
     "pyqt5": {"pyqt5"},
-    # FIXME: wxpython 3.0.2.0-6 is broken of OS-X
-    "wx": {"wxpython<3.0.2.0-6"},
+    # XXX once wxPython 4 is available in EDM, we will want it here
+    "wx": set(),
     "null": set(),
 }
 
@@ -222,6 +222,17 @@ def install(edm, runtime, toolkit, environment, editable, source):
         commands.append(
             "{edm} run -e {environment} -- pip install pyside2"
         )
+    # install wxPython with pip, because we don't have it in EDM yet
+    elif toolkit == "wx":
+        if sys.platform != 'linux':
+            commands.append(
+                "{edm} run -e {environment} -- pip install wxPython"
+            )
+        else:
+            # XXX this is mainly for TravisCI workers; need a generic solution
+            commands.append(
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"
+            )
 
     if editable:
         install_cmd = (

--- a/etstool.py
+++ b/etstool.py
@@ -231,7 +231,8 @@ def install(edm, runtime, toolkit, environment, editable, source):
         else:
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"
+                "{edm} run -e {environment} -- pip install -f "
+                "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython"
             )
 
     if editable:


### PR DESCRIPTION
fixes #312 

Note that previously, "wx" was listed in `available_toolkits`, but not in `supported_combinations` so trying to run `python etstool.py install --toolkit=wx` resulted in a failure.  Additionally, wx had been completely removed from CI altogether. (see #225)

This PR updates `etstool.py` so that wx is included in `supported_combinations` so that one can actually install and run tests with wx as the toolkit.  It also re-adds wx a as a toolkit to be run in CI.  Also, to address the original issue, it installs the relevant version of wx by following what is done in traitsui:
https://github.com/enthought/traitsui/blob/d112a694a4d681861a7ad3abb513cf7c83da9fe5/etstool.py#L246-L255

If we wish to continue simply not having wx as an available toolkit, we can close this PR.  If we do that we would want to open a separate PR removing "wx" references from `etstool.py`.  The only other occurrences of "wx" in envisage itself are here:
https://github.com/enthought/envisage/blob/215195ee5fb0285bc514ce40a573ea09aed69d11/examples/plugins/workbench/AcmeLab/acme/workbench/view/color_view.py#L58-L66
https://github.com/enthought/envisage/blob/215195ee5fb0285bc514ce40a573ea09aed69d11/examples/plugins/workbench/AcmeLabUsingEggs/src/acme.workbench/acme/workbench/view/color_view.py

