### PR TITLE
 Default branch has been renamed from "master" to "main"

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -12,8 +12,8 @@ Release by YYYY-MM-DD
 
 Release candidate
 -------------------
-- [ ] Verify that all relevant PRs have been merged to master.
-- [ ] Create a PR against master to bump version number, merge that PR
+- [ ] Verify that all relevant PRs have been merged to ``main``.
+- [ ] Create a PR against ``main`` to bump version number, merge that PR
 - [ ] From the commit just before bumping the version, create a new branch `maint/<release version number>`
 - [ ] Update changelog and open PR targeting a new `maint/<release version number>` branch
 - [ ] Update `ci-src-requirements.txt` if needed
@@ -36,7 +36,7 @@ Release blockers
 
 Pre-release
 ---
-- [ ] Backport PRs that have been merged to master to the maintenance branch. Use the "need backport ..." tag if there is one (but don't rely 100% on it)
+- [ ] Backport PRs that have been merged to ``main`` to the maintenance branch. Use the "need backport ..." tag if there is one (but don't rely 100% on it)
 - [ ] Verify that no other open issue needs to be addressed before the release.
 - [ ] Test against other ETS packages and other ETS-using projects
 - [ ] Check MANIFEST, requirements, changelog are still up to date.
@@ -60,6 +60,6 @@ Release
 Post-release
 -------------
 - [ ] Package update for `enthought/free` repository (for EDM)
-- [ ] Backport release note and change log to master, and possibly `maint/<release version number>` branch.
+- [ ] Backport release note and change log to ``main``, and possibly `maint/<release version number>` branch.
 - [ ] Update GitHub Release pages https://github.com/enthought/envisage/releases
 - [ ] Announcement (e.g. Google Group)

--- a/README.rst
+++ b/README.rst
@@ -2,14 +2,6 @@
 envisage: extensible application framework
 ==========================================
 
-.. image:: https://travis-ci.org/enthought/envisage.svg?branch=master
-    :alt: Build Status
-    :target: https://travis-ci.org/enthought/envisage
-
-.. image:: https://codecov.io/github/enthought/envisage/coverage.svg?branch=master
-    :alt: Code Coverage
-    :target: https://codecov.io/github/enthought/envisage?branch=master
-
 Documentation: https://docs.enthought.com/envisage
 
 Envisage is a Python-based framework for building extensible applications,
@@ -32,9 +24,9 @@ The Envisage project provides the basic machinery of the Envisage
 framework. You are free to use:
 
 - the envisage ``CorePlugin`` available through the
-  `envisage.api <https://github.com/enthought/envisage/blob/master/envisage/api.py>`__ module
+  `envisage.api <https://github.com/enthought/envisage/blob/main/envisage/api.py>`__ module
 - plug-ins from the envisage
-  `plugins <https://github.com/enthought/envisage/tree/master/envisage/plugins>`__ module
+  `plugins <https://github.com/enthought/envisage/tree/main/envisage/plugins>`__ module
 - plug-ins from other ETS projects that expose their functionality as plug-ins
 - plug-ins that you create yourself
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -233,6 +233,6 @@ intersphinx_mapping = {
 
 extlinks = {
     'github-demo': (
-        'https://github.com/enthought/envisage/tree/master/envisage/examples/demo/%s',   # noqa: E501
+        'https://github.com/enthought/envisage/tree/main/envisage/examples/demo/%s',   # noqa: E501
         '')
 }

--- a/etstool.py
+++ b/etstool.py
@@ -256,7 +256,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
             github_url_fmt.format(pkg) for pkg in source_dependencies
         ]
         # Without the --no-dependencies flag such that new dependencies on
-        # master are brought in.
+        # main branch are brought in.
         commands = [
             "python -m pip install --force-reinstall {pkg}".format(pkg=pkg)
             for pkg in source_pkgs


### PR DESCRIPTION
This PR replaces the use of `master` in the repo with `main` as the default branch name as been updated.