### PR TITLE
Start to fix Attractors example

### DIFF
--- a/envisage/examples/demo/plugins/tasks/attractors/model/henon.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/henon.py
@@ -1,4 +1,5 @@
 # System library imports.
+import numpy as np
 from scipy import array, zeros
 
 # Enthought library imports.
@@ -30,7 +31,7 @@ class Henon(HasTraits):
     b = Float(0.3, auto_set=False, enter_set=True)
 
     # Iteration parameters.
-    initial_point = Array(value=[0.1, 0.1])
+    initial_point = Array(dtype=np.float64, value=[0.1, 0.1])
     steps = Int(10000)
 
     # Iteration results.

--- a/envisage/examples/demo/plugins/tasks/attractors/model/lorenz.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/lorenz.py
@@ -1,4 +1,5 @@
 # System library imports.
+import numpy as np
 from scipy import arange, array
 from scipy.integrate import odeint
 
@@ -42,7 +43,7 @@ class Lorenz(HasTraits):
     beta = Float(8.0 / 3.0, auto_set=False, enter_set=True)
 
     # Integration parameters.
-    initial_point = Array(value=[0.0, 1.0, 0.0])
+    initial_point = Array(dtype=np.float64, value=[0.0, 1.0, 0.0])
     time_start = Float(0.0)
     time_stop = Float(100.0)
     time_step = Float(0.01)

--- a/envisage/examples/demo/plugins/tasks/attractors/model/rossler.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/rossler.py
@@ -1,4 +1,5 @@
 # System library imports.
+import numpy as np
 from scipy import arange, array
 from scipy.integrate import odeint
 
@@ -40,7 +41,7 @@ class Rossler(HasTraits):
     c = Float(5.7, auto_set=False, enter_set=True)
 
     # Integration parameters.
-    initial_point = Array(value=[0.0, 1.0, 0.0])
+    initial_point = Array(dtype=np.float64, value=[0.0, 1.0, 0.0])
     time_start = Float(0.0)
     time_stop = Float(100.0)
     time_step = Float(0.01)


### PR DESCRIPTION
~fixes~ starts process of fixing #404

Previously changing `initial_point` at all one got the traceback:
```
Exception occurred in traits notification handler for event object: TraitChangeEvent(object=<attractors.model.henon.Henon object at 0x7fcc0ae66e60>, name='initial_point', old=array([0.1, 0.1]), new=array(['0.13', '0.1'], dtype='<U4'))
Traceback (most recent call last):
  File "/Users/aayres/.edm/envs/envisage-test-3.6-pyqt5/lib/python3.6/site-packages/traits/observation/_trait_event_notifier.py", line 122, in __call__
    self.dispatcher(handler, event)
  File "/Users/aayres/.edm/envs/envisage-test-3.6-pyqt5/lib/python3.6/site-packages/traits/observation/observe.py", line 26, in dispatch_same
    handler(event)
  File "/Users/aayres/.edm/envs/envisage-test-3.6-pyqt5/lib/python3.6/site-packages/traits/has_traits.py", line 328, in handler
    instance.trait_property_changed(property_name, old)
  File "/Users/aayres/.edm/envs/envisage-test-3.6-pyqt5/lib/python3.6/site-packages/traits/has_traits.py", line 927, in decorator
    self.__dict__[name] = result = function(self)
  File "envisage/examples/demo/plugins/tasks/attractors/model/henon.py", line 68, in _get_points
    point = array([y + 1 - self.a * x ** 2, self.b * x])
TypeError: must be str, not int
```
Inserting a print statement (`print(type(point), point.dtype, point)`) I saw that :
```
<class 'numpy.ndarray'> float64 [0.1 0.1]
<class 'numpy.ndarray'> <U4 ['0.13' '0.1']
```
so by changing a value on `initial_point` we ended up changing the dtype leading to problems.  We always want floats.



Note even after this fix there are still other problems with the example
