### PR TITLE
Fix TasksApplication lifecycle: don't stop plugins while event loop is running

### DIFF
--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -177,6 +177,7 @@ class TasksApplication(Application):
             # Start the GUI event loop.
             gui.set_trait_later(self, "application_initialized", self)
             gui.start_event_loop()
+            self.stop()
 
         return started
 
@@ -530,7 +531,7 @@ class TasksApplication(Application):
 
         # Was this the last window?
         if len(self.windows) == 0:
-            self.stop()
+            self.gui.stop_event_loop()
 
 
 class TasksApplicationState(HasStrictTraits):

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -192,11 +192,13 @@ class TestTasksApplication(unittest.TestCase):
         app = TasksApplication()
         app.gui = DummyGUI()
 
+    @skip_with_flaky_pyside
     def test_simple_lifecycle(self):
         app = TasksApplication(state_location=self.tmpdir)
         app.observe(lambda event: app.exit(), "application_initialized")
         app.run()
 
+    @skip_with_flaky_pyside
     def test_lifecycle_with_plugin(self):
         events = []
         plugin = LifecycleRecordingPlugin(record_to=events)

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -194,7 +194,7 @@ class TestTasksApplication(unittest.TestCase):
 
     def test_simple_lifecycle(self):
         app = TasksApplication(state_location=self.tmpdir)
-        app.on_trait_change(app.exit, "application_initialized")
+        app.observe(lambda event: app.exit(), "application_initialized")
         app.run()
 
     def test_lifecycle_with_plugin(self):


### PR DESCRIPTION
This PR fixes a long-standing bug in the `TasksApplication` where the plugins were stopped while the event loop was still running; that seems unlikely to be what any particular application wants, and we've had to work around it in downstream projects. I doubt that this was ever the intended behaviour.

For backwards compatibility, we keep the behaviour where closing the last Tasks windows causes the application to exit. (That behaviour is also worth discussing, but likely in a separate issue.)

Closes #221.