### PR TITLE
Turn off macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyside2 wx"
-    - os: osx
-      env: RUNTIME=3.6 TOOLKITS="null pyqt5 pyside2 wx"
 
 cache:
   directories:


### PR DESCRIPTION
This PR turns off expensive macOS builds on Travis CI. We'll eventually use GitHub Actions to replace these.