### PR TITLE
Setup intersphinx in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ import enthought_sphinx_theme
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
@@ -183,3 +184,11 @@ latex_logo = "e-logo-rev.png"
 
 # If false, no module index is generated.
 # latex_use_modindex = True
+
+# -- Options for intersphinx extension ---------------------------------------
+
+intersphinx_mapping = {
+    "pyface": ("https://docs.enthought.com/pyface", None),
+    "traits": ("https://docs.enthought.com/traits", None),
+    "traitsui": ("https://docs.enthought.com/traitsui", None),
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,6 +189,7 @@ latex_logo = "e-logo-rev.png"
 
 intersphinx_mapping = {
     "pyface": ("https://docs.enthought.com/pyface", None),
+    "python": ("https://docs.python.org/3", None),
     "traits": ("https://docs.enthought.com/traits", None),
     "traitsui": ("https://docs.enthought.com/traitsui", None),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,8 +33,8 @@ import enthought_sphinx_theme
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.githubpages",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "traits.util.trait_documenter",


### PR DESCRIPTION
fixes #342 

This PR adds the intersphinx extension to the list of extensions - and adds the traits, tratsui and pyface docs urls to intersphinx. This enables links to api docs from the respective dependencies for example from the envisage api docs.