### PR TITLE
Doc - fix a few typos and old copyright year

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ master_doc = "index"
 
 # General substitutions.
 project = "envisage"
-copyright = "2008-2019, Enthought"
+copyright = "2008-2020, Enthought"
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/docs/source/envisage_core_documentation/introduction.rst
+++ b/docs/source/envisage_core_documentation/introduction.rst
@@ -41,7 +41,7 @@ build applications that are based on the concept of plugins. However, one of
 the main goals is to provide a simplified system so that applications and
 plugins can be written by scientists, engineers, and those people whose
 full-time job is *not* necessarily software development, hence a lot of work
-has gone into trying to satify the old adage of "make simple things simple, and
+has gone into trying to satisfy the old adage of "make simple things simple, and
 complex things possible". It will obviously be up to you to judge if we
 succeeded!
 
@@ -51,7 +51,7 @@ Getting Started
 The best way to get started is probably to take the time to read and digest the
 Core_ documentation and then work through the `Hello World`_ and
 `Message of the Day`_ examples. Despite being extremely simple, the examples
-introduces you to *all* of the fundamental concepts of Envisage, and the *real*
+introduce you to *all* of the fundamental concepts of Envisage, and the *real*
 applications that you build (which will hopefully be a lot more useful) will be
 built in exactly the same way.
 

--- a/docs/source/envisage_core_documentation/services.rst
+++ b/docs/source/envisage_core_documentation/services.rst
@@ -265,7 +265,7 @@ To set the properties for a service that has already been registered, use::
 
     application.set_service_properties(wilma_id, {'price' : 150})
 
-Not however, that in practise, it is more common to use the actual attributes
+Note however, that in practise, it is more common to use the actual attributes
 of a service object for the purposes of querying, but this is useful if you
 want additional properties that aren't part of the object's type.
 


### PR DESCRIPTION
This is a trivial PR that simply fixes a couple of typos I noticed reading the docs, and updates the copyright date shown on the docs from 2019 to 2020