### PR TITLE
Check whether we can use EDM 3.5.0

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -7,7 +7,7 @@ name: Test with EDM
 on: [pull_request, workflow_dispatch]
 
 env:
-  INSTALL_EDM_VERSION: 3.4.0
+  INSTALL_EDM_VERSION: 3.5.0
   QT_MAC_WANTS_LAYER: 1
 
 jobs:


### PR DESCRIPTION
This is a test PR to see whether CI works with the newly released EDM 3.5.0