### PR TITLE
 Don't link to examples on the main branch in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -233,6 +233,6 @@ intersphinx_mapping = {
 
 extlinks = {
     'github-demo': (
-        'https://github.com/enthought/envisage/tree/main/envisage/examples/demo/%s',   # noqa: E501
+        f'https://github.com/enthought/envisage/tree/{version}/envisage/examples/demo/%s',   # noqa: E501
         '')
 }


### PR DESCRIPTION
At the moment, the documentation links to examples on the `main`/default branch. This isn't right because the examples might change in between releases, potentially confusing users who are referring to the documentation. This PR fixes that problem by making the documentation use version-specific links i.e. for the 6.0.1 release, the `6.0.1` tag will be used instead of the `main` branch.

I tested this locally by checking the links generated in the built docs - the examples links will be broken as expected as the dev version has no corresponding tag on GitHub. I then hardcoded the version in the sphinx configuration to `6.0.1` and the links worked as expected, pointing to the `6.0.1` tree instead of `main`.