### PR TITLE
[Draft] Reimplement extension registry using observe

### DIFF
--- a/envisage/extension_registry.py
+++ b/envisage/extension_registry.py
@@ -250,7 +250,10 @@ class ObservableExtensionRegistry(HasTraits):
     )
 
     # Mapping from extension point id to a callable to be used
-    # for dispatching events from observe.
+    # for dispatching events from observe. Since the callable does not
+    # hold a reference to the 'listener', it is okay for the dispatchers not
+    # to be removed from this mapping after use, and it is okay for a
+    # dispatcher to be reused many times for the same extension point id.
     _id_to_dispatcher = Dict()
 
     ###########################################################################

--- a/envisage/extension_registry.py
+++ b/envisage/extension_registry.py
@@ -18,12 +18,11 @@ import weakref
 
 # Enthought library imports.
 from traits.api import (
-    ComparisonMode, Dict, HasTraits, Instance, List, provides, Str, Tuple,
+    ComparisonMode, Dict, HasTraits, provides, Str, Tuple,
 )
 from traits.observation.api import trait, observe
 
 # Local imports.
-from .extension_point import ExtensionPoint
 from .extension_point_changed_event import ExtensionPointChangedEvent
 from .i_extension_registry import IExtensionRegistry
 from .unknown_extension_point import UnknownExtensionPoint

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -10,20 +10,26 @@
 """ Tests for the base extension registry. """
 
 # Standard library imports.
-import contextlib
 import unittest
 
 # Enthought library imports.
-from envisage.api import Application, ExtensionPoint
+from envisage.api import Application
 from envisage.api import ExtensionRegistry
-from traits.api import List
 
+from envisage.extension_registry import ObservableExtensionRegistry
 from envisage.tests.test_extension_registry_mixin import (
-    ExtensionRegistryTestMixin
+    ExtensionRegistryTestMixin,
+    SettableExtensionRegistryTestMixin,
+    ListeningExtensionRegistryTestMixin,
 )
 
 
-class ExtensionRegistryTestCase(ExtensionRegistryTestMixin, unittest.TestCase):
+class ExtensionRegistryTestCase(
+        ExtensionRegistryTestMixin,
+        SettableExtensionRegistryTestMixin,
+        ListeningExtensionRegistryTestMixin,
+        unittest.TestCase,
+):
     """ Tests for the base extension registry. """
 
     def setUp(self):
@@ -33,167 +39,22 @@ class ExtensionRegistryTestCase(ExtensionRegistryTestMixin, unittest.TestCase):
         # the same interface!
         self.registry = Application(extension_registry=ExtensionRegistry())
 
-    def test_remove_non_empty_extension_point(self):
-        """ remove non-empty extension point """
 
-        registry = self.registry
+class ObservableExtensionRegistryTestCase(
+        ExtensionRegistryTestMixin,
+        SettableExtensionRegistryTestMixin,
+        ListeningExtensionRegistryTestMixin,
+        unittest.TestCase,
+):
+    """ Tests for the base (?) observable extension registry. """
 
-        # Add an extension point...
-        registry.add_extension_point(self.create_extension_point("my.ep"))
-
-        # ... with some extensions...
-        registry.set_extensions("my.ep", [42])
-
-        # ...and remove it!
-        registry.remove_extension_point("my.ep")
-
-        # Make sure there are no extension points.
-        extension_points = registry.get_extension_points()
-        self.assertEqual(0, len(extension_points))
-
-        # And that the extensions are gone too.
-        self.assertEqual([], registry.get_extensions("my.ep"))
-
-    def test_set_extensions(self):
-        """ set extensions """
-
-        registry = self.registry
-
-        # Add an extension *point*.
-        registry.add_extension_point(self.create_extension_point("my.ep"))
-
-        # Set some extensions.
-        registry.set_extensions("my.ep", [1, 2, 3])
-
-        # Make sure we can get them.
-        self.assertEqual([1, 2, 3], registry.get_extensions("my.ep"))
-
-
-def make_function_listener(events):
-    """
-    Return a simple non-method extension point listener.
-
-    The listener appends events to the ``events`` list.
-    """
-    def listener(registry, event):
-        events.append(event)
-
-    return listener
-
-
-class ListensToExtensionPoint:
-    """
-    Class with a method that can be used as an extension point listener.
-    """
-    def __init__(self, events):
-        self.events = events
-
-    def listener(self, registry, event):
-        self.events.append(event)
-
-
-class ExtensionPointListenerLifetimeTestCase(unittest.TestCase):
     def setUp(self):
-        # We do all of the testing via the application to make sure it offers
-        # the same interface!
-        registry = Application(extension_registry=ExtensionRegistry())
-        extension_point = ExtensionPoint(id="my.ep", trait_type=List())
-        registry.add_extension_point(extension_point)
-        self.registry = registry
-
-        # A place to record events that listeners receive.
-        self.events = []
-
-    def test_add_nonmethod_listener(self):
-        listener = make_function_listener(self.events)
-        self.registry.add_extension_point_listener(listener, "my.ep")
-
-        with self.assertAppendsTo(self.events):
-            self.registry.set_extensions("my.ep", [1, 2, 3])
-
-    def test_remove_nonmethod_listener(self):
-        listener = make_function_listener(self.events)
-
-        self.registry.add_extension_point_listener(listener, "my.ep")
-        self.registry.remove_extension_point_listener(listener, "my.ep")
-
-        with self.assertDoesNotModify(self.events):
-            self.registry.set_extensions("my.ep", [4, 5, 6, 7])
+        self.registry = ObservableExtensionRegistry()
 
     def test_nonmethod_listener_lifetime(self):
-        listener = make_function_listener(self.events)
-        self.registry.add_extension_point_listener(listener, "my.ep")
-
-        # The listener should not kept alive by the registry.
-        del listener
-
-        with self.assertDoesNotModify(self.events):
-            self.registry.set_extensions("my.ep", [4, 5, 6, 7])
-
-    def test_add_method_listener(self):
-        obj = ListensToExtensionPoint(self.events)
-        self.registry.add_extension_point_listener(obj.listener, "my.ep")
-
-        # At this point, the bound method 'obj.listener' no longer
-        # exists; it's already been garbage collected. Nevertheless, the
-        # listener should still fire.
-        with self.assertAppendsTo(self.events):
-            self.registry.set_extensions("my.ep", [1, 2, 3])
-
-    def test_remove_method_listener(self):
-        obj = ListensToExtensionPoint(self.events)
-        # The two occurences of `obj.listener` below refer to different
-        # objects. Nevertheless, they _compare_ equal, so the removal
-        # should still be effective.
-        self.registry.add_extension_point_listener(obj.listener, "my.ep")
-        self.registry.remove_extension_point_listener(obj.listener, "my.ep")
-
-        with self.assertDoesNotModify(self.events):
-            self.registry.set_extensions("my.ep", [1, 2, 3])
-
-    def test_method_listener_lifetime(self):
-        obj = ListensToExtensionPoint(self.events)
-        self.registry.add_extension_point_listener(obj.listener, "my.ep")
-
-        # Removing the last reference to the object should deactivate
-        # the listener.
-        del obj
-
-        with self.assertDoesNotModify(self.events):
-            self.registry.set_extensions("my.ep", [1, 2, 3])
-
-    # Helper assertions #######################################################
-
-    @contextlib.contextmanager
-    def assertAppendsTo(self, some_list):
-        """
-        Assert that exactly one element is appended to a list.
-
-        Return a context manager that checks that the code in the corresponding
-        with block appends exactly one element to the given list.
-        """
-        old_length = len(some_list)
-        yield
-        new_length = len(some_list)
-        diff = new_length - old_length
-        self.assertEqual(
-            diff, 1,
-            msg="Expected exactly one new element; got {}".format(diff),
-        )
-
-    @contextlib.contextmanager
-    def assertDoesNotModify(self, some_list):
-        """
-        Assert that a list is unchanged.
-
-        Return a context manager that checks that the code in the corresponding
-        with block does not modify the length of the given list.
-        """
-        old_length = len(some_list)
-        yield
-        new_length = len(some_list)
-        diff = new_length - old_length
-        self.assertEqual(
-            diff, 0,
-            msg="Expected no new elements; got {}".format(diff),
-        )
+        with self.assertRaises(AssertionError):
+            # Traits observe only holds a weak reference if the handler
+            # is a method. In the case of a normal function, a strong
+            # reference is held. But ExtensionPointRegistry holds a weak
+            # reference regardless. Not sure if that is justified.
+            super().test_nonmethod_listener_lifetime()

--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -8,9 +8,14 @@
 #
 # Thanks for using Enthought open source!
 """
-Base set of tests for extension registry and its subclasses wrapped in a
-mixin class.
+
+This module offers mixin classes for testing implementations of
+``IExtensionRegistry``.
+
+All mixin classes should be complementary.
 """
+
+import contextlib
 
 # Enthought library imports.
 from envisage.api import ExtensionPoint
@@ -19,10 +24,12 @@ from traits.api import List
 
 
 class ExtensionRegistryTestMixin:
-    """ Base set of tests for extension registry and its subclasses.
+    """ Base set of tests for testing generic functionality on
+    ``IExtensionRegistry`` without depending on
+    ``IExtensionRegistry.set_extensions`` (for historical reasons).
 
-    Test cases inherriting from this mixin should define a setUp method that
-    defines self.registry as an instance of ExtensionPointRegistry.
+    Test cases inheriting from this mixin should define a setUp method that
+    defines self.registry as an instance that implements IExtensionRegistry.
     """
 
     def test_empty_registry(self):
@@ -68,6 +75,24 @@ class ExtensionRegistryTestMixin:
         self.assertNotEqual(None, extension_point)
         self.assertEqual("my.ep", extension_point.id)
 
+    def test_get_extension_point_return_none_if_not_found(self):
+        """ get extension point return None if id is not found. """
+        self.assertIsNone(self.registry.get_extension_point("i.do.not.exist"))
+
+    def test_get_extensions_mutation_no_effect_if_undefined(self):
+        """ test one cannot mutate the registry by mutating the list if id
+        is undefined.
+        """
+        # The extension point with id "my.ep" has not been defined
+        extensions = self.registry.get_extensions("my.ep")
+
+        # when
+        extensions.append([[1, 2]])
+
+        # then
+        # the registry is not affected.
+        self.assertEqual(self.registry.get_extensions("my.ep"), [])
+
     def test_remove_empty_extension_point(self):
         """ remove empty_extension point """
 
@@ -108,3 +133,303 @@ class ExtensionRegistryTestMixin:
         """ Create an extension point. """
 
         return ExtensionPoint(id=id, trait_type=trait_type, desc=desc)
+
+
+class SettableExtensionRegistryTestMixin:
+    """ Base set of tests for functionality of ``IExtensionRegistry``
+    that depends on ``IExtensionRegistry.set_extensions``.
+
+    Test cases inheriting from this mixin should define a setUp method that
+    defines self.registry as an instance that implements IExtensionRegistry.
+    """
+
+    def test_remove_non_empty_extension_point(self):
+        """ remove non-empty extension point """
+
+        registry = self.registry
+
+        # Add an extension point...
+        registry.add_extension_point(ExtensionPoint(id="my.ep"))
+
+        # ... with some extensions...
+        registry.set_extensions("my.ep", [42])
+
+        # ...and remove it!
+        registry.remove_extension_point("my.ep")
+
+        # Make sure there are no extension points.
+        extension_points = registry.get_extension_points()
+        self.assertEqual(0, len(extension_points))
+
+        # And that the extensions are gone too.
+        self.assertEqual([], registry.get_extensions("my.ep"))
+
+    def test_set_extensions(self):
+        """ set extensions """
+
+        registry = self.registry
+
+        # Add an extension *point*.
+        registry.add_extension_point(self.create_extension_point("my.ep"))
+
+        # Set some extensions.
+        registry.set_extensions("my.ep", [1, 2, 3])
+
+        # Make sure we can get them.
+        self.assertEqual([1, 2, 3], registry.get_extensions("my.ep"))
+
+    def test_get_nonempty_extensions(self):
+        """ test get nonempty extensions after setting it. """
+
+        registry = self.registry
+        registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        registry.set_extensions("my.ep", [[1, 2], [3, 4]])
+
+        # when
+        extensions = registry.get_extensions("my.ep")
+
+        # then
+        self.assertEqual(extensions, [[1, 2], [3, 4]])
+
+    def test_get_extensions_mutation_no_effect_if_defined(self):
+        """ test one cannot mutate the returned extensions to mutate the
+        registry.
+        """
+        registry = self.registry
+        registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        registry.set_extensions("my.ep", [[1, 2], [3, 4]])
+
+        # when
+        registry.get_extensions("my.ep").append([[5, 6]])
+
+        # then
+        # the registry is not affected.
+        self.assertEqual(
+            self.registry.get_extensions("my.ep"), [[1, 2], [3, 4]]
+        )
+
+    def test_mutate_original_extensions_mutate_registry(self):
+        """ if the original extensions was mutated, the registry is mutated.
+        """
+        # This may be a bug? But it is certainly the current behavior of
+        # ExtensionRegistry.
+        registry = self.registry
+        registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        extensions = [[1, 2], [3, 4]]
+        registry.set_extensions("my.ep", extensions)
+
+        # when
+        extensions.append([5, 6])
+
+        # then
+        self.assertEqual(
+            registry.get_extensions("my.ep"), [[1, 2], [3, 4], [5, 6]]
+        )
+
+    def test_set_extensions_with_unknown_extension_point_id(self):
+        """ Test set_extensions raises UnknownExtensionPoint
+        if the extension point has not been added in the first place.
+        """
+        registry = self.registry
+        with self.assertRaises(UnknownExtensionPoint):
+            registry.set_extensions("i.do.not.exist", [[1]])
+
+
+def make_function_listener(events):
+    """
+    Return a simple non-method extension point listener.
+
+    The listener appends events to the ``events`` list.
+    """
+    def listener(registry, event):
+        events.append(event)
+
+    return listener
+
+
+class ListensToExtensionPoint:
+    """
+    Class with a method that can be used as an extension point listener.
+    """
+    def __init__(self, events):
+        self.events = events
+
+    def listener(self, registry, event):
+        self.events.append(event)
+
+
+class ListeningExtensionRegistryTestMixin:
+    """ Base set of tests for listener functionality of ``IExtensionRegistry``.
+
+    Test cases inheriting from this mixin should define a setUp method that
+    defines self.registry as an instance that implements IExtensionRegistry.
+    """
+
+    def get_object_with_listener_method(self):
+        """ Return an object with a method that can be used as an
+        extension point listener along with the event list for inspection
+        in tests.
+
+        Returns
+        -------
+        object : ListensToExtensionPoint
+        events : list
+            List for collecting events.
+            Each item should be an instance of ExtensionPointChangedEvent
+            if the code being tested is correct.
+        """
+        events = []
+        return ListensToExtensionPoint(events), events
+
+    def get_nonmethod_listener(self):
+        """ Return a callable that can be used as an extension point listener
+        along with the event list for inspection in tests.
+
+        Returns
+        -------
+        listener : callable(registry, event)
+        events : list
+            List for collecting events.
+            Each item should be an instance of ExtensionPointChangedEvent
+            if the code being tested is correct.
+        """
+        events = []
+        return make_function_listener(events), events
+
+    def test_add_nonmethod_listener(self):
+        """ test adding extension point listener and its outcome."""
+        listener, events = self.get_nonmethod_listener()
+
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        self.registry.add_extension_point_listener(listener, "my.ep")
+
+        with self.assertAppendsTo(events):
+            self.registry.set_extensions("my.ep", [[1, 2, 3]])
+
+        # then
+        actual_event, = events
+        self.assertEqual(actual_event.extension_point_id, "my.ep")
+        self.assertIsNone(actual_event.index)
+        self.assertEqual(actual_event.added, [[1, 2, 3]])
+        self.assertEqual(actual_event.removed, [])
+
+    def test_nonmethod_listener_lifetime(self):
+        listener, events = self.get_nonmethod_listener()
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        self.registry.add_extension_point_listener(listener, "my.ep")
+
+        # The listener should not kept alive by the registry.
+        del listener
+
+        with self.assertDoesNotModify(events):
+            self.registry.set_extensions("my.ep", [4, 5, 6, 7])
+
+    def test_add_nonmethod_listener_non_matching_id(self):
+        """ test when the extension id does not match, listener is not fired.
+        """
+        listener, events = self.get_nonmethod_listener()
+
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep2"))
+        self.registry.add_extension_point_listener(listener, "my.ep")
+
+        # setting a different extension should not fire listener
+        with self.assertDoesNotModify(events):
+            self.registry.set_extensions("my.ep2", [[]])
+
+    def test_add_method_listener(self):
+        obj, events = self.get_object_with_listener_method()
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        self.registry.add_extension_point_listener(obj.listener, "my.ep")
+
+        # At this point, the bound method 'obj.listener' no longer
+        # exists; it's already been garbage collected. Nevertheless, the
+        # listener should still fire.
+        with self.assertAppendsTo(events):
+            self.registry.set_extensions("my.ep", [1, 2, 3])
+
+    def test_add_extension_point_listener_none(self):
+        """ Listen to all extension points if extension_point_id is none """
+
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep2"))
+
+        listener, events = self.get_nonmethod_listener()
+        self.registry.add_extension_point_listener(listener, None)
+
+        with self.assertAppendsTo(events):
+            self.registry.set_extensions("my.ep2", [[]])
+
+        with self.assertAppendsTo(events):
+            self.registry.set_extensions("my.ep", [[]])
+
+    def test_remove_nonmethod_listener(self):
+        listener, events = self.get_nonmethod_listener()
+
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        self.registry.add_extension_point_listener(listener, "my.ep")
+        self.registry.remove_extension_point_listener(listener, "my.ep")
+
+        with self.assertDoesNotModify(events):
+            self.registry.set_extensions("my.ep", [[4, 5, 6, 7]])
+
+    def test_remove_method_listener(self):
+        obj, events = self.get_object_with_listener_method()
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+
+        # The two occurences of `obj.listener` below refer to different
+        # objects. Nevertheless, they _compare_ equal, so the removal
+        # should still be effective.
+        self.registry.add_extension_point_listener(obj.listener, "my.ep")
+        self.registry.remove_extension_point_listener(obj.listener, "my.ep")
+
+        with self.assertDoesNotModify(events):
+            self.registry.set_extensions("my.ep", [1, 2, 3])
+
+    def test_method_listener_lifetime(self):
+        obj, events = self.get_object_with_listener_method()
+        self.registry.add_extension_point(ExtensionPoint(id="my.ep"))
+        self.registry.add_extension_point_listener(obj.listener, "my.ep")
+
+        # Removing the last reference to the object should deactivate
+        # the listener.
+        del obj
+
+        with self.assertDoesNotModify(events):
+            self.registry.set_extensions("my.ep", [1, 2, 3])
+
+    # Helper assertions #######################################################
+
+    @contextlib.contextmanager
+    def assertAppendsTo(self, some_list):
+        """
+        Assert that exactly one element is appended to a list.
+
+        Return a context manager that checks that the code in the corresponding
+        with block appends exactly one element to the given list.
+        """
+        old_length = len(some_list)
+        yield
+        new_length = len(some_list)
+        diff = new_length - old_length
+        self.assertEqual(
+            diff, 1,
+            msg="Expected exactly one new element; got {}".format(diff),
+        )
+
+    @contextlib.contextmanager
+    def assertDoesNotModify(self, some_list):
+        """
+        Assert that a list is unchanged.
+
+        Return a context manager that checks that the code in the corresponding
+        with block does not modify the length of the given list.
+        """
+        old_length = len(some_list)
+        yield
+        new_length = len(some_list)
+        diff = new_length - old_length
+        self.assertEqual(
+            diff, 0,
+            msg="Expected no new elements; got {}".format(diff),
+        )


### PR DESCRIPTION
This PR demonstrates how the `ExtensionRegistry` can be rewritten using `observe` from Traits 6.1.

Instead of rewriting the `ExtensionRegistry`, I added an `ObservableExtensionRegistry` which reimplements the `ExtensionRegistry` interface using `observe`.

I shifted all of the tests on `ExtensionRegistry` to mixin classes and run the same tests again this new extension registry.  I also added more tests. These tests demonstrate one discrepancy in `ObservableExtensionRegistry`: a weakref is held for a nonmethod handler in ExtensionRegistry, but for ObservableExtensionRegistry, a strong reference will be held. However the weakref handling for nonmethod handler looks unnecessary in ExtensionRegistry, as such handling is immediately countered in the only usage I could find:
https://github.com/enthought/envisage/blob/8245931f7e3dfcb6513bfb7dc2ae9b10ca6f89a1/envisage/extension_point.py#L226-L229

In summary, I think the approach has worked well...

The original motivation was to find a solution to #291, and I tried to explore whether reimplementing the extension registry using observe and TraitList would provide a fix... 

The answer is No. :) Therefore I don't intend for this PR to be merged, I will close this after CI is green.