### PR TITLE
WIP: Remove eagerness to evaluate extension points.

### DIFF
--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -183,13 +183,6 @@ class ExtensionPoint(TraitType):
                 # normal trait changed event.
                 _update_cache(obj, trait_name)
 
-        # In case the cache was created first and the registry is then mutated
-        # before this ``connect`` is called, the internal cache would be in
-        # an inconsistent state. This also has the side-effect of firing
-        # another change event, hence allowing future changes to be observed
-        # without having to access the trait first.
-        _update_cache(obj, trait_name)
-
         extension_registry = self._get_extension_registry(obj)
 
         # Add the listener to the extension registry.

--- a/envisage/tests/test_extension_point.py
+++ b/envisage/tests/test_extension_point.py
@@ -14,8 +14,6 @@ import pickle
 import unittest
 import weakref
 
-from traits.api import Undefined
-
 # Enthought library imports.
 from envisage.api import Application, ExtensionPoint
 from envisage.api import ExtensionRegistry, IExtensionRegistry
@@ -322,8 +320,8 @@ class ExtensionPointTestCase(unittest.TestCase):
 
         self.assertEqual([42], registry.get_extensions("my.ep"))
 
-    def test_set_typed_extension_point_emit_change(self):
-        """ Test change event is emitted for setting the extension point """
+    def test_set_typed_extension_point_no_change_event(self):
+        """ Test change event is NOT emitted by connecting the extension."""
 
         registry = self.registry
 
@@ -349,13 +347,8 @@ class ExtensionPointTestCase(unittest.TestCase):
         ExtensionPoint.connect_extension_point_traits(f)
 
         # then
-        self.assertEqual(len(on_trait_change_events), 1)
-        self.assertEqual(len(observed_events), 1)
-        event, = observed_events
-        self.assertEqual(event.object, f)
-        self.assertEqual(event.name, "x")
-        self.assertEqual(event.old, Undefined)
-        self.assertEqual(event.new, [])
+        self.assertEqual(len(on_trait_change_events), 0)
+        self.assertEqual(len(observed_events), 0)
 
     def test_object_garbage_collectable(self):
         """ object can be garbage collected after disconnecting listeners."""

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -116,6 +116,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         application = TestApplication(plugins=[a, b, c])
         application.start()
 
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
+
         # Append a contribution.
         b.x.append(4)
 
@@ -154,6 +159,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         application = TestApplication(plugins=[a, b, c])
         application.start()
 
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
+
         # Append a contribution.
         b.x.append(4)
 
@@ -175,6 +185,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
 
         application = TestApplication(plugins=[a, b, c])
         application.start()
+
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
 
         # Remove a contribution.
         b.x.remove(3)
@@ -214,6 +229,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         application = TestApplication(plugins=[a, b, c])
         application.start()
 
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
+
         # Remove a contribution.
         b.x.remove(3)
 
@@ -235,6 +255,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
 
         application = TestApplication(plugins=[a, b, c])
         application.start()
+
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
 
         # Assign an empty list to one of the plugin's contributions.
         b.x = []
@@ -275,6 +300,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         application = TestApplication(plugins=[a, b, c])
         application.start()
 
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
+
         # Assign an empty list to one of the plugin's contributions.
         b.x = []
 
@@ -286,6 +316,38 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual(event.removed, [1, 2, 3])
         self.assertEqual(event.index, 0)
 
+    def test_assign_empty_list_no_event(self):
+        """ assign empty list no event """
+
+        a = PluginA()
+        a.on_trait_change(listener, "x_items")
+        b = PluginB()
+        c = PluginC()
+
+        application = TestApplication(plugins=[a, b, c])
+        application.start()
+
+        # Assign an empty list to one of the plugin's contributions.
+        b.x = []
+
+        # Make sure we pick up the correct contribution via the application.
+        extensions = application.get_extensions("a.x")
+        extensions.sort()
+
+        self.assertEqual(3, len(extensions))
+        self.assertEqual([98, 99, 100], extensions)
+
+        # Make sure we pick up the correct contribution via the plugin.
+        extensions = a.x[:]
+        extensions.sort()
+
+        self.assertEqual(3, len(extensions))
+        self.assertEqual([98, 99, 100], extensions)
+
+        # We shouldn't get a trait event here because we haven't accessed the
+        # extension point yet!
+        self.assertEqual(None, listener.obj)
+
     def test_assign_non_empty_list(self):
         """ assign non-empty list """
 
@@ -296,6 +358,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
 
         application = TestApplication(plugins=[a, b, c])
         application.start()
+
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
 
         # Keep the old values for later slicing check
         source_values = list(a.x)
@@ -349,6 +416,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
 
         application = TestApplication(plugins=[a, b, c])
         application.start()
+
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
 
         # Assign a non-empty list to one of the plugin's contributions.
         b.x = [2, 4, 6, 8]
@@ -426,6 +498,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         application = TestApplication(plugins=[a, b])
         application.start()
 
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3], a.x)
+
         # Now add the other plugin.
         application.add_plugin(c)
 
@@ -501,6 +578,11 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         application = TestApplication(plugins=[a, b, c])
         application.start()
 
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
+
         # Now remove one plugin.
         application.remove_plugin(b)
 
@@ -540,8 +622,10 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         # Now we start the application, which connects the listener.
         application.start()
 
-        # then
-        self.assertEqual(a.x, [4, 5, 6, 98, 99, 100])
+        # fixme: If the extension point has not been accessed then the
+        # provider extension registry can't work out what has changed, so it
+        # won't fire a changed event.
+        self.assertEqual([1, 2, 3, 98, 99, 100], a.x)
 
         # Change the value again.
         b.x = [1, 2]
@@ -555,7 +639,7 @@ class ExtensionPointChangedTestCase(unittest.TestCase):
         self.assertEqual(event.object, a.x)
         self.assertEqual(event.index, 0)
         self.assertEqual(event.added, [1, 2])
-        self.assertEqual(event.removed, [4, 5, 6])
+        self.assertEqual(event.removed, [1, 2, 3])
 
 
 class TestExtensionPointChangedEvent(unittest.TestCase):


### PR DESCRIPTION
This may fix #417

Prior to #354, there are a number of FIXME comments in the tests indicating that it was a bug to have to rely on first access of an extension in order for subsequent change events to fire. #417 suggests that this is either a bug turned feature, or the FIXMEs then were misguided.

The laziness is relied on. Change events should not be fired until after first access.

The FIXMEs should be changed in light of #417, as they are not actually something need solving.