### PR TITLE
Fix plugin repr to include the name of the plugin class

### DIFF
--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -376,4 +376,4 @@ class Plugin(ExtensionProvider):
 
     def __repr__(self):
         """ String representation of a Plugin object """
-        return "Plugin(id={!r}, name={!r})".format(self.id, self.name)
+        return f"{type(self).__name__}(id={self.id!r}, name={self.name!r})"

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -30,6 +30,11 @@ def listener(obj, trait_name, old, new):
     listener.new = new
 
 
+
+class TestPlugin(Plugin):
+    id = "test_plugin"
+
+
 class TestApplication(Application):
     """ The type of application used in the tests. """
 
@@ -384,7 +389,7 @@ class PluginTestCase(unittest.TestCase):
 
     def test_plugin_str_representation(self):
         """ test the string representation of the plugin """
-        plugin_repr = "Plugin(id={!r}, name={!r})"
-        plugin = Plugin(id="Fred", name="Wilma")
-        self.assertEqual(plugin_repr.format("Fred", "Wilma"), str(plugin))
-        self.assertEqual(plugin_repr.format("Fred", "Wilma"), repr(plugin))
+        plugin_repr = "TestPlugin(id={!r}, name={!r})"
+        plugin = TestPlugin(id="Fred", name="Wilma")
+        self.assertEqual(str(plugin), plugin_repr.format("Fred", "Wilma"))
+        self.assertEqual(repr(plugin), plugin_repr.format("Fred", "Wilma"))

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -30,7 +30,6 @@ def listener(obj, trait_name, old, new):
     listener.new = new
 
 
-
 class TestPlugin(Plugin):
     id = "test_plugin"
 


### PR DESCRIPTION
This PR updates `Plugin.__repr__` to use the name of the plugin class in place of the currently hard-coded "Plugin" string.

Before:

```python
>>> from envisage.api import CorePlugin
>>> CorePlugin()
Plugin(id='envisage.core', name='Core')
```

After:

```python
>>> from envisage.api import CorePlugin
>>> CorePlugin()
CorePlugin(id='envisage.core', name='Core')
```

Closes #530 