### PR TITLE
Update changelog for 5.0.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Version 5.0.0
 Released: XXXX-XX-XX
 
 This is a major release mainly relating to code modernization.  In this
-release, support for python versions <3.6 have been dropped.  The
+release, support for Python versions <3.6 have been dropped.  The
 class_load_hooks and single_project modules have been removed. Additionally,
 there were various fixes to bugs, examples, tests, and documentation.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changes
 
 - Drop support for Python 3 versions older than Python 3.6. (#341)
 - Re-export CorePlugin in envisage.api (#332)
-- reate and fill plugin subpackage api modules (#323)
+- Create and fill plugin subpackage api modules (#323)
 - Add relevant classes to envisage.ui.tasks.api (#322)
 - Make TasksApplication.gui expect an IGUI interface, not a GUI instance (#301)
 - Deprecate safeweakref and replace its uses (#275)
@@ -20,7 +20,7 @@ Changes
 Fixes
 -----
 
-- Fix unregister_service ValueError bug (#345)
+- Fix ValueError from unregistering services when application stops (#345)
 - Fix the MOTD example (#319)
 - Fix the Hello_World example (#318)
 - Fix the attractors tasks application example (#317)
@@ -53,19 +53,19 @@ Tests
   (#346)
 - Use mixin instead of having ProviderExtensionRegistryTestCase inherit from
   ExtensionRegistryTestCase (#335)
-- TST: Switch on default warning flag for CI test command (#326)
-- Add test eggs for Python 3.9; remove eggs for Python 2.7 (#289)
+- Switch on default warning flag for CI test command (#326)
+- Add test eggs for Python 3.9 and remove eggs for Python 2.7 (#289)
 
 Build
 -----
 
-- Add apptools to source_dependencies in etstool.py (#348)
+- Fix CI cron job setup to install apptools (#348)
 - Update setup.py to allow prerelease version (#344)
 - Add wx as being supported in etstool, add it back to CI, and test against
   wxPython v4.x (#336)
-- Use edm 3.0.1 instead of 2.0.0 (#297)
-- Don't report code coverage (#288)
-- Fix CI failures on Linux, Windows (#287)
+- Update EDM version to 3.0.1 in Travis CI and Appveyor. (#297)
+- Stop reporting code coverage in CI (#288)
+- Fix CI setup on Linux, Windows (#287)
 - Remove support for PySide and PyQt4 from CI (#285)
 - Don't build CI on Python 3.5 (#284)
 - Add Slack notification for Travis CI runs (#283)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,18 @@ Version 5.0.0
 
 Released: XXXX-XX-XX
 
+This is a major release mainly relating to code modernization.  In this
+release, support for python versions <3.6 have been dropped.  The
+class_load_hooks and single_project modules have been removed. Additionally,
+there were various fixes to bugs, examples, tests, and documentation.
+
+Features
+--------
+
+- Re-export CorePlugin in envisage.api (#332)
+- Create and fill plugin subpackage api modules (#323)
+- Add relevant classes to envisage.ui.tasks.api (#322)
+
 Fixes
 -----
 
@@ -15,13 +27,6 @@ Fixes
 - Fix the Hello_World example (#318)
 - Fix the attractors tasks application example (#317)
 - Make TasksApplication.gui expect an IGUI interface, not a GUI instance (#301)
-
-Features
---------
-
-- Re-export CorePlugin in envisage.api (#332)
-- Create and fill plugin subpackage api modules (#323)
-- Add relevant classes to envisage.ui.tasks.api (#322)
 
 Documentation
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,17 +14,21 @@ Changes
 - Re-export CorePlugin in envisage.api (#332)
 - reate and fill plugin subpackage api modules (#323)
 - Add relevant classes to envisage.ui.tasks.api (#322)
+- Make TasksApplication.gui expect an IGUI interface, not a GUI instance (#301)
 - Deprecate safeweakref and replace its uses (#275)
 
 Fixes
 -----
 
 - Fix unregister_service ValueError bug (#345)
+- Fix the MOTD example (#319)
+- Fix the Hello_World example (#318)
+- Fix the attractors tasks application example (#317)
 
 Features
 --------
 
-- 
+- Add a new shell click command (#305)
 
 Documentation
 -------------
@@ -33,11 +37,13 @@ Documentation
 - Add documentation for envisage APIs (#340)
 - Use jinja templates for API documentation (#339)
 - Improve API docs : document traits (#334)
+- Rebuild documentation, mostly to fix search functionality (#290)
 
 Removals
 --------
 
 - Remove single_project (#331)
+- Remove class_load_hooks and ClassLoadHook (#321)
 
 Tests
 -----
@@ -48,6 +54,7 @@ Tests
 - Use mixin instead of having ProviderExtensionRegistryTestCase inherit from
   ExtensionRegistryTestCase (#335)
 - TST: Switch on default warning flag for CI test command (#326)
+- Add test eggs for Python 3.9; remove eggs for Python 2.7 (#289)
 
 Build
 -----
@@ -56,6 +63,11 @@ Build
 - Update setup.py to allow prerelease version (#344)
 - Add wx as being supported in etstool, add it back to CI, and test against
   wxPython v4.x (#336)
+- Use edm 3.0.1 instead of 2.0.0 (#297)
+- Don't report code coverage (#288)
+- Fix CI failures on Linux, Windows (#287)
+- Remove support for PySide and PyQt4 from CI (#285)
+- Don't build CI on Python 3.5 (#284)
 - Add Slack notification for Travis CI runs (#283)
 - Add flake8 check to etstool and CI (#268)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,22 +71,6 @@ Build
 - Add Slack notification for Travis CI runs (#283)
 - Add flake8 check to etstool and CI (#268)
 
-
-Version 4.9.2
-=============
-
-Released: 2020-02-17
-
-This is a bugfix release that fixes tests that assumed the existence
-of categories machinery (which is removed in Traits 6.0.0).
-
-Fixes
------
-
-- Conditionally skip tests that fail against Traits 6.0.0 due to the removal
-  of Categories. (#263)
-
-
 Version 4.9.1
 =============
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,16 +7,6 @@ Version 5.0.0
 
 Released: XXXX-XX-XX
 
-Changes
--------
-
-- Drop support for Python 3 versions older than Python 3.6. (#341)
-- Re-export CorePlugin in envisage.api (#332)
-- Create and fill plugin subpackage api modules (#323)
-- Add relevant classes to envisage.ui.tasks.api (#322)
-- Make TasksApplication.gui expect an IGUI interface, not a GUI instance (#301)
-- Deprecate safeweakref and replace its uses (#275)
-
 Fixes
 -----
 
@@ -24,11 +14,14 @@ Fixes
 - Fix the MOTD example (#319)
 - Fix the Hello_World example (#318)
 - Fix the attractors tasks application example (#317)
+- Make TasksApplication.gui expect an IGUI interface, not a GUI instance (#301)
 
 Features
 --------
 
-- Add a new shell click command (#305)
+- Re-export CorePlugin in envisage.api (#332)
+- Create and fill plugin subpackage api modules (#323)
+- Add relevant classes to envisage.ui.tasks.api (#322)
 
 Documentation
 -------------
@@ -39,9 +32,15 @@ Documentation
 - Improve API docs : document traits (#334)
 - Rebuild documentation, mostly to fix search functionality (#290)
 
+Deprecations
+------------
+
+- Deprecate safeweakref and replace its uses (#275)
+
 Removals
 --------
 
+- Drop support for Python 3 versions older than Python 3.6. (#341)
 - Remove single_project (#331)
 - Remove class_load_hooks and ClassLoadHook (#321)
 
@@ -67,7 +66,6 @@ Build
 - Stop reporting code coverage in CI (#288)
 - Fix CI setup on Linux, Windows (#287)
 - Remove support for PySide and PyQt4 from CI (#285)
-- Don't build CI on Python 3.5 (#284)
 - Add Slack notification for Travis CI runs (#283)
 - Add flake8 check to etstool and CI (#268)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,22 @@ Changes
 
 - Drop support for Python 3 versions older than Python 3.6. (#341)
 
+
+Version 4.9.2
+=============
+
+Released: 2020-02-17
+
+This is a bugfix release that fixes tests that assumed the existence
+of categories machinery (which is removed in Traits 6.0.0).
+
+Fixes
+-----
+
+- Conditionally skip tests that fail against Traits 6.0.0 due to the removal
+  of Categories. (#263)
+
+
 Version 4.9.1
 =============
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,53 @@ Changes
 -------
 
 - Drop support for Python 3 versions older than Python 3.6. (#341)
+- Re-export CorePlugin in envisage.api (#332)
+- reate and fill plugin subpackage api modules (#323)
+- Add relevant classes to envisage.ui.tasks.api (#322)
+- Deprecate safeweakref and replace its uses (#275)
+
+Fixes
+-----
+
+- Fix unregister_service ValueError bug (#345)
+
+Features
+--------
+
+- 
+
+Documentation
+-------------
+
+- Setup intersphinx in docs (#343)
+- Add documentation for envisage APIs (#340)
+- Use jinja templates for API documentation (#339)
+- Improve API docs : document traits (#334)
+
+Removals
+--------
+
+- Remove single_project (#331)
+
+Tests
+-----
+
+- Add tests for ExtensionRegistry getters (#349)
+- Add tests to demonstrate behaviour when mutating extension point directly
+  (#346)
+- Use mixin instead of having ProviderExtensionRegistryTestCase inherit from
+  ExtensionRegistryTestCase (#335)
+- TST: Switch on default warning flag for CI test command (#326)
+
+Build
+-----
+
+- Add apptools to source_dependencies in etstool.py (#348)
+- Update setup.py to allow prerelease version (#344)
+- Add wx as being supported in etstool, add it back to CI, and test against
+  wxPython v4.x (#336)
+- Add Slack notification for Travis CI runs (#283)
+- Add flake8 check to etstool and CI (#268)
 
 
 Version 4.9.2


### PR DESCRIPTION
This PR simply updates the changelog with the PRs since the last release.  It also adds a section to the changelog for the last release of 4.9.2 which was a small bug fix release.  

In order for this to match the process that was done for https://github.com/enthought/traitsui/issues/1307, this PR should instead target a yet to be created `maint/5.0.0` branch instead of master. 