### PR TITLE
Add tests to demonstrate behaviour when mutating extension point directly

### DIFF
--- a/envisage/tests/test_extension_point.py
+++ b/envisage/tests/test_extension_point.py
@@ -111,6 +111,31 @@ class ExtensionPointTestCase(unittest.TestCase):
         # Make sure the trait change handler was *not* called.
         self.assertEqual(False, f.x_changed_called)
 
+    def test_mutate_extension_point_no_effect(self):
+        """ Extension point is recomputed so mutation has no effect. """
+
+        registry = self.registry
+
+        # Add an extension point.
+        registry.add_extension_point(self._create_extension_point("my.ep"))
+
+        # Set the extensions.
+        registry.set_extensions("my.ep", [1, 2, 3])
+
+        # Declare a class that consumes the extension.
+        class Foo(TestBase):
+            x = ExtensionPoint(List(Int), id="my.ep")
+
+        # when
+        f = Foo()
+        f.x.append(42)
+
+        # then
+        # The registry is not changed, and the extension point is still the
+        # same as before
+        self.assertEqual(registry.get_extensions("my.ep"), [1, 2, 3])
+        self.assertEqual(f.x, [1, 2, 3])
+
     def test_untyped_extension_point(self):
         """ untyped extension point """
 

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -46,6 +46,23 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         with self.assertRaises(SystemError):
             setattr(a, "x", [1, 2, 3])
 
+    def test_mutate_extension_point_no_events(self):
+        """ Mutation will not emit change event for name_items """
+
+        a = PluginA()
+        a.on_trait_change(listener, "x_items")
+        b = PluginB()
+        c = PluginC()
+
+        application = TestApplication(plugins=[a, b, c])
+        application.start()
+
+        # when
+        a.x.append(42)
+
+        # then
+        self.assertIsNone(listener.obj)
+
     def test_append(self):
         """ append """
 


### PR DESCRIPTION
This PR add tests to demonstrate the contradiction / challenge for solving #291.

In summary:
- `ExtensionPoint` is like a property. Its value is recomputed on every access of the attribute.
- Mutating the extension point list _directly_ has no effects on the registry, nor will it fire events for the `x_items` listener
- Being able to listen to `x_items` is misleading. 

Details:
When someone defines an ExtensionPoint in their class like this:
```
class MyApplication(Application):
    x = ExtensionPoint(List, id="my.extension")
```
One can listen to changes to `x_items`, like this:
```
    @on_trait_change("x_items")
    def handle(self):
        ....
```

This makes developers believe that `x` is like a persisted list and they can listen to its mutation.
But that is in fact not true. The value of the extension point is computed every time when the attribute is accessed. It is more like a Property. For it is ephemeral, one cannot listen to the mutation on the list that is refreshed on every access.

In fact, when one listens to `x_items` in the context of extension points, what they are listening to is changes from the contributors of that extension point, and what they want is the specific details on what have been removed or added to the extension point. Envisage could well have called that `x_contribution_changed`, or `x_whatever_event`.  The naming of `x_items` is unfortunate as it clashes with the meaning of mutating a persisted list in on_trait_change mini-language.