### PR TITLE
Fix use of ExtensionPoint class for storage of global state

### DIFF
--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -44,14 +44,6 @@ class ExtensionPoint(TraitType):
     ###########################################################################
 
     @staticmethod
-    def bind(obj, trait_name, extension_point_id):
-        """ Create a binding to an extension point. """
-
-        from .extension_point_binding import bind_extension_point
-
-        return bind_extension_point(obj, trait_name, extension_point_id)
-
-    @staticmethod
     def connect_extension_point_traits(obj):
         """ Connect all of the 'ExtensionPoint' traits on an object. """
 

--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -71,20 +71,6 @@ class ExtensionPointBinding(HasTraits):
         bindings.append(self)
 
     ###########################################################################
-    # 'ExtensionPointBinding' interface.
-    ###########################################################################
-
-    #### Trait initializers ###################################################
-
-    def _extension_registry_default(self):
-        """ Trait initializer. """
-
-        # fixme: Sneaky global!!!!!
-        from .extension_point import ExtensionPoint
-
-        return ExtensionPoint.extension_registry
-
-    ###########################################################################
     # Private interface.
     ###########################################################################
 
@@ -159,29 +145,13 @@ class ExtensionPointBinding(HasTraits):
 
 # Factory function for creating bindings.
 def bind_extension_point(
-    obj, trait_name, extension_point_id, extension_registry=None
+    obj, trait_name, extension_point_id, extension_registry
 ):
     """ Create a binding to an extension point. """
 
-    # This may seem a bit wierd, but we manually build up a dictionary of
-    # the traits that need to be set at the time the 'ExtensionPointBinding'
-    # instance is created.
-    #
-    # This is because we only want to set the 'extension_registry' trait iff
-    # one is explicitly specified. If we passed it in with the default argument
-    # value of 'None' then it counts as 'setting' the trait which prevents
-    # the binding instance from defaulting to the appropriate registry.
-    # Also, if we try to set the 'extension_registry' trait *after*
-    # construction time then it is too late as the binding initialization is
-    # done in the constructor (we could of course split that out, which may be
-    # the 'right' way to do it ;^).
-    traits = {
-        "obj": obj,
-        "trait_name": trait_name,
-        "extension_point_id": extension_point_id,
-    }
-
-    if extension_registry is not None:
-        traits["extension_registry"] = extension_registry
-
-    return ExtensionPointBinding(**traits)
+    return ExtensionPointBinding(
+        obj=obj,
+        trait_name=trait_name,
+        extension_point_id=extension_point_id,
+        extension_registry=extension_registry,
+    )

--- a/envisage/tests/test_extension_point_binding.py
+++ b/envisage/tests/test_extension_point_binding.py
@@ -29,9 +29,6 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
 
         self.extension_registry = MutableExtensionRegistry()
 
-        # Use the extension registry for all extension points and bindings.
-        ExtensionPoint.extension_registry = self.extension_registry
-
     def test_untyped_extension_point(self):
         """ untyped extension point """
 
@@ -52,7 +49,7 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
         f.observe(events.append, "x_items")
 
         # Make some bindings.
-        bind_extension_point(f, "x", "my.ep")
+        bind_extension_point(f, "x", "my.ep", registry)
 
         # Make sure that the object was initialized properly.
         self.assertEqual(1, len(f.x))
@@ -94,7 +91,7 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
         f.observe(events.append, "*")
 
         # Make some bindings.
-        bind_extension_point(f, "x", "my.ep")
+        bind_extension_point(f, "x", "my.ep", registry)
 
         # Make sure that the object was initialized properly.
         self.assertEqual(1, len(f.x))
@@ -138,7 +135,7 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
         f.observe(events.append, "*")
 
         # Make some bindings.
-        bind_extension_point(f, "x", "my.ep")
+        bind_extension_point(f, "x", "my.ep", registry)
 
         # Make sure that the object was initialized properly.
         self.assertEqual(1, len(f.x))


### PR DESCRIPTION
This PR cleans up some odd use of global state (an extension registry that lived on the `ExtensionPoint` trait type class) that's never used in practice.

In detail:

- `ExtensionPointBinding` no longer uses `ExtensionPoint.extension_registry` as the default extension registry. (Note that `ExtensionPoint.extension_registry` doesn't exist unless it's explicitly injected from some external source.)
- The tests for `bind_extension_point` no longer _inject_ a registry onto the `ExtensionPoint` trait type class, and have been updated to use an explicit registry everywhere
- The `extension_registry` argument to `bind_extension_point` is now required rather than optional
- The `bind` static method on the `ExtensionPoint` trait type, which doesn't support specifying an extension registry, has been removed. If any users of this exist, they should use `bind_extension_point` instead.

My original plan was to deprecate calls to `bind_extension_point` that didn't specify a registry. That changed when I discovered that those calls only work after a deliberate injection of a registry onto the `ExtensionPoint` trait type class. To the best of my knowledge, no code is doing that (outside of `test_extension_point_binding` in this package), and all uses of `bind_extension_point` that I found in the wild are already supplying a registry explicitly. I also found no uses of the `ExtensionPoint.bind` static method. So I think in this case deprecation is unnecessary and we can simply remove the functionality.

xref: #97