### PR TITLE
Use the "sphinx-copybutton" extension in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -220,13 +220,6 @@ latex_logo = "e-logo-rev.png"
 # If false, no module index is generated.
 # latex_use_modindex = True
 
-# Options for Sphinx copybutton extension
-# ---------------------------------------
-
-# Matches prompts - "$ ", ">>>" and "..."
-copybutton_prompt_text = r">>> |\.\.\. |\$ "
-copybutton_prompt_is_regexp = True
-
 # -- Options for intersphinx extension ---------------------------------------
 
 intersphinx_mapping = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
     "traits.util.trait_documenter",
 ]
 
@@ -218,6 +219,13 @@ latex_logo = "e-logo-rev.png"
 
 # If false, no module index is generated.
 # latex_use_modindex = True
+
+# Options for Sphinx copybutton extension
+# ---------------------------------------
+
+# Matches prompts - "$ ", ">>>" and "..."
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/etstool.py
+++ b/etstool.py
@@ -244,13 +244,12 @@ def install(edm, runtime, toolkit, environment, editable, source):
                 "{edm} run -e {environment} -- python -m pip install wxPython"
             )
 
-    if pypi_dependencies:
-        commands.extend(
-            [
-                "{edm} run -e {environment} -- pip install " + dep
-                for dep in pypi_dependencies
-            ]
-        )
+    commands.extend(
+        [
+            "{edm} run -e {environment} -- pip install " + dep
+            for dep in pypi_dependencies
+        ]
+    )
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/etstool.py
+++ b/etstool.py
@@ -114,6 +114,9 @@ dependencies = {
     "traitsui",
 }
 
+# Dependencies we install from PyPI
+pypi_dependencies = {"sphinx-copybutton"}
+
 # Dependencies we install from source for cron tests
 # Order from packages with the most dependencies to one with the least
 # dependencies. Packages are forced re-installed in this order.
@@ -240,6 +243,14 @@ def install(edm, runtime, toolkit, environment, editable, source):
             commands.append(
                 "{edm} run -e {environment} -- python -m pip install wxPython"
             )
+
+    if pypi_dependencies:
+        commands.extend(
+            [
+                "{edm} run -e {environment} -- pip install " + dep
+                for dep in pypi_dependencies
+            ]
+        )
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/setup.py
+++ b/setup.py
@@ -319,7 +319,7 @@ if __name__ == "__main__":
         extras_require={
             "docs": [
                 "enthought-sphinx-theme",
-                "Sphinx>=2.1.0,!=3.2.0",
+                "Sphinx>=2.1.0",
                 "sphinx-copybutton",
             ],
             "ipython": ["ipython<8", "ipykernel<6", "traitlets<5.1"],

--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,11 @@ if __name__ == "__main__":
             'importlib-resources>=1.1.0; python_version<"3.9"',
         ],
         extras_require={
-            "docs": ["enthought-sphinx-theme", "Sphinx>=2.1.0,!=3.2.0"],
+            "docs": [
+                "enthought-sphinx-theme",
+                "Sphinx>=2.1.0,!=3.2.0",
+                "sphinx-copybutton",
+            ],
             "ipython": ["ipython<8", "ipykernel<6", "traitlets<5.1"],
             "test": ["coverage", "flake8"],
             "ui": ["pyface", "traitsui"],


### PR DESCRIPTION
This PR does the following: 
- Use the `sphinx_copybutton` extension when building the Sphinx documentation
- Make `sphinx-copybutton` a `docs` extra for the `envisage` package
- Add a `pypi_dependencies` section to the `etstool` utility and add `sphinx-copybutton` as a PyPI dependency for the moment.

Ref https://sphinx-copybutton.readthedocs.io/en/latest/