### PR TITLE
drop support for python 3.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,16 @@
  Envisage CHANGELOG
 ====================
 
+Version 5.0.0
+=============
+
+Released: XXXX-XX-XX
+
+Changes
+-------
+
+- Drop support for Python 3 versions older than Python 3.6. (#341)
+
 Version 4.9.1
 =============
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ framework. You are free to use:
 Prerequisites
 -------------
 
-The supported versions of Python are Python >= 3.5.  Envisage requires:
+The supported versions of Python are Python >= 3.6.  Envisage requires:
 
 * `apptools <https://pypi.org/project/apptools/>`_
 * `traits <https://pypi.org/project/traits/>`_

--- a/setup.py
+++ b/setup.py
@@ -272,8 +272,6 @@ if __name__ == "__main__":
             Operating System :: Microsoft :: Windows
             Operating System :: POSIX :: Linux
             Programming Language :: Python
-            Programming Language :: Python :: 3
-            Programming Language :: Python :: 3.5
             Programming Language :: Python :: 3.6
             Programming Language :: Python :: 3.7
             Programming Language :: Python :: 3.8
@@ -313,6 +311,6 @@ if __name__ == "__main__":
             ],
             "envisage.ui.tasks.tests": ["data/*.pkl"],
         },
-        python_requires=">=3.5",
+        python_requires=">=3.6",
         zip_safe=False,
     )

--- a/setup.py
+++ b/setup.py
@@ -275,6 +275,7 @@ if __name__ == "__main__":
             Programming Language :: Python :: 3.6
             Programming Language :: Python :: 3.7
             Programming Language :: Python :: 3.8
+            Programming Language :: Python :: 3.9
             Programming Language :: Python :: Implementation :: CPython
             Topic :: Scientific/Engineering
             Topic :: Software Development


### PR DESCRIPTION
fixes #313 

This PR simply updates the `setup.py` script in two places and adds a short message to `CHANGES.txt` mentioning support for python <= 3.5 is dropped