### PR TITLE
Make test egg generation more reliable

### DIFF
--- a/envisage/tests/test_egg_based.py
+++ b/envisage/tests/test_egg_based.py
@@ -35,7 +35,7 @@ def build_egg(egg_dir, dist_dir):
     """
     subprocess.run(
         [
-            "python",
+            sys.executable,
             "setup.py",
             "bdist_egg",
             "--dist-dir",


### PR DESCRIPTION
1) Use sys.executable instead of 'python' to generate eggs to ensure the eggs are generated for the currently running python version.

2) Ensure the egg generation is run with a clean environment (stray environment variables caused problems on Debian, for instance).