### PR TITLE
Install Traits without build isolation

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -255,7 +255,10 @@ def install(edm, runtime, toolkit, environment, editable, source):
         # Without the --no-dependencies flag such that new dependencies on
         # main branch are brought in.
         commands = [
-            "python -m pip install --force-reinstall {pkg}".format(pkg=pkg)
+            (
+                "python -m pip install --no-build-isolation "
+                "--force-reinstall {pkg}".format(pkg=pkg)
+            )
             for pkg in source_pkgs
         ]
         commands = [

--- a/etstool.py
+++ b/etstool.py
@@ -255,7 +255,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
 
         # Install build prerequisites from EDM (needed because we're avoiding
         # build isolation below).
-        commands = ["{edm} install -e {environment} setuptools wheel"]
+        commands = ["{edm} install -y -e {environment} setuptools wheel"]
         execute(commands, parameters)
 
         # Without the --no-dependencies flag such that new dependencies on
@@ -267,8 +267,8 @@ def install(edm, runtime, toolkit, environment, editable, source):
         commands = [
             (
                 "python -m pip install --no-build-isolation "
-                "--force-reinstall {pkg}".format(pkg=pkg)
-            )
+                "--force-reinstall {pkg}"
+            ).format(pkg=pkg)
             for pkg in source_pkgs
         ]
         commands = [

--- a/etstool.py
+++ b/etstool.py
@@ -252,8 +252,18 @@ def install(edm, runtime, toolkit, environment, editable, source):
         source_pkgs = [
             github_url_fmt.format(pkg) for pkg in source_dependencies
         ]
+
+        # Install build prerequisites from EDM (needed because we're avoiding
+        # build isolation below).
+        commands = ["{edm} install -e {environment} setuptools wheel"]
+        execute(commands, parameters)
+
         # Without the --no-dependencies flag such that new dependencies on
         # main branch are brought in.
+
+        # --no-build-isolation is necessary to temporarily work around
+        # an incompatibility between setuptools >= 65.2.0 and the EDM runtimes.
+        # See enthought/traits#1721.        
         commands = [
             (
                 "python -m pip install --no-build-isolation "

--- a/etstool.py
+++ b/etstool.py
@@ -263,7 +263,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
 
         # --no-build-isolation is necessary to temporarily work around
         # an incompatibility between setuptools >= 65.2.0 and the EDM runtimes.
-        # See enthought/traits#1721.        
+        # See enthought/traits#1721.
         commands = [
             (
                 "python -m pip install --no-build-isolation "


### PR DESCRIPTION
Currently building Traits from source fails thanks to an incompatibility between recent setuptools and EDM runtimes. This PR adds the `--no-build-isolation` flag so that the build uses the version of `setuptools` already in the EDM environment rather than the latest version from PyPI.

xref: enthought/traits#1721