### PR TITLE
Rewrite "_*_changed" static trait handler methods to use "observe"

### DIFF
--- a/envisage/application.py
+++ b/envisage/application.py
@@ -15,11 +15,12 @@ import logging
 import os
 
 # Enthought library imports.
-from traits.etsconfig.api import ETSConfig
 from apptools.preferences.api import IPreferences, ScopedPreferences
 from apptools.preferences.api import set_default_preferences
-from traits.api import Delegate, Event, HasTraits, Instance, Str
-from traits.api import VetoableEvent, provides
+from traits.api import (
+    Delegate, Event, HasTraits, Instance, observe, provides, Str, VetoableEvent
+)
+from traits.etsconfig.api import ETSConfig
 
 # Local imports.
 from .i_application import IApplication
@@ -463,8 +464,11 @@ class Application(HasTraits):
     # 'application' trait of plugin instances - but that is only done for the
     # same reason as this (i.e. it is nice to be able to pass plugins into the
     # application constructor).
-    def _plugin_manager_changed(self, trait_name, old, new):
+
+    @observe("plugin_manager")
+    def _update_application(self, event):
         """ Static trait change handler. """
+        old, new = event.old, event.new
 
         if old is not None:
             old.application = None

--- a/envisage/composite_plugin_manager.py
+++ b/envisage/composite_plugin_manager.py
@@ -14,8 +14,9 @@
 import logging
 
 # Enthought library imports.
-from traits.api import Event, HasTraits, Instance, List, provides
-from traits.api import on_trait_change
+from traits.api import (
+    Event, HasTraits, Instance, List, observe, on_trait_change, provides,
+)
 
 # Local imports.
 from .i_application import IApplication
@@ -59,7 +60,9 @@ class CompositePluginManager(HasTraits):
     # The application that the plugin manager is part of.
     application = Instance(IApplication)
 
-    def _application_changed(self, trait_name, old, new):
+    @observe("application")
+    def _update_application(self, event):
+        new = event.new
         for plugin_manager in self.plugin_managers:
             plugin_manager.application = new
 

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -80,7 +80,7 @@ class CorePlugin(Plugin):
     )
 
     @on_trait_change("preferences_items")
-    def _preferences_changed(self, event):
+    def _update_preferences(self, event):
         """ React to new preferencess being *added*.
 
         Note that we don't currently do anything if preferences are *removed*.
@@ -113,7 +113,7 @@ class CorePlugin(Plugin):
     )
 
     @on_trait_change("service_offers_items")
-    def _service_offers_changed(self, event):
+    def _register_new_services(self, event):
         """ React to new service offers being *added*.
 
         Note that we don't currently do anything if services are *removed* as

--- a/envisage/egg_basket_plugin_manager.py
+++ b/envisage/egg_basket_plugin_manager.py
@@ -67,7 +67,7 @@ class EggBasketPluginManager(PluginManager):
     plugin_path = List(Directory)
 
     @on_trait_change("plugin_path[]")
-    def _plugin_path_changed(self, obj, trait_name, removed, added):
+    def _update_path_and_reset_plugins(self, obj, trait_name, removed, added):
         self._update_sys_dot_path(removed, added)
         self.reset_traits(["_plugins"])
 

--- a/envisage/package_plugin_manager.py
+++ b/envisage/package_plugin_manager.py
@@ -48,7 +48,7 @@ class PackagePluginManager(PluginManager):
     plugin_path = List(Directory)
 
     @on_trait_change("plugin_path[]")
-    def _plugin_path_changed(self, obj, trait_name, removed, added):
+    def _update_path_and_reset_plugins(self, obj, trait_name, removed, added):
         self._update_sys_dot_path(removed, added)
         self.reset_traits(["_plugins"])
 

--- a/envisage/plugin_extension_registry.py
+++ b/envisage/plugin_extension_registry.py
@@ -11,7 +11,7 @@
 
 
 # Enthought library imports.
-from traits.api import Instance, on_trait_change
+from traits.api import Instance, observe, on_trait_change
 
 # Local imports.
 from .i_plugin_manager import IPluginManager
@@ -37,8 +37,10 @@ class PluginExtensionRegistry(ProviderExtensionRegistry):
 
     #### Trait change handlers ################################################
 
-    def _plugin_manager_changed(self, trait_name, old, new):
+    @observe("plugin_manager")
+    def _update_providers(self, event):
         """ Static trait change handler. """
+        old, new = event.old, event.new
 
         # In practise I can't see why you would ever want (or need) to change
         # the registry's plugin manager on the fly, but hey... Hence, 'old'

--- a/envisage/plugin_manager.py
+++ b/envisage/plugin_manager.py
@@ -13,7 +13,7 @@
 from fnmatch import fnmatch
 import logging
 
-from traits.api import Event, HasTraits, Instance, List, Str, provides
+from traits.api import Event, HasTraits, Instance, List, observe, provides, Str
 
 from .i_application import IApplication
 from .i_plugin import IPlugin
@@ -56,7 +56,8 @@ class PluginManager(HasTraits):
     #: The application that the plugin manager is part of.
     application = Instance(IApplication)
 
-    def _application_changed(self, trait_name, old, new):
+    @observe("application")
+    def _update_application_on_all_plugins(self, event):
         """ Static trait change handler. """
 
         self._update_plugin_application([], self._plugins)
@@ -177,15 +178,17 @@ class PluginManager(HasTraits):
     # The plugins that the manager manages!
     _plugins = List(IPlugin)
 
-    def __plugins_changed(self, trait_name, old, new):
+    @observe("_plugins")
+    def _update_application_on_plugins(self, event):
         """ Static trait change handler. """
-
+        old, new = event.old, event.new
         self._update_plugin_application(old, new)
 
-    def __plugins_items_changed(self, trait_name, old, new):
+    @observe("_plugins:items")
+    def _update_application_on_changed_plugins(self, event):
         """ Static trait change handler. """
 
-        self._update_plugin_application(new.removed, new.added)
+        self._update_plugin_application(event.removed, event.added)
 
     def _include_plugin(self, plugin_id):
         """ Return True if the plugin should be included.

--- a/envisage/plugins/text_editor/editor/text_editor.py
+++ b/envisage/plugins/text_editor/editor/text_editor.py
@@ -16,7 +16,7 @@ from os.path import basename
 # Enthought library imports.
 from pyface.workbench.api import TraitsUIEditor
 from pyface.api import FileDialog, CANCEL
-from traits.api import Code, Instance
+from traits.api import Code, Instance, observe
 from traitsui.api import CodeEditor, Group, Item, View
 from traitsui.key_bindings import KeyBinding, KeyBindings
 from traitsui.menu import NoButtons
@@ -151,9 +151,10 @@ class TextEditor(TraitsUIEditor):
 
     #### Trait change handlers ################################################
 
-    def _obj_changed(self, new):
+    @observe("obj")
+    def _handle_update_to_object(self, event):
         """ Static trait change handler. """
-
+        new = event.new
         # The path will be the empty string if we are editing a file that has
         # not yet been saved.
         if len(new.path) == 0:
@@ -167,15 +168,17 @@ class TextEditor(TraitsUIEditor):
             with open(new.path, "r", encoding="utf-8") as f:
                 self.text = f.read()
 
-    def _text_changed(self, trait_name, old, new):
+    @observe("text")
+    def _set_dirty(self, event):
         """ Static trait change handler. """
 
         if self.traits_inited():
             self.dirty = True
 
-    def _dirty_changed(self, dirty):
+    @observe("dirty")
+    def _update_name(self, event):
         """ Static trait change handler. """
-
+        dirty = event.new
         if len(self.obj.path) > 0:
             if dirty:
                 self.name = basename(self.obj.path) + "*"

--- a/envisage/tests/event_tracker.py
+++ b/envisage/tests/event_tracker.py
@@ -12,6 +12,7 @@
 
 # Enthought library imports.
 from traits.api import HasTraits, List, Str, Tuple
+from traits.has_traits import observe
 
 
 class EventTracker(HasTraits):
@@ -46,16 +47,18 @@ class EventTracker(HasTraits):
 
     #### Trait change handlers ################################################
 
-    def _subscriptions_changed(self, old, new):
+    @observe("subscriptions")
+    def _handle_changes_to_subscriptions(self, event):
         """ Static trait change handler. """
-
+        old, new = event.old, event.new
         for subscription in old:
             self._remove_subscription(subscription)
 
         for subscription in new:
             self._add_subscription(subscription)
 
-    def _subscriptions_items_changed(self, event):
+    @observe("subscriptions:items")
+    def _handle_changes_to_subscriptions_items(self, event):
         """ Static trait change handler. """
 
         for subscription in event.removed:

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -18,8 +18,9 @@ import unittest
 from envisage.api import Application, ExtensionPoint
 from envisage.api import IPluginActivator, Plugin, contributes_to
 from envisage.tests.ets_config_patcher import ETSConfigPatcher
-from traits.api import HasTraits, Instance, Int, Interface, List
-from traits.api import provides
+from traits.api import (
+    HasTraits, Instance, Int, Interface, List, observe, provides,
+)
 
 
 def listener(obj, trait_name, old, new):
@@ -308,7 +309,8 @@ class PluginTestCase(unittest.TestCase):
             id = "A"
             x = ExtensionPoint(List(Int), id="x")
 
-            def _x_items_changed(self, event):
+            @observe("x:items")
+            def _notify_listeners(self, event):
                 self.added = event.added
                 self.removed = event.removed
 

--- a/envisage/ui/action/abstract_action_manager_builder.py
+++ b/envisage/ui/action/abstract_action_manager_builder.py
@@ -12,7 +12,7 @@
 
 # Enthought library imports.
 from pyface.action.api import ActionManager, MenuManager
-from traits.api import HasTraits, Instance, List, provides
+from traits.api import HasTraits, Instance, List, observe, provides
 
 # Local imports.
 from .action_set import ActionSet
@@ -179,9 +179,10 @@ class AbstractActionManagerBuilder(HasTraits):
 
     #### Trait change handler #################################################
 
-    def _action_sets_changed(self, old, new):
+    @observe("action_sets")
+    def _update_action_sets_on_manager(self, event):
         """ Static trait change handler. """
-
+        new = event.new
         self._action_set_manager.action_sets = new
 
     #### Methods ##############################################################

--- a/envisage/ui/tasks/action/task_window_launch_group.py
+++ b/envisage/ui/tasks/action/task_window_launch_group.py
@@ -12,7 +12,7 @@
 from pyface.action.api import ActionItem, Group
 from pyface.tasks.api import TaskWindowLayout
 from pyface.tasks.action.api import TaskAction
-from traits.api import List, Str
+from traits.api import List, observe, Str
 
 
 class TaskWindowLaunchAction(TaskAction):
@@ -38,9 +38,11 @@ class TaskWindowLaunchAction(TaskAction):
 
     #### Trait change handlers ################################################
 
-    def _task_changed(self, task):
+    @observe("task")
+    def _update_name(self, event):
         """ Name the action (unless a name has already been assigned).
         """
+        task = event.new
         if task and not self.name:
             name = ""
             for factory in task.window.application.task_factories:

--- a/examples/legacy/plugins/workbench/Lorenz/acme/lorenz/lorenz.py
+++ b/examples/legacy/plugins/workbench/Lorenz/acme/lorenz/lorenz.py
@@ -7,7 +7,7 @@ from scipy.integrate import odeint
 
 # Enthought library imports.
 from chaco.chaco_plot_editor import ChacoPlotItem
-from traits.api import Array, DelegatesTo, Float, HasTraits
+from traits.api import Array, DelegatesTo, Float, HasTraits, observe
 from traits.api import Instance, List, Trait
 from traitsui.api import Item, HGroup, VGroup, View
 
@@ -36,22 +36,8 @@ class Lorenz(HasTraits):
     def __init__(self):
         self.refresh()
 
-    def _output_changed(self):
-        self.refresh()
-
-    def _prandtl_changed(self):
-        self.refresh()
-
-    def _rayleigh_changed(self):
-        self.refresh()
-
-    def _beta_changed(self):
-        self.refresh()
-
-    def _init_changed(self):
-        self.refresh()
-
-    def _time_changed(self):
+    @observe("output,prandtl,rayleigh,beta,init,time")
+    def _refresh_model_data(self, event):
         self.refresh()
 
     def lorenz(self, w, t, prandtl, rayleigh, beta):


### PR DESCRIPTION
This PR updates most, but not all, of the `_*_changed` static trait handler methods to use traits `observe` instead. See related PR #400 