### PR TITLE
Fix EggPluginManager to use current pkg_resources.working_set

### DIFF
--- a/envisage/egg_plugin_manager.py
+++ b/envisage/egg_plugin_manager.py
@@ -54,7 +54,7 @@ class EggPluginManager(PluginManager):
     # The working set that contains the eggs that contain the plugins that
     # live in the house that Jack built ;^) By default we use the global
     # working set.
-    working_set = Instance(pkg_resources.WorkingSet, pkg_resources.working_set)
+    working_set = Instance(pkg_resources.WorkingSet)
 
     # An optional list of the Ids of the plugins that are to be excluded by
     # the manager.
@@ -89,6 +89,11 @@ class EggPluginManager(PluginManager):
         logger.debug("egg plugin manager found plugins <%s>", plugins)
 
         return plugins
+
+    def _working_set_default(self):
+        """ Trait initializer. """
+
+        return pkg_resources.working_set
 
     ###########################################################################
     # Private interface.

--- a/envisage/tests/test_egg_plugin_manager.py
+++ b/envisage/tests/test_egg_plugin_manager.py
@@ -9,6 +9,9 @@
 # Thanks for using Enthought open source!
 """ Tests for the Egg plugin manager. """
 
+# 3rd party imports.
+import pkg_resources
+
 # Enthought library imports.
 from envisage.api import EggPluginManager
 
@@ -131,6 +134,16 @@ class EggPluginManagerTestCase(EggBasedTestCase):
         # Make sure the plugin manager found only the required plugins and that
         # it starts and stops them correctly..
         self._test_start_and_stop(plugin_manager, expected)
+
+    def test_uses_global_working_set_by_default(self):
+        old_working_set = pkg_resources.working_set
+
+        # Create fresh working set for this test, to make sure that the plugin
+        # manager picks up the *current* value of pkg_resources.working_set.
+        pkg_resources.working_set = pkg_resources.WorkingSet()
+
+        plugin_manager = EggPluginManager()
+        self.assertEqual(plugin_manager.working_set, pkg_resources.working_set)
 
     ###########################################################################
     # Private interface.

--- a/envisage/tests/test_egg_plugin_manager.py
+++ b/envisage/tests/test_egg_plugin_manager.py
@@ -136,14 +136,20 @@ class EggPluginManagerTestCase(EggBasedTestCase):
         self._test_start_and_stop(plugin_manager, expected)
 
     def test_uses_global_working_set_by_default(self):
-        old_working_set = pkg_resources.working_set
+        original_working_set = pkg_resources.working_set
 
-        # Create fresh working set for this test, to make sure that the plugin
-        # manager picks up the *current* value of pkg_resources.working_set.
-        pkg_resources.working_set = pkg_resources.WorkingSet()
-
-        plugin_manager = EggPluginManager()
-        self.assertEqual(plugin_manager.working_set, pkg_resources.working_set)
+        try:
+            # Create fresh working set for this test, to make sure that the
+            # plugin manager picks up the *current* value of
+            # pkg_resources.working_set.
+            pkg_resources.working_set = pkg_resources.WorkingSet()
+            plugin_manager = EggPluginManager()
+            self.assertEqual(
+                plugin_manager.working_set,
+                pkg_resources.working_set,
+            )
+        finally:
+            pkg_resources.working_set = original_working_set
 
     ###########################################################################
     # Private interface.


### PR DESCRIPTION
The `EggPluginManager` uses the following trait definition for its working set:

```
working_set = Instance(pkg_resources.WorkingSet, pkg_resources.working_set)
```

This means that we're capturing the value of `pkg_resources.working_set` at import time, and using that value as the default for each `EggPluginManager`.

For testing purposes, it's convenient to be able to use a temporary replacement working set for `pkg_resources.working_set` to avoid test interactions. But this currently doesn't work.

This PR changes the `working_set` trait so that it looks up `pkg_resources.working_set` on first use, on a per-`EggPluginManager`-instance basis, instead of doing that lookup just once at import time.
