### PR TITLE
Release Envisage 6.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ MAJOR = 6
 MINOR = 0
 MICRO = 1
 PRERELEASE = ""
-IS_RELEASED = False
+IS_RELEASED = True
 
 # If this file is part of a Git export (for example created with "git archive",
 # or downloaded from GitHub), ARCHIVE_COMMIT_HASH gives the full hash of the


### PR DESCRIPTION
This PR simply flips `IS_RELEASED` from `False` to `True`, thereby making the 6.0.1 Envisage Release. The squash-merged commit on the `maint/6.0` branch will be tagged as the release commit.