### PR TITLE
Pin PySide6 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -334,7 +334,7 @@ if __name__ == "__main__":
                 # PySide6 6.4.0 has incompatible changes that Pyface hasn't
                 # yet adapted to. xref: enthought/pyface#1163
                 (
-                    "pyside6!=6.2.2,!=6.2.2.1,!=6.2.3,!=6.2.4,!=6.3.0;<6.4.0 "
+                    "pyside6!=6.2.2,!=6.2.2.1,!=6.2.3,!=6.2.4,!=6.3.0,<6.4.0; "
                     + "python_version<'3.8'"
                 ),
                 "pyside6<6.4.0; python_version>='3.8'",

--- a/setup.py
+++ b/setup.py
@@ -331,13 +331,13 @@ if __name__ == "__main__":
                 # Avoid https://bugreports.qt.io/browse/PYSIDE-1797, which
                 # causes some versions of PySide6 to be unimportable on Python
                 # 3.6 and 3.7.
-                (
-                    "pyside6!=6.2.2,!=6.2.2.1,!=6.2.3,!=6.2.4,!=6.3.0; "
-                    + "python_version<'3.8'"
-                ),
                 # PySide6 6.4.0 has incompatible changes that Pyface hasn't
                 # yet adapted to. xref: enthought/pyface#1163
-                "pyside6<6.4; python_version>='3.8'",
+                (
+                    "pyside6!=6.2.2,!=6.2.2.1,!=6.2.3,!=6.2.4,!=6.3.0;<6.4.0 "
+                    + "python_version<'3.8'"
+                ),
+                "pyside6<6.4.0; python_version>='3.8'",
             ],
         },
         license="BSD",

--- a/setup.py
+++ b/setup.py
@@ -335,7 +335,9 @@ if __name__ == "__main__":
                     "pyside6!=6.2.2,!=6.2.2.1,!=6.2.3,!=6.2.4,!=6.3.0; "
                     + "python_version<'3.8'"
                 ),
-                "pyside6; python_version>='3.8'",
+                # PySide6 6.4.0 has incompatible changes that Pyface hasn't
+                # yet adapted to. xref: enthought/pyface#1163
+                "pyside6<6.4; python_version>='3.8'",
             ],
         },
         license="BSD",


### PR DESCRIPTION
CI is currently failing thanks to a backwards incompatible change in PySide6 6.4.0, which affects Pyface. We'll pin the PySide6 version until Pyface has a chance to adapt to the PySide6 changes.

Fixes #486.