### PR TITLE
Experiment: Remove segfault-related test skips

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -17,15 +17,8 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        runtime: ['3.6', '3.8']
-        toolkit: ['null', 'pyqt5', 'pyside2', 'pyside6']
-        exclude:
-          - runtime: '3.6'
-            toolkit: 'pyside6'
-          - runtime: '3.8'
-            toolkit: 'pyside2'
-          - runtime: '3.8'
-            toolkit: 'pyqt5'
+        runtime: ['3.8']
+        toolkit: ['null', 'pyside6']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -57,7 +57,6 @@ class TestTasksApplication(unittest.TestCase):
         self.tmpdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmpdir)
 
-    @skip_with_flaky_pyside
     def test_layout_save_with_protocol_3(self):
         # Test that the protocol can be overridden on a per-application basis.
         state_location = self.tmpdir
@@ -78,7 +77,6 @@ class TestTasksApplication(unittest.TestCase):
             protocol_bytes = f.read(2)
         self.assertEqual(protocol_bytes, b"\x80\x03")
 
-    @skip_with_flaky_pyside
     def test_layout_save_creates_directory(self):
         # Test that state can still be saved if the target directory
         # doesn't exist.
@@ -100,7 +98,6 @@ class TestTasksApplication(unittest.TestCase):
         self.assertTrue(state_location.exists())
         self.assertTrue(state_path.exists())
 
-    @skip_with_flaky_pyside
     def test_layout_load(self):
         # Check we can load a previously-created state. That previous state
         # has an main window size of (492, 743) (to allow us to check that
@@ -122,7 +119,6 @@ class TestTasksApplication(unittest.TestCase):
         state = app._state
         self.assertEqual(state.previous_window_layouts[0].size, (492, 743))
 
-    @skip_with_flaky_pyside
     def test_layout_load_pickle_protocol_3(self):
         # Same as the above test, but using a state stored with pickle
         # protocol 3.

--- a/etstool.py
+++ b/etstool.py
@@ -146,6 +146,7 @@ environment_vars = {
 
 github_url_fmt = "git+http://github.com/enthought/{0}.git#egg={0}"
 
+
 # Options shared between different click commands.
 edm_option = click.option(
     "--edm",
@@ -261,6 +262,16 @@ def install(edm, runtime, toolkit, environment, editable, source):
             "{edm} run -e {environment} -- " + command for command in commands
         ]
         execute(commands, parameters)
+
+    # Hack / experiment: use a particular commit of pyface
+    pyface_url = "git+http://github.com/enthought/pyface.git@e6b82fdeb71033b61ea17c72a517c84025b06a94"  # noqa: E501
+    commands = [
+        f"python -m pip install --force-reinstall {pyface_url}"
+    ]
+    commands = [
+        "{edm} run -e {environment} -- " + command for command in commands
+    ]
+    execute(commands, parameters)
 
     # Always install local source at the end to mitigate risk of testing
     # against a distributed release.

--- a/setup.py
+++ b/setup.py
@@ -316,6 +316,7 @@ if __name__ == "__main__":
             "setuptools",
             "traits>=6.2",
             'importlib-resources>=1.1.0; python_version<"3.9"',
+            "pyface @ git+http://github.com/enthought/pyface.git@e6b82fdeb71033b61ea17c72a517c84025b06a94",
         ],
         extras_require={
             "docs": [

--- a/setup.py
+++ b/setup.py
@@ -316,6 +316,7 @@ if __name__ == "__main__":
             "setuptools",
             "traits>=6.2",
             'importlib-resources>=1.1.0; python_version<"3.9"',
+            'importlib_metadata; python_version<"3.8"',
             "pyface @ git+http://github.com/enthought/pyface.git@e6b82fdeb71033b61ea17c72a517c84025b06a94",
         ],
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,7 @@ if __name__ == "__main__":
             "traits>=6.2",
             'importlib-resources>=1.1.0; python_version<"3.9"',
             'importlib_metadata; python_version<"3.8"',
-            "pyface @ git+http://github.com/enthought/pyface.git@e6b82fdeb71033b61ea17c72a517c84025b06a94",
+            "pyface @ git+http://github.com/enthought/pyface.git@e6b82fdeb71033b61ea17c72a517c84025b06a94",  # noqa: E501
         ],
         extras_require={
             "docs": [


### PR DESCRIPTION
Issue #476 reports an end-of-test-run segfault that we've been seeing consistently both here and in the test suites of downstream projects.

However, in those downstream projects, the segfault seems to have gone away since we removed uses of IPython. So it seems worth rechecking whether they're present after #496 was merged.

This PR removes the related test skips. If we can get a few segfault-free runs of CI on this PR, we can probably go ahead and remove the `skip_with_flake8_pyside6` decorator, too.