### PR TITLE
Refactor documentation links to source on GitHub

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,6 +87,24 @@ today_fmt = "%B %d, %Y"
 # show_authors = False
 
 
+# Substitutions reusable for all files.
+
+rst_epilog = """
+.. |acme.motd| replace:: :github-demo:`acme.motd <MOTD/acme/motd/motd_plugin.py>`
+.. |acme.motd.software_quotes| replace:: :github-demo:`acme.motd.software_quotes <MOTD/acme/motd/software_quotes/software_quotes_plugin.py>`
+.. |ExtensionPoint| replace:: :class:`~envisage.extension_point.ExtensionPoint`
+.. |Application| replace:: :class:`~envisage.application.Application`
+.. |IApplication| replace:: :class:`~envisage.i_application.IApplication`
+.. |IMessage| replace:: :github-demo:`IMessage <MOTD/acme/motd/i_message.py>`
+.. |Message| replace:: :github-demo:`Message <MOTD/acme/motd/message.py>`
+.. |messages.py| replace:: :github-demo:`message.py <MOTD/acme/motd/software_quotes/messages.py>`
+.. |Message of the Day| replace:: :github-demo:`Message of the Day <MOTD>`
+.. |MOTD| replace:: :github-demo:`MOTD <MOTD/acme/motd/motd.py>`
+.. |IMOTD| replace:: :github-demo:`IMOTD <MOTD/acme/motd/i_motd.py>`
+.. |MOTDPlugin| replace:: :github-demo:`MOTDPlugin <MOTD/acme/motd/motd_plugin.py>`
+.. |MOTD run| replace:: :github-demo:`run.py <MOTD/run.py>`
+"""
+
 # Options for HTML output
 # -----------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,19 +90,26 @@ today_fmt = "%B %d, %Y"
 # Substitutions reusable for all files.
 
 rst_epilog = """
-.. |acme.motd| replace:: :github-demo:`acme.motd <MOTD/acme/motd/motd_plugin.py>`
-.. |acme.motd.software_quotes| replace:: :github-demo:`acme.motd.software_quotes <MOTD/acme/motd/software_quotes/software_quotes_plugin.py>`
+..
+   # substitutions for API objects
+
 .. |ExtensionPoint| replace:: :class:`~envisage.extension_point.ExtensionPoint`
 .. |Application| replace:: :class:`~envisage.application.Application`
 .. |IApplication| replace:: :class:`~envisage.i_application.IApplication`
-.. |IMessage| replace:: :github-demo:`IMessage <MOTD/acme/motd/i_message.py>`
-.. |Message| replace:: :github-demo:`Message <MOTD/acme/motd/message.py>`
-.. |messages.py| replace:: :github-demo:`message.py <MOTD/acme/motd/software_quotes/messages.py>`
-.. |Message of the Day| replace:: :github-demo:`Message of the Day <MOTD>`
+
+..
+   # substitutions for MOTD examples
+
+.. |acme.motd| replace:: :github-demo:`acme.motd <MOTD/acme/motd/motd_plugin.py>`
+.. |acme.motd.software_quotes| replace:: :github-demo:`acme.motd.software_quotes <MOTD/acme/motd/software_quotes/software_quotes_plugin.py>`
 .. |MOTD| replace:: :github-demo:`MOTD <MOTD/acme/motd/motd.py>`
 .. |IMOTD| replace:: :github-demo:`IMOTD <MOTD/acme/motd/i_motd.py>`
 .. |MOTDPlugin| replace:: :github-demo:`MOTDPlugin <MOTD/acme/motd/motd_plugin.py>`
 .. |MOTD run| replace:: :github-demo:`run.py <MOTD/run.py>`
+.. |IMessage| replace:: :github-demo:`IMessage <MOTD/acme/motd/i_message.py>`
+.. |Message| replace:: :github-demo:`Message <MOTD/acme/motd/message.py>`
+.. |messages.py| replace:: :github-demo:`message.py <MOTD/acme/motd/software_quotes/messages.py>`
+.. |Message of the Day| replace:: :github-demo:`Message of the Day <MOTD>`
 """
 
 # Options for HTML output

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -110,7 +110,7 @@ rst_epilog = """
 .. |Message| replace:: :github-demo:`Message <MOTD/acme/motd/message.py>`
 .. |messages.py| replace:: :github-demo:`message.py <MOTD/acme/motd/software_quotes/messages.py>`
 .. |Message of the Day| replace:: :github-demo:`Message of the Day <MOTD>`
-"""
+"""   # noqa: E501
 
 # Options for HTML output
 # -----------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,6 +33,7 @@ import enthought_sphinx_theme
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.extlinks",
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
@@ -192,4 +193,13 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "traits": ("https://docs.enthought.com/traits", None),
     "traitsui": ("https://docs.enthought.com/traitsui", None),
+}
+
+
+# -- Options for extlinks extension -------------------------------------------
+
+extlinks = {
+    'github-demo': (
+        'https://github.com/enthought/envisage/tree/master/examples/%s',   # noqa: E501
+        '')
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,6 @@ today_fmt = "%B %d, %Y"
 # output. They are ignored by default.
 # show_authors = False
 
-
 # Substitutions reusable for all files.
 
 rst_epilog = """

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,9 +92,18 @@ rst_epilog = """
 ..
    # substitutions for API objects
 
-.. |ExtensionPoint| replace:: :class:`~envisage.extension_point.ExtensionPoint`
 .. |Application| replace:: :class:`~envisage.application.Application`
 .. |IApplication| replace:: :class:`~envisage.i_application.IApplication`
+.. |ExtensionPoint| replace:: :class:`~envisage.extension_point.ExtensionPoint`
+.. |Plugin| replace:: :class:`~envisage.plugin.Plugin`
+.. |IPlugin| replace:: :class:`~envisage.i_plugin.IPlugin`
+.. |envisage.api| replace:: :mod:`envisage.api`
+.. |envisage.ui.workbench| replace:: :mod:`envisage.ui.workbench.api`
+
+..
+   # substitutions for the Hello World example
+
+.. |Hello World| replace:: :github-demo:`Hello World <Hello_World/hello_world.py>`
 
 ..
    # substitutions for MOTD examples

--- a/docs/source/envisage_core_documentation/extension_points.rst
+++ b/docs/source/envisage_core_documentation/extension_points.rst
@@ -253,24 +253,3 @@ events if extensions are added/removed to/from the extension point at runtime.
 
 
 .. _`Python Eggs`: http://peak.telecommunity.com/DevCenter/PythonEggs
-
-..
-   # substitutions
-
-.. |acme.motd| replace:: :github-demo:`acme.motd <MOTD/acme/motd/motd_plugin.py>`
-
-.. |acme.motd.software_quotes| replace:: :github-demo:`acme.motd.software_quotes <MOTD/acme/motd/software_quotes/software_quotes_plugin.py>`
-
-.. |ExtensionPoint| replace:: :class:`~envisage.extension_point.ExtensionPoint`
-
-.. |IApplication| replace:: :class:`~envisage.i_application.IApplication`
-
-.. |IMessage| replace:: :github-demo:`IMessage <MOTD/acme/motd/i_message.py>`
-
-.. |Message| replace:: :github-demo:`Message <MOTD/acme/motd/message.py>`
-
-.. |messages.py| replace:: :github-demo:`message.py <MOTD/acme/motd/software_quotes/messages.py>`
-
-.. |Message of the Day| replace:: :github-demo:`Message of the Day <MOTD>`
-
-.. |MOTD| replace:: :github-demo:`MOTD <MOTD/acme/motd/motd.py>`

--- a/docs/source/envisage_core_documentation/extension_points.rst
+++ b/docs/source/envisage_core_documentation/extension_points.rst
@@ -2,7 +2,7 @@ Extension Points
 ================
 
 Whether or not we as software developers like to admit it, most (if not all) of
-the applications we write need to change over time. We fix bugs, and we add, 
+the applications we write need to change over time. We fix bugs, and we add,
 modify, and remove features. In other words, we spend most of our time either
 fixing or extending applications.
 
@@ -14,7 +14,7 @@ mechanism at each one. This makes it hard for developers who want to extend
 the application to know a) *where* they can add extensions, and b) *how*
 to add them.
 
-Envisage attempts to address this problem by admitting up front that 
+Envisage attempts to address this problem by admitting up front that
 applications need to be extensible, and by providing a standard way for
 developers to advertise the places where extension can occur (known as
 *extension points*), and for other developers to contribute *extensions* to
@@ -22,7 +22,7 @@ them.
 
 In Envisage, extension points and the extensions contributed to them are stored
 in the *extension registry*. To see how extension points actually work, let's
-take a look at the `Message of the Day`_ example included in the Envisage
+take a look at the |Message of the Day| example included in the Envisage
 distribution. This example shows how to build a very simple application that
 prints a (hopefully witty, educational, or inspiring) "Message of the Day"
 chosen at random from a list of contributed messages.
@@ -32,12 +32,12 @@ Declaring an Extension Point
 
 Plugins declare their extension points in one of two ways:
 
-1) Declaratively - using the 'ExtensionPoint' trait type
+1) Declaratively - using the |ExtensionPoint| trait type
 2) Programmatically - by overriding the 'get_extension_points' method.
 
-In the MOTD example, the acme.motd_ plugin needs to advertise an extension
+In the MOTD example, the |acme.motd| plugin needs to advertise an extension
 point that allows other plugins to contribute new messages. Using the
-'ExtensionPoint' trait type, the plugin would look like this::
+|ExtensionPoint| trait type, the plugin would look like this::
 
     class MOTDPlugin(Plugin):
         """ The MOTD Plugin. """"
@@ -84,25 +84,25 @@ Either way, this tells us three things about the extension point:
 
 1) That the extension point is called "acme.motd.messages"
 2) That every item in a list of contributions to the extension point must
-   implement the IMessage_ interface.
+   implement the |IMessage| interface.
 3) That the extension point allows you to contribute messages!
 
 Making contributions to an Extension Point
 ------------------------------------------
 
-The `Message of the Day`_ example has a second plugin,
-acme.motd.software_quotes_ that contributes some pithy quotes about software
+The |Message of the Day| example has a second plugin,
+|acme.motd.software_quotes| that contributes some pithy quotes about software
 development to the application.
 
 First of all, we have to create the messages that we want to add. Remember that
-when the acme.motd_ plugin advertised the extension point, it told us that
-every contribution had to implement the IMessage_ interface. Happily, there is
-a class that does just that already defined for us (Message_) and so we create
-a simple module (messages.py_) and add our Message_ instances to it::
+when the |acme.motd| plugin advertised the extension point, it told us that
+every contribution had to implement the |IMessage| interface. Happily, there is
+a class that does just that already defined for us (|Message|) and so we create
+a simple module (|messages.py|) and add our |Message| instances to it::
 
     messages = [
         ...
-    
+
         Message(
             author = "Martin Fowler",
             text   = "Any fool can write code that a computer can understand. Good"
@@ -118,7 +118,7 @@ a simple module (messages.py_) and add our Message_ instances to it::
         ...
     ]
 
-Now we create a plugin for the acme.motd.software_quotes_ package and tell
+Now we create a plugin for the |acme.motd.software_quotes| package and tell
 Envisage about the messages that we have just created. Again there are are
 two ways that a plugin can do this:
 
@@ -186,14 +186,14 @@ event.
 Retrieving the contributions to an Extension Point
 --------------------------------------------------
 
-OK, here's where we are so far: One plugin (acme.motd_) has advertised the fact
+OK, here's where we are so far: One plugin (|acme.motd|) has advertised the fact
 that it has an extension point called "acme.motd.messages", and that the
-contributions to the extension point must implement the IMessage_ interface.
-Another plugin (acme.motd.software_quotes_) has kindly offered to contribute
+contributions to the extension point must implement the |IMessage| interface.
+Another plugin (|acme.motd.software_quotes|) has kindly offered to contribute
 some messages about software development. Now we need to know how to retrieve
 the contributed messages at runtime.
 
-In the MOTD example, the messages are retrieved by the acme.motd_ plugin::
+In the MOTD example, the messages are retrieved by the |acme.motd| plugin::
 
     class MOTDPlugin(Plugin):
         """ The MOTD Plugin. """"
@@ -223,15 +223,15 @@ In the MOTD example, the messages are retrieved by the acme.motd_ plugin::
             ...
 
 As you can see, all we have to do is to access the **messages** extension point
-trait when we create our instance of the MOTD_ class.
+trait when we create our instance of the |MOTD| class.
 
 This example demonstrates a common pattern in Envisage application development,
 in that contributions to extension points are most often used by plugin
 implementations to create and initialize services (in this case, an instance of
-the MOTD_ class).
+the |MOTD| class).
 
 The extension registry can also be accessed through the following method on the
-IApplication_ interface::
+|IApplication| interface::
 
     def get_extensions(self, extension_point):
         """ Return a list containing all contributions to an extension point.
@@ -245,31 +245,32 @@ extension point you would use::
 
     messages = application.get_extensions('acme.motd.messages')
 
-Note however, that using the ExtensionPoint_ trait type, adds the ability to
+Note however, that using the |ExtensionPoint| trait type, adds the ability to
 validate the contributions -- in this case, to make sure that they are all
-objects that implement (or can be adapted to) the IMessage_ interface. It also
+objects that implement (or can be adapted to) the |IMessage| interface. It also
 automatically connects the trait so that the plugin will receive trait change
 events if extensions are added/removed to/from the extension point at runtime.
 
 
 .. _`Python Eggs`: http://peak.telecommunity.com/DevCenter/PythonEggs
 
-.. _acme.motd: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd_plugin.py
+..
+   # substitutions
 
-.. _acme.motd.software_quotes: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/software_quotes/software_quotes_plugin.py
+.. |acme.motd| replace:: :github-demo:`acme.motd <MOTD/acme/motd/motd_plugin.py>`
 
-.. _ExtensionPoint: https://github.com/enthought/envisage/tree/master/envisage/extension_point.py
+.. |acme.motd.software_quotes| replace:: :github-demo:`acme.motd.software_quotes <MOTD/acme/motd/software_quotes/software_quotes_plugin.py>`
 
-.. _IApplication: https://github.com/enthought/envisage/tree/master/envisage/i_application.py
+.. |ExtensionPoint| replace:: :class:`~envisage.extension_point.ExtensionPoint`
 
-.. _IMessage: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/i_message.py
+.. |IApplication| replace:: :class:`~envisage.i_application.IApplication`
 
-.. _Message: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/message.py
+.. |IMessage| replace:: :github-demo:`IMessage <MOTD/acme/motd/i_message.py>`
 
-.. _messages.py: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/software_quotes/messages.py
+.. |Message| replace:: :github-demo:`Message <MOTD/acme/motd/message.py>`
 
-.. _`Message of the Day`: https://github.com/enthought/envisage/tree/master/examples/MOTD
+.. |messages.py| replace:: :github-demo:`message.py <MOTD/acme/motd/software_quotes/messages.py>`
 
-.. _MOTD: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd.py
+.. |Message of the Day| replace:: :github-demo:`Message of the Day <MOTD>`
 
-.. _MOTDPlugin: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd_plugin.py
+.. |MOTD| replace:: :github-demo:`MOTD <MOTD/acme/motd/motd.py>`

--- a/docs/source/envisage_core_documentation/introduction.rst
+++ b/docs/source/envisage_core_documentation/introduction.rst
@@ -10,7 +10,7 @@ The project is really divided into 3 sub-projects:-
 
 1) Core_
 
-   The Envisage Core, found in the top-level envisage_ package,
+   The Envisage Core, found in the top-level |envisage.api| package,
    defines the basic application architecture including the plugin and
    extension mechanisms. All of the other sub-projects are simply collections
    of plugins that are built on top of the core.
@@ -23,7 +23,7 @@ The project is really divided into 3 sub-projects:-
    functionality commonly required in this type of application including
    actions, menubars, toolbars, user preferences, wizards etc. One of the most
    useful plugins in this project is the Workbench_ plugin (found in the
-   envisage.ui.workbench_ package) that helps you build a style of
+   |envisage.ui.workbench| package) that helps you build a style of
    user interface that is often (but not exclusively) found in integrated
    development environments (IDEs).
 
@@ -49,7 +49,7 @@ Getting Started
 ---------------
 
 The best way to get started is probably to take the time to read and digest the
-Core_ documentation and then work through the `Hello World`_ and
+Core_ documentation and then work through the |Hello World| and
 `Message of the Day`_ examples. Despite being extremely simple, the examples
 introduce you to *all* of the fundamental concepts of Envisage, and the *real*
 applications that you build (which will hopefully be a lot more useful) will be
@@ -68,8 +68,11 @@ documentation and examples first).
 .. _OSGi: http://www.osgi.org
 .. _Workbench: Workbench.html
 
-.. _`Hello World`: https://github.com/enthought/envisage/tree/master/examples/Hello_World/hello_world.py
+..
+   # substitutions
 
-.. _envisage: https://github.com/enthought/envisage/tree/master/envisage/api.py
+.. |Hello World| replace:: :github-demo:`Hello World <Hello_World/hello_world.py>`
 
-.. _envisage.ui.workbench: https://github.com/enthought/envisage/tree/master/envisage/ui/workbench/api.py
+.. |envisage.api| replace:: :mod:`envisage.api`
+
+.. |envisage.ui.workbench| replace:: :mod:`envisage.ui.workbench.api`

--- a/docs/source/envisage_core_documentation/introduction.rst
+++ b/docs/source/envisage_core_documentation/introduction.rst
@@ -67,6 +67,3 @@ documentation and examples first).
 .. _NetBeans: http://www.netbeans.org
 .. _OSGi: http://www.osgi.org
 .. _Workbench: Workbench.html
-
-..
-   # substitutions

--- a/docs/source/envisage_core_documentation/introduction.rst
+++ b/docs/source/envisage_core_documentation/introduction.rst
@@ -70,9 +70,3 @@ documentation and examples first).
 
 ..
    # substitutions
-
-.. |Hello World| replace:: :github-demo:`Hello World <Hello_World/hello_world.py>`
-
-.. |envisage.api| replace:: :mod:`envisage.api`
-
-.. |envisage.ui.workbench| replace:: :mod:`envisage.ui.workbench.api`

--- a/docs/source/envisage_core_documentation/message_of_the_day.rst
+++ b/docs/source/envisage_core_documentation/message_of_the_day.rst
@@ -9,12 +9,12 @@ the rare applications that is so simple that why would you bother), but it does
 serve to illustrate all of the fundamental aspects of building an Envisage
 application.
 
-All of the code for this example can be found in the `examples/MOTD`_ directory
-of the Envisage distribution, and to run it simply type::
+All of the code for this example can be found in the |Message of the Day|
+directory of the Envisage distribution, and to run it simply type::
 
    cd .../examples/MOTD
    python run.py
-  
+
 (or equivalent, depending on your operating system and shell)
 
 Before we dive right in to building our extensible application, let's take a
@@ -29,38 +29,38 @@ Plain Ol' MOTD
 --------------
 
 So lets take a look at our non-Envisage aware MOTD application, the code for
-which is in the acme.motd_ package. A good place to start as a developer
+which is in the |acme.motd| package. A good place to start as a developer
 *using* any package in Envisage (and, for that matter, the entire Enthought
 tool-suite) is to look at any interfaces and classes exposed via its 'api.py'
 module.
 
 In this case, there are 2 interfaces
 
-1) IMOTD_
+1) |IMOTD|
 
-  The interface for simple "Message of the Day" functionality.
+   The interface for simple "Message of the Day" functionality.
 
-2) IMessage_
+2) |IMessage|
 
-  The interface supported by each message returned by the motd() method on
-  the IMOTD_ interface.
+   The interface supported by each message returned by the motd() method on
+   the |IMOTD| interface.
 
 We also (*not* coincidentally!) have 2 corresponding implementation classes:
 
-1) MOTD_
-2) Message_
+1) |MOTD|
+2) |Message|
 
-As you can see, the MOTD_ class simply contains a list of messages and
+As you can see, the |MOTD| class simply contains a list of messages and
 when its motd() method is called, it returns a random choice from that list.
 
-An example of using our MOTD_ class at the Python prompt might be::
+An example of using our |MOTD| class at the Python prompt might be::
 
     >>> from acme.motd.api import Message, MOTD
     >>> motd = MOTD(messages=[Message(author='Anon', text='Hello World!')])
     >>> message = motd.motd()
     >>> print '"%s" - %s' % (message.text, message.author)
     "Hello World!" - Anon
-    >>> 
+    >>>
 
 Well, we had to get "Hello World" in there somewhere!
 
@@ -78,18 +78,18 @@ Create the main Application class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First of all, we need to create an object that represents the application
-itself. In Envisage, this can be any object that implements the IApplication_
-interface, but is usually either an instance of the default Application_ class,
+itself. In Envisage, this can be any object that implements the |IApplication|
+interface, but is usually either an instance of the default |Application| class,
 or one derived from it.
 
-In the MOTD_ example, we create the class in the run.py_ module as follows::
+In the |MOTD| example, we create the class in the |MOTD run| module as follows::
 
     application = Application(
         id      = 'acme.motd',
         plugins = [CorePlugin(), MOTDPlugin(), SoftwareQuotesPlugin()]
     )
 
-    application.run()    
+    application.run()
 
 In this case, we use the simplest way to tell Envisage which plugins make up
 the application by passing them in explicitly. Envisage applications allow you
@@ -102,13 +102,13 @@ The 'acme.motd' plugin
 ~~~~~~~~~~~~~~~~~~~~~~
 
 As shown above, the corresponding plugin implementation is in the
-MOTDPlugin_ class::
+|MOTDPlugin| class::
 
   class MOTDPlugin(Plugin):
       """ The 'Message of the Day' plugin.
 
       This plugin simply prints the 'Message of the Day' to stdout.
-    
+
       """
 
       # The IDs of the extension points that this plugin offers.
@@ -182,7 +182,7 @@ MOTDPlugin_ class::
           # Note that we always offer the service via its name, but look it up
           # via the actual protocol.
           from acme.motd.api import IMOTD
-        
+
           # Lookup the MOTD service.
           motd = self.application.get_service(IMOTD)
 
@@ -195,7 +195,7 @@ MOTDPlugin_ class::
           return
 
 Although it is obviously a bit of overkill, the example shows how we would
-take a MOTD_ object and register it a service for other parts of the
+take a |MOTD| object and register it a service for other parts of the
 application to use. Sadly, in this example, there are no other parts of the
 application, so we just lookup and use the service ourselves!
 
@@ -203,14 +203,14 @@ The 'acme.motd.software_quotes' plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First of all, we have to create the messages that we want to add. Remember that
-when the acme.motd_ plugin advertised the extension point, it told us that
-every contribution had to implement the IMessage_ interface. Happily, there is
-a class that does just that already defined for us (Message_) and so we create
-a simple module ('messages.py'_) and add our Message_ instances to it::
+when the |acme.motd| plugin advertised the extension point, it told us that
+every contribution had to implement the |IMessage| interface. Happily, there is
+a class that does just that already defined for us (|Message|) and so we create
+a simple module ('messages.py'_) and add our |Message| instances to it::
 
     messages = [
         ...
-    
+
         Message(
             author = "Martin Fowler",
             text   = "Any fool can write code that a computer can understand. Good"
@@ -226,7 +226,7 @@ a simple module ('messages.py'_) and add our Message_ instances to it::
         ...
     ]
 
-Now we create a plugin for the acme.motd.software_quotes_ package and tell
+Now we create a plugin for the |acme.motd.software_quotes| package and tell
 Envisage about the messages that we have just created::
 
   class SoftwareQuotesPlugin(Plugin):
@@ -244,7 +244,7 @@ Envisage about the messages that we have just created::
 
       # Messages for the 'Message Of The Day'.
       messages = List(contributes_to='acme.motd.messages')
-    
+
       ###########################################################################
       # 'SoftwareQuotesPlugin' interface.
       ###########################################################################
@@ -256,28 +256,3 @@ Envisage about the messages that we have just created::
           from messages import messages
 
           return messages
-
-.. _`Python Eggs`: http://peak.telecommunity.com/DevCenter/PythonEggs
-
-.. _acme.motd: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/api.py
-
-.. _acme.motd.software_quotes: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/software_quotes/setup.py
-
-.. _Application: https://github.com/enthought/envisage/tree/master/envisage/application.py
-
-.. _`examples/MOTD`: https://github.com/enthought/envisage/tree/master/examples/MOTD
-
-.. _IApplication: https://github.com/enthought/envisage/tree/master/envisage/i_application.py
-
-.. _IMessage: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/i_message.py
-
-.. _Message: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/message.py
-
-.. _MOTD: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd.py
-
-.. _IMOTD: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/i_motd.py
-
-.. _MOTDPlugin: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd_plugin.py
-
-.. _run.py: https://github.com/enthought/envisage/tree/master/examples/MOTD/run.py
-

--- a/docs/source/envisage_core_documentation/message_of_the_day_(using_eggs).rst
+++ b/docs/source/envisage_core_documentation/message_of_the_day_(using_eggs).rst
@@ -9,8 +9,9 @@ the rare applications that is so simple that why would you bother), but it does
 serve to illustrate all of the fundamental aspects of building an Envisage
 application.
 
-All of the code for this example can be found in the `examples/MOTD`_ directory
-of the Envisage distribution. This directory contains two subdirectories:
+All of the code for this example can be found in the |Message of the Day|
+directory of the Envisage distribution. This directory contains two
+subdirectories:
 
 dist
   This directory contains the actual runnable application as it *might*
@@ -21,9 +22,9 @@ dist
 
     cd dist
     python run.py
-  
+
   (or equivalent, depending on your operating system and shell)
-  
+
 src
   This directory contains the source code for the eggs that make up the
   application. This is there to allow easy access to the example code, but
@@ -41,38 +42,38 @@ Plain Ol' MOTD
 --------------
 
 So lets take a look at our non-Envisage aware MOTD application, the code for
-which is in the acme.motd_ package. A good place to start as a developer
+which is in the |acme.motd| package. A good place to start as a developer
 *using* any package in Envisage (and, for that matter, the entire Enthought
 tool-suite) is to look at any interfaces and classes exposed via its 'api.py'
 module.
 
 In this case, there are 2 interfaces
 
-1) IMOTD_
+1) |IMOTD|
 
   The interface for simple "Message of the Day" functionality.
 
-2) IMessage_
+2) |IMessage|
 
   The interface supported by each message returned by the motd() method on
-  the IMOTD_ interface.
+  the |IMOTD| interface.
 
 We also (*not* coincidentally!) have 2 corresponding implementation classes:
 
-1) MOTD_
-2) Message_
+1) |MOTD|
+2) |Message|
 
-As you can see, the MOTD_ class simply contains a list of messages and
+As you can see, the |MOTD| class simply contains a list of messages and
 when its motd() method is called, it returns a random choice from that list.
 
-An example of using our MOTD_ class at the Python prompt might be::
+An example of using our |MOTD| class at the Python prompt might be::
 
     >>> from acme.motd.api import Message, MOTD
     >>> motd = MOTD(messages=[Message(author='Anon', text='Hello World!')])
     >>> message = motd.motd()
     >>> print '"%s" - %s' % (message.text, message.author)
     "Hello World!" - Anon
-    >>> 
+    >>>
 
 Well, we had to get "Hello World" in there somewhere!
 
@@ -90,11 +91,11 @@ Create the main Application class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First of all, we need to create an object that represents the application
-itself. In Envisage, this can be any object that implements the IApplication_
-interface, but is usually either an instance of the default Application_ class,
+itself. In Envisage, this can be any object that implements the |IApplication|
+interface, but is usually either an instance of the default |Application| class,
 or one derived from it.
 
-In the MOTD_ example, we create the class in the run.py_ module as follows::
+In the |MOTD| example, we create the class in the |MOTD run| module as follows::
 
     def run():
         """ The function that starts your application. """
@@ -104,7 +105,7 @@ In the MOTD_ example, we create the class in the run.py_ module as follows::
 
         return Application(id='acme.motd').run()
 
-Note that the run.py_ file also contains some boilerplate code to add the
+Note that the |MOTD run| file also contains some boilerplate code to add the
 application's `Python Eggs`_ to the ``sys.path``, but this is not specific
 to Envisage - that code would be required for any egg-based application.
 
@@ -114,7 +115,7 @@ Create the 'acme.motd' plugin
 This is the plugin that will deliver the "Message of the Day" functionality
 into the application. It will do this by declaring an extension point to
 allow other plugins to contribute messages, and by using contributions to
-create an instance of the MOTD_ class and to publish it as a service.
+create an instance of the |MOTD| class and to publish it as a service.
 
 By default, Envisage finds plugins via Python eggs, so all we have to do is
 to declare the existence of our plugin using the "envisage.plugins"
@@ -131,7 +132,7 @@ entry point in our 'setup.py' module::
 	acme.motd = acme.motd.motd_plugin:MOTDPlugin
 
         ...
-    
+
         """
     )
 
@@ -145,13 +146,13 @@ Notice that we don't import the plugin from an 'api.py' module. This is to
 delay importing implementation code until it is actually needed.
 
 As showm above, the corresponding plugin implementation is in the
-MOTDPlugin_ class::
+|MOTDPlugin| class::
 
   class MOTDPlugin(Plugin):
       """ The 'Message of the Day' plugin.
 
       This plugin simply prints the 'Message of the Day' to stdout.
-    
+
       """
 
       # The IDs of the extension points that this plugin offers.
@@ -225,7 +226,7 @@ MOTDPlugin_ class::
           # Note that we always offer the service via its name, but look it up
           # via the actual protocol.
           from acme.motd.api import IMOTD
-        
+
           # Lookup the MOTD service.
           motd = self.application.get_service(IMOTD)
 
@@ -238,7 +239,7 @@ MOTDPlugin_ class::
           return
 
 Although it is obviously a bit of overkill, the example shows how we would
-take a MOTD_ object and register it a service for other parts of the
+take a |MOTD| object and register it a service for other parts of the
 application to use. Sadly, in this example, there are no other parts of the
 application, so we just lookup and use the service ourselves!
 
@@ -260,14 +261,14 @@ Create the 'acme.motd.software_quotes' plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First of all, we have to create the messages that we want to add. Remember that
-when the acme.motd_ plugin advertised the extension point, it told us that
-every contribution had to implement the IMessage_ interface. Happily, there is
-a class that does just that already defined for us (Message_) and so we create
-a simple module ('messages.py'_) and add our Message_ instances to it::
+when the |acme.motd| plugin advertised the extension point, it told us that
+every contribution had to implement the |IMessage| interface. Happily, there is
+a class that does just that already defined for us (|Message|) and so we create
+a simple module ('messages.py'_) and add our |Message| instances to it::
 
     messages = [
         ...
-    
+
         Message(
             author = "Martin Fowler",
             text   = "Any fool can write code that a computer can understand. Good"
@@ -283,7 +284,7 @@ a simple module ('messages.py'_) and add our Message_ instances to it::
         ...
     ]
 
-Now we create a plugin for the acme.motd.software_quotes_ package and tell
+Now we create a plugin for the |acme.motd.software_quotes| package and tell
 Envisage about the messages that we have just created::
 
   class SoftwareQuotesPlugin(Plugin):
@@ -301,7 +302,7 @@ Envisage about the messages that we have just created::
 
       # Messages for the 'Message Of The Day'.
       messages = List(contributes_to='acme.motd.messages')
-    
+
       ###########################################################################
       # 'SoftwareQuotesPlugin' interface.
       ###########################################################################
@@ -314,7 +315,7 @@ Envisage about the messages that we have just created::
 
           return messages
 
-And finally we go to the 'setup.py' file for the acme.motd.software_quotes_ egg
+And finally we go to the 'setup.py' file for the |acme.motd.software_quotes| egg
 and tell Envisage about the plugin::
 
     setup(
@@ -340,32 +341,9 @@ If we run the application now , we will (if all is well!) get a random, pithy
 quote about software development!
 
 To add more messages to the application in future, all we have to do is to
-create other plugins similar to the 'acme.motd.software_quotes' egg and drop 
+create other plugins similar to the 'acme.motd.software_quotes' egg and drop
 them into the '.../examples/MOTD/dist/eggs' directory.
 
 We have successfully built our first extensible, pluggable application!
 
 .. _`Python Eggs`: http://peak.telecommunity.com/DevCenter/PythonEggs
-
-.. _acme.motd: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/api.py
-
-.. _acme.motd.software_quotes: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/software_quotes/setup.py
-
-.. _Application: https://github.com/enthought/envisage/tree/master/envisage/application.py
-
-.. _`examples/MOTD`: https://github.com/enthought/envisage/tree/master/examples/MOTD
-
-.. _IApplication: https://github.com/enthought/envisage/tree/master/envisage/i_application.py
-
-.. _IMessage: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/i_message.py
-
-.. _Message: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/message.py
-
-.. _MOTD: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd.py
-
-.. _IMOTD: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/i_motd.py
-
-.. _MOTDPlugin: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd_plugin.py
-
-.. _run.py: https://github.com/enthought/envisage/tree/master/examples/MOTD/run.py
-

--- a/docs/source/envisage_core_documentation/plugins.rst
+++ b/docs/source/envisage_core_documentation/plugins.rst
@@ -17,8 +17,8 @@ uses an implementation based on `Python Eggs`_.
 Creating a Plugin
 -----------------
 
-All plugins must implement the IPlugin_ interface (an easy way to achieve this
-is to subclass the base Plugin_ class), and should provide the following
+All plugins must implement the |IPlugin| interface (an easy way to achieve this
+is to subclass the base |Plugin| class), and should provide the following
 "housekeeping" information:
 
 - a globally unique identifier (e.g., "acme.motd")
@@ -37,8 +37,8 @@ is to subclass the base Plugin_ class), and should provide the following
 
   A nice description of the intent and features of your plugin.
 
-Here is a snippet from the `acme.motd`_ plugin that is part of the `Message of
-the Day`_ example::
+Here is a snippet from the |acme.motd| plugin that is part of the |Message of
+the Day| example::
 
     class MOTDPlugin(Plugin):
         """ The 'Message of the Day' plugin.
@@ -59,7 +59,7 @@ Plugin Lifecycle
 ----------------
 
 Plugins have a lifecycle in the context of an application. There are currently
-two key lifecycle methods on the IPlugin_ interface::
+two key lifecycle methods on the |IPlugin| interface::
 
     def start(self):
         """ Start the plugin.
@@ -93,12 +93,8 @@ method of each plugin in the reverse order that they were started in.
 .. _`Python Eggs`: http://peak.telecommunity.com/DevCenter/PythonEggs
 .. _Services: services.html
 
-.. _acme.motd: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/setup.py
+..
+   # substitutions
 
-.. _IPlugin: https://github.com/enthought/envisage/tree/master/envisage/i_plugin.py
-
-.. _`Message of the Day`: https://github.com/enthought/envisage/tree/master/examples/MOTD
-
-.. _MOTD: https://github.com/enthought/envisage/tree/master/examples/MOTD/acme/motd/motd.py
-
-.. _Plugin: https://github.com/enthought/envisage/tree/master/envisage/plugin.py
+.. |Plugin| replace:: :class:`~envisage.plugin.Plugin`
+.. |IPlugin| replace:: :class:`~envisage.i_plugin.IPlugin`

--- a/docs/source/envisage_core_documentation/plugins.rst
+++ b/docs/source/envisage_core_documentation/plugins.rst
@@ -92,9 +92,3 @@ method of each plugin in the reverse order that they were started in.
 .. _`Extension Points`: extension_points.html
 .. _`Python Eggs`: http://peak.telecommunity.com/DevCenter/PythonEggs
 .. _Services: services.html
-
-..
-   # substitutions
-
-.. |Plugin| replace:: :class:`~envisage.plugin.Plugin`
-.. |IPlugin| replace:: :class:`~envisage.i_plugin.IPlugin`

--- a/docs/source/envisage_core_documentation/services.rst
+++ b/docs/source/envisage_core_documentation/services.rst
@@ -28,7 +28,7 @@ and it even allows you to publish your own entries for free (unlike the "real"
 one)!
 
 In an Envisage application, the service registry is accessed through the
-following methods on the IApplication_ interface::
+following methods on the |IApplication| interface::
 
     def get_service(self, protocol, query='', minimimize='', maximize=''):
         """ Return at most one service that matches the specified query.
@@ -39,7 +39,7 @@ following methods on the IApplication_ interface::
         """ Return the dictionary of properties associated with a service.
 
         """
-        
+
     def get_services(self, protocol, query='', minimimize='', maximize=''):
         """ Return all services that match the specified query.
 
@@ -199,7 +199,7 @@ in which case only one of the services that matches the query is returned::
 
     plumber = application.get_service(IPlumber, "price < 200")
 
-This query would return *either* *fred* or *wilma*.	
+This query would return *either* *fred* or *wilma*.
 
 Using *minimize* and *maximize*
 -------------------------------
@@ -247,7 +247,7 @@ get_service_properties() method with the appropriate service identifier::
 
     wilma = Plumber(name='wilma', location='BH6')
     wilma_id = application.register_service(IPlumber, wilma, {'price':125})
-	
+
     ...
 
     properties = application.get_service_properties(wilma_id)
@@ -260,7 +260,7 @@ To set the properties for a service that has already been registered, use::
 
     wilma = Plumber(name='wilma', location='BH6')
     wilma_id = application.register_service(IPlumber, wilma, {'price':125})
-	
+
     ...
 
     application.set_service_properties(wilma_id, {'price' : 150})
@@ -298,5 +298,3 @@ To register the factory, we just use 'application.register_service' as usual::
 
 Now, the first time somebody tries to get any 'IPlumber' service, the factory
 is called and the returned plumber object replaces the factory in the registry.
-
-.. _IApplication: https://github.com/enthought/envisage/tree/master/envisage/i_application.py

--- a/docs/source/envisage_core_documentation/workbench.rst
+++ b/docs/source/envisage_core_documentation/workbench.rst
@@ -1,7 +1,7 @@
 Workbench
 =========
 
-The workbench plugin, found in the envisage.ui.workbench_ package,
+The workbench plugin, found in the :mod:`envisage.ui.workbench.api` package,
 provides a style of user interface that is often (but not exclusively) found in
 integrated development environments (IDEs). Note that this does not mean that
 all of your user interfaces must fit this pattern -- just that if they do, then
@@ -59,5 +59,3 @@ widget to allow views, editors and perspectives to be contributed via plugins.
     :maxdepth: 2
 
     preferences.rst
-
-.. _envisage.ui.workbench: https://github.com/enthought/envisage/tree/master/envisage/ui/workbench/api.py

--- a/docs/source/tasks_user_manual/extensibility.rst
+++ b/docs/source/tasks_user_manual/extensibility.rst
@@ -415,14 +415,13 @@ several other menu-related conveniences, can be found in
 
 .. [1] In this section, we shall be referencing--often with considerable
        simplification--the Attractors example code in the EnvisagePlugins
-       package, available `online
-       <https://github.com/enthought/envisageplugins/tree/master/examples/tasks/attractors>`_
+       package, available :github-demo:`online <plugins/tasks/attractors>`
        and in the ETS distribution.
 
 .. [2] Although they are expanded into Pyface action items, schemas belong to a
        distinct API. It is beyond the scope of this document to describe the
-       Pyface action API. For lack of more complete documentation, the reader is
-       referred to the `source code
-       <https://github.com/enthought/traitsgui/blob/master/enthought/pyface/action/>`_.
+       Pyface action API. For more complete documentation, the reader is
+       referred to the `Pyface documentation
+       <https://docs.enthought.com/pyface/>`_.
 
 .. [3] Tasks differs from the Workbench in this regard.

--- a/docs/source/tasks_user_manual/layout.rst
+++ b/docs/source/tasks_user_manual/layout.rst
@@ -43,7 +43,7 @@ Defining a Task
 ---------------
 
 Minimally, a task is defined by subclassing ``Task`` and providing a central
-pane. For example, we define a task for editing Python scripts [3]_::
+pane. For example, we define a task for editing Python scripts::
 
     from pyface.tasks.api import Task
 
@@ -234,9 +234,3 @@ appears multiple times in a layout.
 .. [2] Throughout this document, "``Task``" will refer to the class of that name
        in the Tasks API, while "task" will be reserved for the general UI
        concept, and similarly for other terms.
-
-.. [3] In this and the subsequent section, we will be referencing (often in
-       abbreviated form) the Tasks example code in the TraitsGUI package,
-       available `online
-       <https://github.com/enthought/traitsgui/tree/master/examples/tasks>`_ and
-       in the ETS distribution.

--- a/docs/source/tasks_user_manual/menus.rst
+++ b/docs/source/tasks_user_manual/menus.rst
@@ -24,7 +24,7 @@ Defining a Menu Bar
 
 Resuming our example of the script editing task from the previous section, we
 shall define some menu items for opening and saving files. As in Traits UI and
-Pyface, individual menu items are instances of the ``Action`` class [1]_. We
+Pyface, individual menu items are instances of the ``Action`` class. We
 might define the 'Open' action as follows::
 
     from pyface.action.api import Action
@@ -128,8 +128,3 @@ files to our script editing task::
                                TaskAction(method='save',
                                           tooltip='Save the current file',
                                           image=ImageResource('document_save'))) ]
-
-.. rubric:: Footnotes
-
-.. [1] The most convenient reference in this case is the `source code
-       <https://github.com/enthought/traitsgui/blob/master/enthought/pyface/action/action.py>`_ itself.


### PR DESCRIPTION
The documentation has URL links to sources on GitHub. Some of them can be replaced by cross references to the API documentation. Some of them cannot.

When we need to move files across (e.g. for solving #320, see #359), we would have to update these links laboriously. This PR refactors the links so that "https://github.com/enthought/envisage/tree/master/..." is only defined once, in `conf.py`. And when we do move the example files, only the link in `conf.py` requires changes.

There are some drive-by to replace GitHub links with API documentation references, as well as removing some dead links.