### PR TITLE
Entry point plugin manager

### DIFF
--- a/envisage/entry_point_plugin_manager.py
+++ b/envisage/entry_point_plugin_manager.py
@@ -9,34 +9,34 @@
 # Thanks for using Enthought open source!
 
 
-from traits.api import Instance, List, Str, Union
+try:
+    from importlib.metadata import entry_points, EntryPoints
+except ImportError:
+    from importlib_metadata import entry_points, EntryPoints
+
+from traits.api import Instance, Str
 
 from envisage.plugin_manager import PluginManager
 
 
-try:
-    from importlib.metadata import EntryPoints, entry_points
-except ImportError:
-    from importlib_metadata import EntryPoints, entry_points
-
-
 class EntryPointPluginManager(PluginManager):
+    """
+    A plugin manager that loads the initial set of plugins from
+    a collection of Python entry points (see importlib.metadata).
+    """
 
+    #: Name of the entry point group that we'll load plugins from, if
+    #: the 'entry_points' trait is not provided.
     group = Str("envisage.plugins")
 
-    #: Entry points that the plugins will be loaded from.
-    # XXX Add some kind of name-based filtering on top of this.
+    #: Entry points that the plugins will be loaded from. Overrides
+    #: the 'group' trait.
     entry_points = Instance(EntryPoints)
 
     def _entry_points_default(self):
-        # XXX Find a way to test this. Likely needs an integration test.
-        # Though we can safely test with envisage.plugins.
         return entry_points(group=self.group)
 
     # Protected 'PluginManager' protocol ######################################
 
     def __plugins_default(self):
-        return [
-            entry_point.load()()
-            for entry_point in self.entry_points
-        ]
+        return [entry_point.load()() for entry_point in self.entry_points]

--- a/envisage/entry_point_plugin_manager.py
+++ b/envisage/entry_point_plugin_manager.py
@@ -1,0 +1,42 @@
+# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+from traits.api import Instance, List, Str, Union
+
+from envisage.plugin_manager import PluginManager
+
+
+try:
+    from importlib.metadata import EntryPoints, entry_points
+except ImportError:
+    from importlib_metadata import EntryPoints, entry_points
+
+
+class EntryPointPluginManager(PluginManager):
+
+    group = Str("envisage.plugins")
+
+    #: Entry points that the plugins will be loaded from.
+    # XXX Add some kind of name-based filtering on top of this.
+    entry_points = Instance(EntryPoints)
+
+    def _entry_points_default(self):
+        # XXX Find a way to test this. Likely needs an integration test.
+        # Though we can safely test with envisage.plugins.
+        return entry_points(group=self.group)
+
+    # Protected 'PluginManager' protocol ######################################
+
+    def __plugins_default(self):
+        return [
+            entry_point.load()()
+            for entry_point in self.entry_points
+        ]

--- a/envisage/tests/support.py
+++ b/envisage/tests/support.py
@@ -16,6 +16,7 @@ than for external Envisage-based code. The helpers here should be considered
 private to Envisage.
 """
 
+import contextlib
 import unittest
 
 from pyface.api import GUI
@@ -41,3 +42,61 @@ except ImportError:
 else:
     pyside6_available = True
     del PySide6
+
+
+# 'event_recorder' is an evil piece of global state that lets us record events
+# in situations where we don't have direct access to the objects that are
+# generating those events.
+
+
+class _EventRecorder:
+    """
+    Object that can temporary send events to any particular list.
+
+    Examples
+    --------
+
+    Use as follows::
+
+        my_events = []
+        with event_recorder.record_to(my_events):
+            <do stuff that calls event_recorder.record>
+
+        <inspect contents of my_events>
+
+    """
+
+    @contextlib.contextmanager
+    def start_recording(self, target_list=None):
+        """
+        Context manager that records events for the duration of the context.
+
+        Yields the list being recorded to.
+        """
+        if hasattr(self, "_events"):
+            raise RuntimeError("start_recording calls cannot be nested")
+
+        if target_list is None:
+            target_list = []
+
+        self._events = target_list
+        try:
+            yield target_list
+        finally:
+            del self._events
+
+    def record(self, event):
+        """
+        Record an 'event' (which can be any Python object).
+
+        May only be used within a 'start_recording' context.
+        """
+        if not hasattr(self, "_events"):
+            raise RuntimeError(
+                "The 'record' method may only be called within a "
+                "start_recording context."
+            )
+        self._events.append(event)
+
+
+event_recorder = _EventRecorder()

--- a/envisage/tests/test_entry_point_plugin_manager.py
+++ b/envisage/tests/test_entry_point_plugin_manager.py
@@ -1,0 +1,112 @@
+# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+try:
+    from importlib.metadata import EntryPoint, EntryPoints
+except ImportError:
+    from importlib_metadata import EntryPoint, EntryPoints
+
+import unittest
+import contextlib
+
+from traits.api import Event
+
+from envisage.plugin import Plugin
+from envisage.entry_point_plugin_manager import EntryPointPluginManager
+from envisage.i_plugin_manager import IPluginManager
+
+
+# XXX Move the EventRecorder to test support?
+
+# 'event_recorder' is a piece of global state that lets us record plugin start
+# and stop events.
+
+class EventRecorder:
+    @contextlib.contextmanager
+    def record_to(self, target_list):
+        self._events = target_list
+        try:
+            yield
+        finally:
+            del self._events
+
+    def record(self, event):
+        if not hasattr(self, "_events"):
+            raise RuntimeError(
+                "No target list for recording. Set a target list using "
+                "the 'record_to' context manager."
+            )
+        self._events.append(event)
+
+
+event_recorder = EventRecorder()
+
+
+# Instrumented plugins
+
+
+class BaseInstrumentedPlugin(Plugin):
+    def start(self):
+        event_recorder.record(("starting", self.id))
+
+    def stop(self):
+        event_recorder.record(("stopping", self.id))
+
+
+class SpyPlugin(BaseInstrumentedPlugin):
+    id = "SpyPlugin"
+
+
+class AnotherSpyPlugin(BaseInstrumentedPlugin):
+    id = "AnotherSpyPlugin"
+
+
+
+class TestEntryPointPluginManager(unittest.TestCase):
+    def test_implements_interface(self):
+        self.assertIsInstance(EntryPointPluginManager(), IPluginManager)
+
+    def test_entry_points_directly_specified(self):
+
+        # Name of the entry points group that we'll use for testing.
+        group = "myapp.plugins"
+
+        # No good - we need to run in the target environment.
+        # Can we fake it for now, then add integration tests later?
+
+        # Entry points in the (mocked) environment.
+        # Triples (entry point group name, entry point name, object reference)
+        entry_points = EntryPoints(
+            EntryPoint(group=group, name=name, value=value)
+            for name, value in [
+                ("spy_plugin", "envisage.tests.test_entry_point_plugin_manager:SpyPlugin"),
+                ("another_spy_plugin", "envisage.tests.test_entry_point_plugin_manager:AnotherSpyPlugin"),
+            ]
+        )
+
+        # XXX Add other entry points that aren't plugins; check that they
+        # aren't picked up.
+
+        manager = EntryPointPluginManager(entry_points=entry_points)
+
+        events = []
+        with event_recorder.record_to(events):
+            manager.start()
+            manager.stop()
+
+        self.assertEqual(
+            events,
+            [('starting', 'SpyPlugin'), ('starting', 'AnotherSpyPlugin'), ('stopping', 'AnotherSpyPlugin'), ('stopping', 'SpyPlugin')],
+        )
+
+    def test_select_by_group(self):
+        manager = EntryPointPluginManager(group="envisage.plugins")
+
+        breakpoint()


### PR DESCRIPTION
This PR adds a simple plugin manager that retrieves its plugins from entry points. This is intended to replace existing plugin managers like the `EggPluginManager`, `EggBasketPluginManager` and `PackagePluginManager` that are more closely tied to package details - the goal is to better separate Envisage from those packaging details and rely on `setuptools`,  `importlib.metadata` and other third party packaging tools to take care of those instead.

The minimal use looks like:

```python
plugin_manager = EntryPointPluginManager(group="fancy_application.plugins")
```

after which `plugin_manager.start()` will find all plugins on the current Python environment registered under the `fancy_application.plugins` entry point group, and instantiate and start them.

Alternatively, a collection of entry points can be provided directly via the `entry_points` trait. In this case, the value of the `group` trait (if any) is ignored.

Other plugin managers have various forms of filtering built in; I think we can add that later to this one if the need arises. (And the current filtering doesn't entirely work as intended, either - see #531.)