### PR TITLE
Experiment: Add 3.11 to test matrix for the PyPI tests

### DIFF
--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.10']
+        python-version: ['3.7', '3.8', '3.10', '3.11']
         toolkit: ['pyside6']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
PR to discover what (if any) the blockers are to getting Envisage working with Python 3.11.