### PR TITLE
Fix Unregister service value error bug

### DIFF
--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -199,4 +199,8 @@ class CorePlugin(Plugin):
     @observe("application:service_registry:unregistered")
     def unregistered_updated(self, event):
         """ React to services being unregistered. """
-        self._service_ids.remove(event.new)
+
+        # we only want to reaect to unregistered services that were originally
+        # registered using the CorePlugins service_offers extension point
+        if event.new in self._service_ids:
+            self._service_ids.remove(event.new)

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -14,7 +14,7 @@
 from envisage.extension_point import ExtensionPoint
 from envisage.plugin import Plugin
 from envisage.service_offer import ServiceOffer
-from traits.api import List, on_trait_change, Str
+from traits.api import List, observe, on_trait_change, Str
 
 
 class CorePlugin(Plugin):
@@ -138,7 +138,6 @@ class CorePlugin(Plugin):
 
     def start(self):
         """ Start the plugin. """
-
         # Load all contributed preferences files into the application's root
         # preferences node.
         self._load_preferences(self.preferences)
@@ -196,3 +195,7 @@ class CorePlugin(Plugin):
         )
 
         return service_id
+
+    @observe("application:service_registry:unregistered")
+    def unregistered_updated(self, event):
+        self._service_ids.remove(event.new)

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -195,12 +195,3 @@ class CorePlugin(Plugin):
         )
 
         return service_id
-
-    @observe("application:service_registry:unregistered")
-    def unregistered_updated(self, event):
-        """ React to services being unregistered. """
-
-        # we only want to reaect to unregistered services that were originally
-        # registered using the CorePlugins service_offers extension point
-        if event.new in self._service_ids:
-            self._service_ids.remove(event.new)

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -14,7 +14,7 @@
 from envisage.extension_point import ExtensionPoint
 from envisage.plugin import Plugin
 from envisage.service_offer import ServiceOffer
-from traits.api import List, observe, on_trait_change, Str
+from traits.api import List, on_trait_change, Str
 
 
 class CorePlugin(Plugin):

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -198,4 +198,5 @@ class CorePlugin(Plugin):
 
     @observe("application:service_registry:unregistered")
     def unregistered_updated(self, event):
+        """ React to services being unregistered. """
         self._service_ids.remove(event.new)

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -289,10 +289,10 @@ class Plugin(ExtensionProvider):
         service_ids.reverse()
 
         for service_id in service_ids:
-            # note the service may have already been individually unregistered
             try:
-                self.application.service_registry.get_service_from_id(service_id)  # noqa: E501
+                self.application.get_service_from_id(service_id)
             except ValueError:
+                # the service may have already been individually unregistered
                 pass
             else:
                 self.application.unregister_service(service_id)

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -291,7 +291,7 @@ class Plugin(ExtensionProvider):
         for service_id in service_ids:
             # note the service may have already been individually unregistered
             try:
-                self.application.service_registry.get_service_from_id(service_id)
+                self.application.service_registry.get_service_from_id(service_id)  # noqa: E501
             except ValueError:
                 pass
             else:

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -289,7 +289,12 @@ class Plugin(ExtensionProvider):
         service_ids.reverse()
 
         for service_id in service_ids:
-            self.application.unregister_service(service_id)
+            try:
+                self.application.service_registry.get_service_from_id(service_id)
+            except ValueError:
+                pass
+            else:
+                self.application.unregister_service(service_id)
 
         # Just in case the plugin is started again!
         self._service_ids = []

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -289,6 +289,7 @@ class Plugin(ExtensionProvider):
         service_ids.reverse()
 
         for service_id in service_ids:
+            # note the service may have already been individually unregistered
             try:
                 self.application.service_registry.get_service_from_id(service_id)
             except ValueError:

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -216,3 +216,24 @@ class CorePluginTestCase(unittest.TestCase):
 
         # Run it!
         return application.run()
+
+    def test_unregister_service(self):
+
+        class IJunk(Interface):
+            trash = Str()
+
+        class Junk(HasTraits):
+            trash = Str("garbage")
+        
+        some_junk = Junk()
+
+        application = TestApplication(
+            plugins=[CorePlugin()],
+        )
+        
+        application.start()
+
+        some_junk_id = application.register_service(IJunk, some_junk)
+        application.unregister_service(some_junk_id)
+
+        application.stop()

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -192,7 +192,7 @@ class CorePluginTestCase(unittest.TestCase):
             service_offers = List(contributes_to=SERVICE_OFFERS)
 
             def _service_offers_default(self):
-            
+
                 a_service_offer = ServiceOffer(
                     protocol=IJunk,
                     factory=self._create_junk_service,
@@ -209,7 +209,7 @@ class CorePluginTestCase(unittest.TestCase):
             def _unregister_junk_service(self):
                 # only 1 service is registered so it has service_id of 1
                 self.application.unregister_service(1)
-        
+
         application = TestApplication(
             plugins=[CorePlugin(), PluginA()],
         )
@@ -224,13 +224,13 @@ class CorePluginTestCase(unittest.TestCase):
 
         class Junk(HasTraits):
             trash = Str("garbage")
-        
+
         some_junk = Junk()
 
         application = TestApplication(
             plugins=[CorePlugin()],
         )
-        
+
         application.start()
 
         some_junk_id = application.register_service(IJunk, some_junk)

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -18,20 +18,7 @@ from pkg_resources import resource_filename
 # Enthought library imports.
 from envisage.api import Application, CorePlugin, Plugin
 from envisage.api import ServiceOffer
-from traits.api import (
-    HasTraits,
-    Interface,
-    List,
-    on_trait_change,
-    pop_exception_handler as pop_on_trait_change_handler,
-    push_exception_handler as push_on_trait_change_handler,
-    Str,
-)
-from traits.observation.api import (
-    pop_exception_handler as pop_observe_handler,
-    push_exception_handler as push_observe_handler,
-)
-
+from traits.api import HasTraits, Interface, List, on_trait_change, Str
 
 # This module's package.
 PKG = "envisage.tests"
@@ -45,14 +32,6 @@ class TestApplication(Application):
 
 class CorePluginTestCase(unittest.TestCase):
     """ Tests for the core plugin. """
-
-    def setUp(self):
-        push_on_trait_change_handler(reraise_exceptions=True)
-        push_observe_handler(reraise_exceptions=True)
-
-    def tearDown(self):
-        pop_observe_handler()
-        pop_on_trait_change_handler()
 
     def test_service_offers(self):
         """ service offers """
@@ -198,6 +177,10 @@ class CorePluginTestCase(unittest.TestCase):
 
     # regression test for enthought/envisage#251
     def test_unregister_service_offer(self):
+        """ Unregister a service that is contributed to the
+        "envisage.service_offers" extension point while the application is
+        running.
+        """
 
         class IJunk(Interface):
             trash = Str()
@@ -235,9 +218,12 @@ class CorePluginTestCase(unittest.TestCase):
         )
 
         # Run it!
-        return application.run()
+        application.run()
 
     def test_unregister_service(self):
+        """ Unregister a service which was registered on the application
+        directly, not through the CorePlugin's extension point. CorePlugin
+        should not do anything to interfere. """
 
         class IJunk(Interface):
             trash = Str()

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -18,7 +18,19 @@ from pkg_resources import resource_filename
 # Enthought library imports.
 from envisage.api import Application, CorePlugin, Plugin
 from envisage.api import ServiceOffer
-from traits.api import HasTraits, Interface, List, on_trait_change, Str
+from traits.api import (
+    HasTraits,
+    Interface,
+    List,
+    on_trait_change,
+    pop_exception_handler as pop_on_trait_change_handler,
+    push_exception_handler as push_on_trait_change_handler,
+    Str,
+)
+from traits.observation.api import (
+    pop_exception_handler as pop_observe_handler,
+    push_exception_handler as push_observe_handler,
+)
 
 
 # This module's package.
@@ -33,6 +45,14 @@ class TestApplication(Application):
 
 class CorePluginTestCase(unittest.TestCase):
     """ Tests for the core plugin. """
+
+    def setUp(self):
+        push_on_trait_change_handler(reraise_exceptions=True)
+        push_observe_handler(reraise_exceptions=True)
+
+    def tearDown(self):
+        pop_observe_handler()
+        pop_on_trait_change_handler()
 
     def test_service_offers(self):
         """ service offers """

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -16,9 +16,9 @@ import unittest
 from pkg_resources import resource_filename
 
 # Enthought library imports.
-from envisage.api import Application, Plugin
+from envisage.api import Application, CorePlugin, Plugin
 from envisage.api import ServiceOffer
-from traits.api import Interface, List
+from traits.api import HasTraits, Interface, List, on_trait_change, Str
 
 
 # This module's package.
@@ -36,8 +36,6 @@ class CorePluginTestCase(unittest.TestCase):
 
     def test_service_offers(self):
         """ service offers """
-
-        from envisage.api import CorePlugin
 
         class IMyService(Interface):
             pass
@@ -80,8 +78,6 @@ class CorePluginTestCase(unittest.TestCase):
 
     def test_dynamically_added_service_offer(self):
         """ dynamically added service offer """
-
-        from envisage.api import CorePlugin
 
         class IMyService(Interface):
             pass
@@ -137,10 +133,6 @@ class CorePluginTestCase(unittest.TestCase):
     def test_preferences(self):
         """ preferences """
 
-        # The core plugin is the plugin that offers the preferences extension
-        # point.
-        from envisage.api import CorePlugin
-
         class PluginA(Plugin):
             id = "A"
             preferences = List(contributes_to="envisage.preferences")
@@ -161,10 +153,6 @@ class CorePluginTestCase(unittest.TestCase):
 
     def test_dynamically_added_preferences(self):
         """ dynamically added preferences """
-
-        # The core plugin is the plugin that offers the preferences extension
-        # point.
-        from envisage.api import CorePlugin
 
         class PluginA(Plugin):
             id = "A"
@@ -187,3 +175,44 @@ class CorePluginTestCase(unittest.TestCase):
 
         # Make sure we can get one of the preferences.
         self.assertEqual("42", application.preferences.get("enthought.test.x"))
+
+    # regression test for enthought/envisage#251
+    def test_unregister_service_offer(self):
+
+        class IJunk(Interface):
+            trash = Str()
+
+        class Junk(HasTraits):
+            trash = Str("garbage")
+
+        class PluginA(Plugin):
+            # The Ids of the extension points that this plugin contributes to.
+            SERVICE_OFFERS = "envisage.service_offers"
+
+            service_offers = List(contributes_to=SERVICE_OFFERS)
+
+            def _service_offers_default(self):
+            
+                a_service_offer = ServiceOffer(
+                    protocol=IJunk,
+                    factory=self._create_junk_service,
+                )
+
+                return [a_service_offer]
+
+            def _create_junk_service(self):
+                """ Factory method for the 'Junk' service. """
+
+                return Junk()
+
+            @on_trait_change("application:started")
+            def _unregister_junk_service(self):
+                # only 1 service is registered so it has service_id of 1
+                self.application.unregister_service(1)
+        
+        application = TestApplication(
+            plugins=[CorePlugin(), PluginA()],
+        )
+
+        # Run it!
+        return application.run()


### PR DESCRIPTION
fixes #251 

This PR first adds a failing regression test for the error described in the issue.  

To fix the issue, I added a listener in the `CorePlugin` class that listens to the `service_registry`'s `unregistered` event trait.  As mentioned in the issue, when `Application.unregister_service(<id>)` was called, the id was not also removed from `CorePlugin._service_ids`, so in the handler we simply remove the unregistered service id from `self._service_ids`.