### PR TITLE
Bump version number for continued development towards Envisage 6.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import setup, find_packages
 # into the package source.
 MAJOR = 6
 MINOR = 1
-MICRO = 0
+MICRO = 1
 PRERELEASE = ""
 IS_RELEASED = False
 


### PR DESCRIPTION
This PR bumps the version on the maintenance branch for continued development towards Envisage 6.1.1 (should that prove necessary).