### PR TITLE
Add a specific repr for ExtensionPointChangedEvent

### DIFF
--- a/envisage/extension_point_changed_event.py
+++ b/envisage/extension_point_changed_event.py
@@ -29,7 +29,9 @@ class ExtensionPointChangedEvent(TraitListEvent):
         return
 
     def __repr__(self):
-        return "ExtensionPointChangedEvent(index={!r}, removed={!r}, " \
-            "added={!r}, extension_point_id={!r})".format(
-                self.index, self.removed, self.added, self.extension_point_id
-            )
+        return ("ExtensionPointChangedEvent(extension_point_id={!r}, "
+                "index={!r}, removed={!r}, added={!r})").format(
+                    self.extension_point_id,
+                    self.index,
+                    self.removed,
+                    self.added)

--- a/envisage/extension_point_changed_event.py
+++ b/envisage/extension_point_changed_event.py
@@ -27,3 +27,9 @@ class ExtensionPointChangedEvent(TraitListEvent):
         self.extension_point_id = extension_point_id
 
         return
+
+    def __repr__(self):
+        return "ExtensionPointChangedEvent(index={!r}, removed={!r}, " \
+        "added={!r}, extension_point_id={!r})".format(
+            self.index, self.removed, self.added, self.extension_point_id
+        )

--- a/envisage/extension_point_changed_event.py
+++ b/envisage/extension_point_changed_event.py
@@ -30,6 +30,6 @@ class ExtensionPointChangedEvent(TraitListEvent):
 
     def __repr__(self):
         return "ExtensionPointChangedEvent(index={!r}, removed={!r}, " \
-        "added={!r}, extension_point_id={!r})".format(
-            self.index, self.removed, self.added, self.extension_point_id
-        )
+            "added={!r}, extension_point_id={!r})".format(
+                self.index, self.removed, self.added, self.extension_point_id
+            )

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -13,6 +13,7 @@
 import unittest
 
 # Local imports.
+from envisage.api import ExtensionPointChangedEvent
 from envisage.tests.test_application import (
     PluginA,
     PluginB,
@@ -365,8 +366,6 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
     def test_extension_point_change_event_str_representation(self):
         """ test string representation of the ExtensionPointChangedEvent class
         """
-        from envisage.api import ExtensionPointChangedEvent
-
         desired_repr = ("ExtensionPointChangedEvent(extension_point_id={}, "
                         "index=0, removed=[], added=[])")
         ext_pt_changed_evt = ExtensionPointChangedEvent(extension_point_id=1)

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -361,3 +361,14 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual([], listener.new.added)
         self.assertEqual([1, 2, 3], listener.new.removed)
         self.assertEqual(0, listener.new.index)
+
+    def test_extension_point_change_event_str_representation(self):
+        """ test string representation of the ExtensionPointChangedEvent class
+        """
+        from envisage.api import ExtensionPointChangedEvent
+
+        desired_repr = ("ExtensionPointChangedEvent(extension_point_id={}, "
+                        "index=0, removed=[], added=[])")
+        ext_pt_changed_evt = ExtensionPointChangedEvent(extension_point_id=1)
+        self.assertEqual(desired_repr.format(1), str(ext_pt_changed_evt))
+        self.assertEqual(desired_repr.format(1), repr(ext_pt_changed_evt))


### PR DESCRIPTION
fixes #352 

This PR simply overrides the repr method of `ExtensionPointChangedEvent` so that printing an instance of `ExtensionPointChangedEvent` will not result in something like
`TraitListEvent(index=None, removed=[], added=[42, 'a string', True])`. 

The new repr is very similar, only changing `TraitListEvent` to `ExtensionPointChangedEvent` and mentioning the `extension_point_id` of the `ExtensionPointChangedEvent`.