### PR TITLE
update name of release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -1,5 +1,5 @@
 ---
-name: Tracking issue
+name: Release Checklist
 about: Use this template for upcoming releases.
 title: "[Release Number] Release Checklist"
 ---


### PR DESCRIPTION
This PR simply changes the name of the release issue template to "Release Checklist".  This is what you currently see when opening a new issue:

<img width="1471" alt="Screen Shot 2020-11-24 at 1 05 58 PM" src="https://user-images.githubusercontent.com/36972686/100145949-bbf2ff00-2e5e-11eb-9a1f-d0093f17cb06.png">

"Tracking Issue" is a bad name that doesn't make sense.