### PR TITLE
Add tests for ExtensionRegistry getters

### DIFF
--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -72,6 +72,18 @@ class ExtensionRegistryTestMixin:
         """ get extension point return None if id is not found. """
         self.assertIsNone(self.registry.get_extension_point("i.do.not.exist"))
 
+    def test_get_extensions_mutation_no_effect_if_undefined(self):
+        """ test one cannot mutate the registry by mutating the list. """
+        # The extension point with id "my.ep" has not been defined
+        extensions = self.registry.get_extensions("my.ep")
+
+        # when
+        extensions.append([[1, 2]])
+
+        # then
+        # the registry is not affected.
+        self.assertEqual(self.registry.get_extensions("my.ep"), [])
+
     def test_remove_empty_extension_point(self):
         """ remove empty_extension point """
 

--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -68,6 +68,10 @@ class ExtensionRegistryTestMixin:
         self.assertNotEqual(None, extension_point)
         self.assertEqual("my.ep", extension_point.id)
 
+    def test_get_extension_point_return_none_if_not_found(self):
+        """ get extension point return None if id is not found. """
+        self.assertIsNone(self.registry.get_extension_point("i.do.not.exist"))
+
     def test_remove_empty_extension_point(self):
         """ remove empty_extension point """
 


### PR DESCRIPTION
In #347, I added more tests for the ExtensionRegistry. This PR brings two of the tests to master.

`test_get_extensions_mutation_no_effect_if_undefined`: Ensures mutating the list returned by `get_extensions` has no effect on the registry. This is the only test that fails if I remove the `[:]` in this line:
https://github.com/enthought/envisage/blob/0798c1c6ce29628f4ef7221c564f5efc81709c78/envisage/extension_registry.py#L114

`test_get_extension_point_return_none_if_not_found` tests the leniency of `ExtensionRegistry.get_extension_point` when the id is not defined. Attempt to break this test also breaks some other indirect tests to do with the removing extension points via `ProviderExtensionRegistry`, which subclasses `ExtensionRegistry`. I feel a more directed test is needed for this behaviour.