### PR TITLE
Fix test hangs with PySide2 / macOS 11

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   INSTALL_EDM_VERSION: 3.2.3
+  QT_MAC_WANTS_LAYER: 1
 
 jobs:
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -8,6 +8,7 @@ on: pull_request
 
 env:
   INSTALL_EDM_VERSION: 3.2.3
+  QT_MAC_WANTS_LAYER: 1
 
 jobs:
 


### PR DESCRIPTION
The cron job recently started hanging for builds on PySide2 / macOS; this seems likely to be related to the GitHub Actions move to macOS 11 for its workers.

This PR contains a probable fix for the issue. Note that the `test-with-pypi.yml` workflow has _not_ been updated: our hypothesis is that it's only EDM builds of PySide2 that are affected.

(see also enthought/pyface#1056)

xref: https://github.com/enthought/envisage/runs/4558034418?check_suite_focus=true