### PR TITLE
Fix index slice in ExtensionPointChangedEvent when plugin changes

### DIFF
--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -327,7 +327,7 @@ class Plugin(ExtensionProvider):
             else:
                 added = new
                 removed = old
-                index = slice(0, max(len(old), len(new)))
+                index = slice(0, len(old))
 
             # Let the extension registry know about the change.
             self._fire_extension_point_changed(

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -274,7 +274,7 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual(source_values, application.get_extensions("a.x"))
 
         self.assertEqual(0, listener.new.index.start)
-        self.assertEqual(4, listener.new.index.stop)
+        self.assertEqual(3, listener.new.index.stop)
 
     def test_add_plugin(self):
         """ add plugin """

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -236,6 +236,9 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         # won't fire a changed event.
         self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
 
+        # Keep the old values for later slicing check
+        source_values = list(a.x)
+
         # Assign a non-empty list to one of the plugin's contributions.
         b.x = [2, 4, 6, 8]
 
@@ -259,6 +262,17 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual("x_items", listener.trait_name)
         self.assertEqual([2, 4, 6, 8], listener.new.added)
         self.assertEqual([1, 2, 3], listener.new.removed)
+
+        # The removed entry should match what the old values say
+        self.assertEqual(
+            listener.new.removed, source_values[listener.new.index]
+        )
+
+        # If we use the index and apply the changes to the old list, we should
+        # recover the new list
+        source_values[listener.new.index] = listener.new.added
+        self.assertEqual(source_values, application.get_extensions("a.x"))
+
         self.assertEqual(0, listener.new.index.start)
         self.assertEqual(4, listener.new.index.stop)
 


### PR DESCRIPTION
When the extensions list is changed by adding or removing a plugin, the ExtensionPointChangedEvent reports a slice object as the index, but the end value is incorrect: If one uses that index to reproduce the new list from the values of the old list, they get incorrect results.

The first commit adds two assertions. The first assertion fails with master like this:
```
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/envisage/envisage/tests/test_extension_point_changed.py", line 268, in test_assign_non_empty_list
    listener.new.removed, source_values[listener.new.index]
AssertionError: [1, 2, 3] != [1, 2, 3, 98]
```
That is, if you use the index on the old values to recover the removed values, you get the wrong answer.

The second assertion fails with master like this:
```
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/envisage/envisage/tests/test_extension_point_changed.py", line 274, in test_assign_non_empty_list
    self.assertEqual(source_values, application.get_extensions("a.x"))
AssertionError: Lists differ: [2, 4, 6, 8, 99, 100] != [2, 4, 6, 8, 98, 99, 100]

First differing element 4:
99
98

Second list contains 1 additional elements.
First extra element 6:
100

- [2, 4, 6, 8, 99, 100]
+ [2, 4, 6, 8, 98, 99, 100]
?             ++++
```
That is if you use the index on the old values and assign the "added" values to it, you also don't recover the new values.

The second commit fixes both assertions, and make the necessary change to the test that asserts the slice end value.