### PR TITLE
Revert recent changes to flake8 command in etstool.py

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -309,15 +309,7 @@ def flake8(edm, runtime, toolkit, environment):
 
     """
     parameters = get_parameters(edm, runtime, toolkit, environment)
-    targets = [
-        "envisage",
-        "docs",
-        "etstool.py",
-        "setup.py",
-    ]
-    commands = [
-        "{edm} run -e {environment} -- python -m flake8 " + " ".join(targets)
-    ]
+    commands = ["{edm} run -e {environment} -- python -m flake8 "]
     execute(commands, parameters)
 
 


### PR DESCRIPTION
Follow up to #426, see comment: https://github.com/enthought/envisage/pull/426#pullrequestreview-690385930

These changes should no longer be needed as we don't mess with the edm root directory anymore on the gh action workflows.