### PR TITLE
Prepare 6.0 maintenance branch for 6.0.1 bugfix release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ from setuptools import setup, find_packages
 # into the package source.
 MAJOR = 6
 MINOR = 0
-MICRO = 0
+MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = True
+IS_RELEASED = False
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
Simply update the `MICRO` version in the setup file and flip back `IS_RELEASED` to `False`.