### PR TITLE
update changelog to mention 4.9.2 bugfix release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,22 @@ Changes
 
 - Drop support for Python 3 versions older than Python 3.6. (#341)
 
+
+Version 4.9.2
+=============
+
+Released: 2020-02-17
+
+This is a bugfix release that fixes tests that assumed the existence
+of categories machinery (which is removed in Traits 6.0.0).
+
+Fixes
+-----
+
+- Conditionally skip tests that fail against Traits 6.0.0 due to the removal
+  of Categories. (#263)
+
+
 Version 4.9.1
 =============
 


### PR DESCRIPTION
As mentioned here: https://github.com/enthought/envisage/pull/364#discussion_r528879640

This portion of the changelog can be updated independently of the content for the 5.0.0 release.  This PR simply adds a small section to the changelog detailing the 4.9.2 bugfix release. 