### PR TITLE
Replace "Either" trait type with "Union"

### DIFF
--- a/envisage/service_offer.py
+++ b/envisage/service_offer.py
@@ -11,7 +11,7 @@
 
 
 # Enthought library imports.
-from traits.api import Callable, Dict, Either, HasTraits, Str, Type
+from traits.api import Callable, Dict, HasTraits, Str, Type, Union
 
 
 class ServiceOffer(HasTraits):
@@ -25,7 +25,7 @@ class ServiceOffer(HasTraits):
     #: to import a class or interface.
     #:
     #: e.g. 'foo.bar.baz.Baz' is turned into 'from foo.bar.baz import Baz'
-    protocol = Either(Str, Type)
+    protocol = Union(Str, Type)
 
     #: A callable (or a string that can be used to import a callable) that is
     #: the factory that creates the actual service object.
@@ -35,7 +35,7 @@ class ServiceOffer(HasTraits):
     #:   callable(**properties) -> Any
     #:
     #: e.g. 'foo.bar.baz.Baz' is turned into 'from foo.bar.baz import Baz'
-    factory = Either(Str, Callable)
+    factory = Union(Str, Callable)
 
     #: An optional set of properties to associate with the service offer.
     #:


### PR DESCRIPTION
This PR replaces the `Either` trait with the `Union` trait.

> A new Union trait type has been added. This is intended as a simpler replacement for the existing Either trait type, which will eventually be deprecated.

See https://github.com/enthought/traits/releases/tag/6.1.0.

See similar PR in traitsui https://github.com/enthought/traitsui/pull/1581