### PR TITLE
Remove "contributes_to" decorator and supporting code

### DIFF
--- a/envisage/api.py
+++ b/envisage/api.py
@@ -31,7 +31,6 @@ Application, plugin and related classes
 - :class:`~.CorePlugin`
 - :class:`~.EggPluginManager`
 - :class:`~.ExtensionPoint`
-- :func:`~.contributes_to`
 - :class:`~.ExtensionPointBinding`
 - :func:`~.bind_extension_point`
 - :class:`~.ExtensionProvider`
@@ -70,7 +69,7 @@ from .application import Application
 from .core_plugin import CorePlugin
 from .egg_plugin_manager import EggPluginManager
 from .extension_registry import ExtensionRegistry
-from .extension_point import ExtensionPoint, contributes_to
+from .extension_point import ExtensionPoint
 from .extension_point_binding import (
     ExtensionPointBinding,
     bind_extension_point,

--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -24,47 +24,6 @@ from traits.trait_list_object import TraitList
 from .i_extension_point import IExtensionPoint
 
 
-def contributes_to(id):
-    """ A factory for extension point decorators!
-
-    As an alternative to making contributions via traits, you can use this
-    decorator to mark any method on a 'Plugin' as contributing to an extension
-    point (note this is *only* used on 'Plugin' instances!).
-
-    e.g. Using a trait you might have something like::
-
-        class MyPlugin(Plugin):
-            messages = List(contributes_to='acme.messages')
-
-            def _messages_default(self):
-                return ['Hello', 'Hola']
-
-    whereas, using the decorator, it would be::
-
-        class MyPlugin(Plugin):
-            @contributes_to('acme.messages')
-            def _get_messages(self):
-                return ['Hello', 'Hola']
-
-    There is not much in it really, but the decorator version looks a little
-    less like 'magic' since it doesn't require the developer to know about
-    Traits default initializers. However, if you know that you will want to
-    dynamically change your contributions then use the trait version  because
-    all you have to do is change the value of the trait and the framework will
-    react accordingly.
-
-    """
-
-    def decorator(fn):
-        """ A decorator for marking methods as extension contributors. """
-
-        fn.__extension_point__ = id
-
-        return fn
-
-    return decorator
-
-
 # Exception message template.
 INVALID_TRAIT_TYPE = (
     'extension points must be "List"s e.g. List, List(Int)'

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -122,8 +122,6 @@ class Plugin(ExtensionProvider):
     def get_extensions(self, extension_point_id):
         """ Return the provider's extensions to an extension point. """
 
-        extensions = []
-
         # Each class can have at most *one* trait that contributes to a
         # particular extension point.
         #
@@ -132,7 +130,10 @@ class Plugin(ExtensionProvider):
         # fine to allow mutiple traits!
         trait_names = self.trait_names(contributes_to=extension_point_id)
 
-        if len(trait_names) == 1:
+        if len(trait_names) == 0:
+            extensions = []
+
+        elif len(trait_names) == 1:
             extensions = self._get_extensions_from_trait(trait_names[0])
 
         else:

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -10,7 +10,6 @@
 """ The default implementation of the 'IPlugin' interface. """
 
 # Standard library imports.
-import inspect
 import logging
 import os
 from os.path import exists, join

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -16,7 +16,7 @@ import unittest
 
 # Enthought library imports.
 from envisage.api import Application, ExtensionPoint
-from envisage.api import IPluginActivator, Plugin, contributes_to
+from envisage.api import IPluginActivator, Plugin
 from envisage.tests.ets_config_patcher import ETSConfigPatcher
 from traits.api import HasTraits, Instance, Int, Interface, List
 from traits.api import provides
@@ -258,47 +258,6 @@ class PluginTestCase(unittest.TestCase):
 
         # We should get an error because the plugin has multiple traits
         # contributing to the same extension point.
-        self.assertEqual([1, 2, 3], application.get_extensions("x"))
-
-    def test_contributes_to_decorator(self):
-        """ contributes to decorator """
-
-        class PluginA(Plugin):
-            id = "A"
-            x = ExtensionPoint(List, id="x")
-
-        class PluginB(Plugin):
-            id = "B"
-
-            @contributes_to("x")
-            def _x_contributions(self):
-                return [1, 2, 3]
-
-        a = PluginA()
-        b = PluginB()
-
-        application = TestApplication(plugins=[a, b])
-        self.assertEqual([1, 2, 3], application.get_extensions("x"))
-
-    def test_contributes_to_decorator_ignored_if_trait_present(self):
-        """ contributes to decorator ignored if trait present """
-
-        class PluginA(Plugin):
-            id = "A"
-            x = ExtensionPoint(List, id="x")
-
-        class PluginB(Plugin):
-            id = "B"
-            x = List([1, 2, 3], contributes_to="x")
-
-            @contributes_to("x")
-            def _x_contributions(self):
-                return [4, 5, 6]
-
-        a = PluginA()
-        b = PluginB()
-
-        application = TestApplication(plugins=[a, b])
         self.assertEqual([1, 2, 3], application.get_extensions("x"))
 
     def test_add_plugins_to_empty_application(self):


### PR DESCRIPTION
This PR removes the `contributes_to` decorator and the supporting code and tests.
This PR also stops checking for contributions to extension points in the `f"enthought.{extension_point_id}"` namespace.

fixes #399 and #398 