### PR TITLE
Fix a test that only passed due to test interactions

### DIFF
--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -29,18 +29,19 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
     def setUp(self):
         """ Prepares the test fixture before each test method is called. """
 
+        # Some tests cause sys.path to be modified. Capture the original
+        # contents so that we can restore sys.path later.
+        self._original_sys_path_contents = sys.path[:]
+
         # The location of the 'eggs' test data directory.
         self.eggs_dir = join(dirname(__file__), "eggs")
         self.bad_eggs_dir = join(dirname(__file__), "bad_eggs")
 
     def tearDown(self):
         """ Called immediately after each test method has been called. """
-        # Undo any side-effects: egg_basket_plugin_manager modifies sys.path.
-        sys_path = []
-        for path in sys.path:
-            if self.bad_eggs_dir not in path:
-                sys_path.append(path)
-        sys.path = sys_path
+
+        # Undo any sys.path modifications
+        sys.path[:] = self._original_sys_path_contents
 
         # `envisage.egg_utils.get_entry_points_in_egg_order` modifies the
         # global working set.

--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -188,6 +188,10 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
             iter(plugin_manager)
 
     def test_ignore_broken_distributions_loads_good_distributions(self):
+        # Make sure that the acme.foo distribution is already in the
+        # working set, with version 0.1a1.
+        pkg_resources.working_set.add_entry(join(self.eggs_dir, "acme.foo"))
+
         data = {"count": 0}
 
         def on_broken_distribution(dist, exc):

--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -174,9 +174,13 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         self.assertTrue(isinstance(exc, ImportError))
 
     def test_ignore_broken_distributions_raises_exceptions_by_default(self):
+        # Make sure that the acme.foo distribution is already in the
+        # working set, with version 0.1a1.
+        pkg_resources.working_set.add_entry(join(self.eggs_dir, "acme.foo"))
+
         plugin_manager = EggBasketPluginManager(
             plugin_path=[
-                self.bad_eggs_dir,
+                # Attempt to add acme.foo, with conflicting version 0.1a11
                 self._create_broken_distribution_eggdir("acme.foo*.egg"),
             ],
         )

--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -175,9 +175,10 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
         self.assertTrue(isinstance(exc, ImportError))
 
     def test_ignore_broken_distributions_raises_exceptions_by_default(self):
-        # Make sure that the acme.foo distribution is already in the
-        # working set, with version 0.1a1.
-        pkg_resources.working_set.add_entry(join(self.eggs_dir, "acme.foo"))
+        # Make sure that the distributions from eggs are already in the working
+        # set. This includes acme.foo, with version 0.1a1.
+        for dist in pkg_resources.find_distributions(self.eggs_dir):
+            pkg_resources.working_set.add(dist)
 
         plugin_manager = EggBasketPluginManager(
             plugin_path=[
@@ -189,9 +190,10 @@ class EggBasketPluginManagerTestCase(unittest.TestCase):
             iter(plugin_manager)
 
     def test_ignore_broken_distributions_loads_good_distributions(self):
-        # Make sure that the acme.foo distribution is already in the
-        # working set, with version 0.1a1.
-        pkg_resources.working_set.add_entry(join(self.eggs_dir, "acme.foo"))
+        # Make sure that the distributions from eggs are already in the working
+        # set. This includes acme.foo, with version 0.1a1.
+        for dist in pkg_resources.find_distributions(self.eggs_dir):
+            pkg_resources.working_set.add(dist)
 
         data = {"count": 0}
 


### PR DESCRIPTION
Fix a test that was only passing as a result of side-effects from other tests in the same `TestCase`.

The test was passing when run as part of the complete test case because a distribution of `acme.foo` with version `0.1a1` was already in the global working set. This PR changes the test to explicitly add `acme.foo` to the global working set, so that the test passes both standalone and as part of the whole test case.

(Note that the global working set is reset at `tearDown` time, though I plan another PR to clean up the test side-effects.)

Closes #441 
