### PR TITLE
Setup slack notification for cron jobs

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -53,3 +53,31 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
+
+  notify-on-failure:
+    needs: test-with-edm
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-success:
+    needs: test-with-edm
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}

--- a/.github/workflows/test-wx.yml
+++ b/.github/workflows/test-wx.yml
@@ -44,3 +44,31 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
+
+  notify-on-failure:
+    needs: test-with-edm
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on failure
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: FAILED
+          color: danger
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}
+
+  notify-on-success:
+    needs: test-with-edm
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack channel on success
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          status: SUCCESS
+          color: good
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_ACTION_SECRET }}


### PR DESCRIPTION
This PR sets up slack notification for the cron jobs. I manually triggered the cron jobs on this branch to ensure that the slack notifications get fired. Ref https://github.com/enthought/envisage/actions/runs/1027278891 and https://github.com/enthought/envisage/actions/runs/1027279665

One more step towards https://github.com/enthought/ets/issues/65