### PR TITLE
Exclude the build directory in flake8 configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = examples
+exclude = examples,build
 ignore = E266, W503
 per-file-ignores = */api.py:F401


### PR DESCRIPTION
Currently, flake8 errors in the codebase get reported twice by the continuous integration workflows: once for the true location of the code, and once for the copy in the `build` directory that's created as a side-effect of the way that modern `pip` and `setuptools` work together.

For example, from a recent run (https://github.com/enthought/envisage/actions/runs/4436008433/jobs/7783891320):
```
[EXECUTING] /home/runner/edm/bin/edm run -e envisage-test-3.8-null -- python -m flake8
./build/lib/envisage/tests/test_plugin.py:34:1: E303 too many blank lines (3)
./envisage/tests/test_plugin.py:34:1: E303 too many blank lines (3)
Command '['/home/runner/edm/bin/edm', 'run', '-e', 'envisage-test-3.8-null', '--', 'python', '-m', 'flake8']' returned non-zero exit status 1.
```

We're already excluding the `build` directory in `.gitignore`, but not in our flake8 configuration. This PR fixes that, so that we no longer get duplicate flake8 errors.