### PR TITLE
Use the correct state location when creating the folder

### DIFF
--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -446,7 +446,7 @@ class TasksApplication(Application):
         # Extend the base class method to ensure the state directory exists.
         super()._initialize_application_home()
 
-        state_location = os.path.join(self.home, "tasks", ETSConfig.toolkit)
+        state_location = self.state_location
         logger.debug(f"Creating folder for tasks state: {state_location}")
         os.makedirs(state_location, mode=0o700, exist_ok=True)
 

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -78,6 +78,7 @@ class TestTasksApplication(unittest.TestCase):
             protocol_bytes = f.read(2)
         self.assertEqual(protocol_bytes, b"\x80\x03")
 
+    @skip_with_flaky_pyside
     def test_layout_save_creates_directory(self):
         # Test that state can still be saved if the target directory
         # doesn't exist.

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import os
+import pathlib
 import shutil
 import sys
 import tempfile
@@ -61,6 +62,27 @@ class TestTasksApplication(unittest.TestCase):
         with open(memento_file, "rb") as f:
             protocol_bytes = f.read(2)
         self.assertEqual(protocol_bytes, b"\x80\x03")
+
+    def test_layout_save_creates_directory(self):
+        # Test that state can still be saved if the target directory
+        # doesn't exist.
+        state_location = pathlib.Path(self.tmpdir) / "subdir"
+        state_filename = "memento_test"
+        state_path = state_location / state_filename
+
+        self.assertFalse(state_location.exists())
+        self.assertFalse(state_path.exists())
+
+        # Create application and set it up to exit as soon as it's launched.
+        app = TasksApplication(
+            state_location=state_location,
+            state_filename=state_filename,
+        )
+        app.on_trait_change(app.exit, "application_initialized")
+        app.run()
+
+        self.assertTrue(state_location.exists())
+        self.assertTrue(state_path.exists())
 
     def test_layout_load(self):
         # Check we can load a previously-created state. That previous state


### PR DESCRIPTION
Inspired by discussion in #489, where @corranwebster observes that:

> But there is something a bit dodgy about _initialize_application_home in that it isn't using self.state_location but a hard-coded path instead: if state_location changes after __init__ then you'll end up with this situation.

And indeed `_initialize_application_home` should depend on `self.state_location` as the single point of truth for the location; the current code will create the wrong directory in the event that the user passed `state_location` when creating the application.

This PR fixes that, and adds a regression test.