### PR TITLE
Add apptools to source_dependencies in etstool.py

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -115,6 +115,7 @@ dependencies = {
 
 # Dependencies we install from source for cron tests
 source_dependencies = {
+    "apptools",
     "pyface",
     "traits",
     "traitsui",


### PR DESCRIPTION
In #162 cron jobs were set up and the framework was added so that they could installed ets packages from source.  `apptools` was not included originally in the list of `source_dependencies`, but it should be.