### PR TITLE
Update package resource protocol to use importlib.resources

### DIFF
--- a/envisage/resource/package_resource_protocol.py
+++ b/envisage/resource/package_resource_protocol.py
@@ -58,6 +58,7 @@ class PackageResourceProtocol(HasTraits):
             TypeError,  # TypeError is raised if package is a module
             FileNotFoundError,
             IsADirectoryError,
+            PermissionError,
         ):
             raise NoSuchResourceError(address)
 

--- a/envisage/resource/package_resource_protocol.py
+++ b/envisage/resource/package_resource_protocol.py
@@ -11,7 +11,6 @@
 
 
 # Standard library imports.
-import errno
 try:
     from importlib.resources import files
 except ImportError:

--- a/envisage/resource/package_resource_protocol.py
+++ b/envisage/resource/package_resource_protocol.py
@@ -54,7 +54,9 @@ class PackageResourceProtocol(HasTraits):
 
         try:
             f = files(package).joinpath(*resource_path).open('rb')
-        except (ModuleNotFoundError, TypeError, FileNotFoundError, IsADirectoryError):
+        except (
+            ModuleNotFoundError, TypeError, FileNotFoundError, IsADirectoryError,
+        ):
             # TypeError is raised if package is a module
             raise NoSuchResourceError(address)
 

--- a/envisage/resource/package_resource_protocol.py
+++ b/envisage/resource/package_resource_protocol.py
@@ -55,9 +55,11 @@ class PackageResourceProtocol(HasTraits):
         try:
             f = files(package).joinpath(*resource_path).open('rb')
         except (
-            ModuleNotFoundError, TypeError, FileNotFoundError, IsADirectoryError,
+            ModuleNotFoundError,
+            TypeError,  # TypeError is raised if package is a module
+            FileNotFoundError,
+            IsADirectoryError,
         ):
-            # TypeError is raised if package is a module
             raise NoSuchResourceError(address)
 
         return f

--- a/envisage/resource/package_resource_protocol.py
+++ b/envisage/resource/package_resource_protocol.py
@@ -12,9 +12,10 @@
 
 # Standard library imports.
 import errno
-
-# 3rd party imports.
-import pkg_resources
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 # Enthought library imports.
 from traits.api import HasTraits, provides
@@ -28,7 +29,7 @@ from .no_such_resource_error import NoSuchResourceError
 class PackageResourceProtocol(HasTraits):
     """ A resource protocol for package resources.
 
-    This protocol uses 'pkg_resources' to find and access resources.
+    This protocol uses 'importlib.resources' to find and access resources.
 
     An address for this protocol is a string in the form::
 
@@ -37,8 +38,6 @@ class PackageResourceProtocol(HasTraits):
     e.g::
 
         'acme.ui.workbench/preferences.ini'
-
-
     """
 
     ###########################################################################
@@ -54,7 +53,7 @@ class PackageResourceProtocol(HasTraits):
         resource_name = address[first_forward_slash + 1:]
 
         try:
-            f = pkg_resources.resource_stream(package, resource_name)
+            f = (files(package) / resource_name).open('rb')
 
         except IOError as e:
             if e.errno == errno.ENOENT:

--- a/envisage/resource/tests/test_resource_manager.py
+++ b/envisage/resource/tests/test_resource_manager.py
@@ -12,13 +12,14 @@
 
 # Standard library imports.
 import unittest
+from io import StringIO
 from urllib.error import HTTPError
 import urllib.request
+try:
+    from importlib.resources import files, as_file
+except ImportError:
+    from importlib_resources import files, as_file
 
-from io import StringIO
-
-# Major package imports.
-from pkg_resources import resource_filename
 
 # Enthought library imports.
 from envisage.resource.api import ResourceManager
@@ -74,17 +75,18 @@ class ResourceManagerTestCase(unittest.TestCase):
         rm = ResourceManager()
 
         # Get the filename of the 'api.py' file.
-        filename = resource_filename("envisage.resource", "api.py")
+        resource = files("envisage.resource") / "api.py"
+        with as_file(resource) as path:
 
-        # Open a file resource.
-        f = rm.file("file://" + filename)
-        self.assertNotEqual(f, None)
-        contents = f.read()
-        f.close()
+            # Open a file resource.
+            f = rm.file(f"file://{path}")
+            self.assertNotEqual(f, None)
+            contents = f.read()
+            f.close()
 
-        # Open the api file via the file system.
-        with open(filename, "rb") as g:
-            self.assertEqual(g.read(), contents)
+            # Open the api file via the file system.
+            with open(path, "rb") as g:
+                self.assertEqual(g.read(), contents)
 
     def test_no_such_file_resource(self):
         """ no such file resource """
@@ -106,11 +108,25 @@ class ResourceManagerTestCase(unittest.TestCase):
         contents = f.read()
         f.close()
 
-        # Get the filename of the 'api.py' file.
-        filename = resource_filename("envisage.resource", "api.py")
+        # Get the bytes of the 'api.py' file.
+        resource = files("envisage.resource") / "api.py"
+        with resource.open("rb") as g:
+            self.assertEqual(g.read(), contents)
 
-        # Open the api file via the file system.
-        with open(filename, "rb") as g:
+    def test_package_resource_subdir(self):
+        """ package resource """
+
+        rm = ResourceManager()
+
+        # Open a package resource.
+        f = rm.file("pkgfile://envisage.resource/tests/__init__.py")
+        self.assertNotEqual(f, None)
+        contents = f.read()
+        f.close()
+
+        # Get the bytes of the 'api.py' file.
+        resource = files("envisage.resource") / "tests" / "__init__.py"
+        with resource.open("rb") as g:
             self.assertEqual(g.read(), contents)
 
     def test_no_such_package_resource(self):
@@ -120,10 +136,19 @@ class ResourceManagerTestCase(unittest.TestCase):
 
         # Open a package resource.
         with self.assertRaises(NoSuchResourceError):
+            rm.file("pkgfile://envisage.resource/")
+
+        with self.assertRaises(NoSuchResourceError):
+            rm.file("pkgfile:///envisage")
+
+        with self.assertRaises(NoSuchResourceError):
             rm.file("pkgfile://envisage.resource/bogus.py")
 
         with self.assertRaises(NoSuchResourceError):
             rm.file("pkgfile://completely.bogus/bogus.py")
+
+        with self.assertRaises(NoSuchResourceError):
+            rm.file("pkgfile://envisage.resource.resource_manager/anything")
 
     def test_http_resource(self):
         """ http resource """

--- a/setup.py
+++ b/setup.py
@@ -310,7 +310,12 @@ if __name__ == "__main__":
                 "demo_examples = envisage.examples._etsdemo_info:info",
             ],
         },
-        install_requires=["apptools", "setuptools", "traits>=6.2"],
+        install_requires=[
+            "apptools",
+            "setuptools",
+            "traits>=6.2",
+            'importlib-resources>=1.1.0; python_version<"3.9"',
+        ],
         extras_require={
             "docs": ["enthought-sphinx-theme", "Sphinx>=2.1.0,!=3.2.0"],
             "ipython": ["ipython<8", "ipykernel<6", "traitlets<5.1"],


### PR DESCRIPTION
Use `importlib.resources` in `PackageResourceProtocol` instead of `pkg_resources`.  Revised code should be completely compatible: `file` returns a byte stream, just as the `pkg_resources`-based code did.  Modernized error handling based on what `importlib.resources` raises for the cases we are interested in.

Also updated tests to use `importlib.resources`, and expanded their scope to catch some other cases of note.

There are other uses of `pkg_resources` in the codebase which are out of scope for this PR.