### PR TITLE
Change default pickle protocol to more recent version for python >= 3.4

### DIFF
--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -50,11 +50,8 @@ class TasksApplication(Application):
     #: Extension point ID for task extensions
     TASK_EXTENSIONS = "envisage.ui.tasks.task_extensions"
 
-    #: Pickle protocol to use for persisting layout information. Subclasses may
-    #: want to increase this, depending on their compatibility needs. Protocol
-    #: version 2 is safe for Python >= 2.3. Protocol version 4 is safe for
-    #: Python >= 3.4.
-    layout_save_protocol = Int(2)
+    #: Pickle protocol to use for persisting layout information.
+    layout_save_protocol = Int(4)
 
     #### 'TasksApplication' interface #########################################
 

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -38,25 +38,6 @@ class TestTasksApplication(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmpdir)
 
-    def test_layout_save_uses_protocol_2(self):
-        # We use pickle protocol 2 by default, to allow compatibility
-        # across Python versions.
-        state_location = self.tmpdir
-
-        # Create application, and set it up to exit as soon as it's launched.
-        app = TasksApplication(state_location=state_location)
-        app.on_trait_change(app.exit, "application_initialized")
-
-        memento_file = os.path.join(state_location, app.state_filename)
-        self.assertFalse(os.path.exists(memento_file))
-        app.run()
-        self.assertTrue(os.path.exists(memento_file))
-
-        # Check that the generated file has protocol 2.
-        with open(memento_file, "rb") as f:
-            protocol_bytes = f.read(2)
-        self.assertEqual(protocol_bytes, b"\x80\x02")
-
     @unittest.skipUnless(
         3 <= pickle.HIGHEST_PROTOCOL, "Test uses pickle protocol 3"
     )


### PR DESCRIPTION
This PR simply change the default value for `layout_save_protocol` to 4 as protocol version 4 is safe for python >= 3.4.  It also removes a test that was testing that protocol 2 was used by default, which we no longer want.


This was missed when addressing #313 