### PR TITLE
Switch to ubuntu-22.04 for wxpython run

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install packages for Qt support
         uses: ./.github/actions/install-qt-support
       - name: Cache EDM packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -40,7 +40,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Set up bootstrap Python

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install packages for Qt support
         uses: ./.github/actions/install-qt-support
       - name: Cache EDM packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -39,7 +39,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Set up bootstrap Python

--- a/.github/workflows/test-wx.yml
+++ b/.github/workflows/test-wx.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get install libnotify4
         if: runner.os == 'Linux'
       - name: Cache EDM packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}

--- a/.github/workflows/test-wx.yml
+++ b/.github/workflows/test-wx.yml
@@ -29,6 +29,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libsdl-image1.2
           sudo apt-get install libsdl2-2.0-0
+          sudo apt-get install libnotify4
         if: runner.os == 'Linux'
       - name: Cache EDM packages
         uses: actions/cache@v2

--- a/.github/workflows/test-wx.yml
+++ b/.github/workflows/test-wx.yml
@@ -16,7 +16,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: ['ubuntu-20.04']
+        os: ['ubuntu-latest']
         runtime: ['3.8']
         toolkit: ['wx']
 

--- a/.github/workflows/test-wx.yml
+++ b/.github/workflows/test-wx.yml
@@ -37,7 +37,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Set up bootstrap Python

--- a/etstool.py
+++ b/etstool.py
@@ -222,9 +222,9 @@ def install(edm, runtime, toolkit, environment, editable, source):
     # install wxPython with pip, because we don't have it in EDM
     if toolkit == "wx":
         if sys.platform == "linux":
-            # XXX This assumes Ubuntu 20.04, and targets CI.
+            # XXX This assumes Ubuntu 22.04, and targets CI.
             commands.append(
-                "{edm} run -e {environment} -- python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/ wxPython"  # noqa: E501
+                "{edm} run -e {environment} -- python -m pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ wxPython"  # noqa: E501
             )
         else:
             commands.append(


### PR DESCRIPTION
This PR fixes the wxPython workflow:

- Use ubuntu-latest instead of ubuntu-20.04 (this also fixes that we were testing for ubuntu-latest when deciding whether to use xvfb-run or not)
- Add libnotify.so.4 as a wxPython dependency
- Use the ubuntu-22.04 wheel for wxPython

It also updates the `action/cache` version, in response to warnings.

Test run: https://github.com/enthought/envisage/actions/runs/3854233633