### PR TITLE
Add an unbind_extension_point function

### DIFF
--- a/envisage/api.py
+++ b/envisage/api.py
@@ -44,6 +44,7 @@ Application, plugin and related classes
 - :class:`~.ExtensionPoint`
 - :class:`~.ExtensionPointBinding`
 - :func:`~.bind_extension_point`
+- :func:`~.unbind_extension_point`
 - :class:`~.ExtensionProvider`
 - :class:`~.ExtensionPointChangedEvent`
 - :class:`~.ImportManager`
@@ -84,6 +85,7 @@ from .extension_point import ExtensionPoint
 from .extension_point_binding import (
     ExtensionPointBinding,
     bind_extension_point,
+    unbind_extension_point,
 )
 from .extension_provider import ExtensionProvider
 from .extension_point_changed_event import ExtensionPointChangedEvent

--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -10,9 +10,6 @@
 """ A binding between a trait on an object and an extension point. """
 
 
-# Standard library imports.
-import weakref
-
 # Enthought library imports.
 from traits.api import Any, HasTraits, Instance, Str, Undefined
 
@@ -25,9 +22,9 @@ class ExtensionPointBinding(HasTraits):
 
     #### 'ExtensionPointBinding' *CLASS* interface ############################
 
-    # We keep a reference to each binding alive until its associated object
-    # is garbage collected.
-    _bindings = weakref.WeakKeyDictionary()
+    # Global dictionary used to keep ExtensionPointBinding objects alive
+    # without needing to keep a reference to them.
+    _bindings = {}
 
     #### 'ExtensionPointBinding' interface ####################################
 
@@ -63,12 +60,7 @@ class ExtensionPointBinding(HasTraits):
         self._set_trait(notify=False)
 
         # Wire-up the trait change and extension point handlers.
-        self._initialize()
-
-        # We keep a reference to each binding alive until its associated
-        # object is garbage collected.
-        bindings = ExtensionPointBinding._bindings.setdefault(self.obj, [])
-        bindings.append(self)
+        self._bind()
 
     ###########################################################################
     # Private interface.
@@ -103,7 +95,7 @@ class ExtensionPointBinding(HasTraits):
 
     #### Methods ##############################################################
 
-    def _initialize(self):
+    def _bind(self):
         """ Wire-up trait change handlers etc. """
 
         # Listen for the object's trait being changed.
@@ -116,6 +108,23 @@ class ExtensionPointBinding(HasTraits):
         # Listen for the extension point being changed.
         self.extension_registry.add_extension_point_listener(
             self._extension_point_listener, self.extension_point_id
+        )
+
+    def _unbind(self):
+        """Undo the effects of _initialize"""
+
+        self.extension_registry.remove_extension_point_listener(
+            self._extension_point_listener, self.extension_point_id
+        )
+
+        self.obj.on_trait_change(
+            self._on_trait_items_changed,
+            self.trait_name + "_items",
+            remove=True,
+        )
+
+        self.obj.on_trait_change(
+            self._on_trait_changed, self.trait_name, remove=True
         )
 
     def _set_trait(self, notify):
@@ -147,11 +156,87 @@ class ExtensionPointBinding(HasTraits):
 def bind_extension_point(
     obj, trait_name, extension_point_id, extension_registry
 ):
-    """ Create a binding to an extension point. """
+    """Create a binding to an extension point.
 
-    return ExtensionPointBinding(
+    The returned ExtensionPointBinding object is also stored in a (private)
+    global dictionary, so that users aren't required to keep a reference to it.
+    That global dictionary entry can be removed with a matching call to
+    unbind_extension_point.
+
+    Parameters
+    ----------
+    obj : HasTraits
+        The HasTraits object that we're binding to
+    trait_name : str
+        The name of the trait on obj to bind to. This trait should have
+        List type.
+    extension_point_id : str
+        The id of the extension point.
+    extension_registry : IExtensionRegistry
+        The extension registry that the extension point is registered to.
+
+    Returns
+    -------
+    ExtensionPointBinding
+        An object that manages the binding.
+    """
+
+    binding = ExtensionPointBinding(
         obj=obj,
         trait_name=trait_name,
         extension_point_id=extension_point_id,
         extension_registry=extension_registry,
     )
+
+    # Keep a reference to each binding in the ExtensionPointBinding._bindings
+    # global dictionary. Without this, the binding would become inactive
+    # if the caller didn't keep a reference.
+    bindings = ExtensionPointBinding._bindings.setdefault(obj, [])
+    bindings.append(binding)
+    return binding
+
+
+def unbind_extension_point(
+    obj, trait_name, extension_point_id, extension_registry
+):
+    """
+    Remove an extension point binding.
+
+    Changes to extension point contributions will no longer affect the
+    related trait. Also removes the matching ExtensionPointBinding
+    object from the global dictionary.
+
+    Parameters
+    ----------
+    obj : HasTraits
+        The HasTraits object that we're binding to
+    trait_name : str
+        The name of the trait on obj to bind to. This trait should have
+        List type.
+    extension_point_id : str
+        The id of the extension point.
+    extension_registry : IExtensionRegistry
+        The extension registry that the extension point is registered to.
+    """
+    # Find the corresponding binding in the global dict.
+    bindings = ExtensionPointBinding._bindings
+
+    # Find the matching ExtensionPointBinding object. Search in reverse order,
+    # since that's most likely to give the right binding quickly under the
+    # normal first-in-last-out pattern for nested setup and teardown.
+    index, binding = next(
+        (index, binding)
+        for index, binding in reversed(list(enumerate(bindings[obj])))
+        if binding.trait_name == trait_name
+        if binding.extension_point_id == extension_point_id
+        if binding.extension_registry == extension_registry
+    )
+
+    # Remove the binding from the global dict, and remove the dict entry
+    # altogether if it's now empty.
+    bindings[obj].pop(index)
+    if not bindings[obj]:
+        bindings.pop(obj)
+
+    # Undo the binding
+    binding._unbind()

--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -110,7 +110,7 @@ class ExtensionPointBinding(HasTraits):
         )
 
     def _unbind(self):
-        """Undo the effects of _initialize"""
+        """Undo the effects of _bind"""
 
         self.extension_registry.remove_extension_point_listener(
             self._extension_point_listener, self.extension_point_id

--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -22,8 +22,7 @@ class ExtensionPointBinding(HasTraits):
 
     #### 'ExtensionPointBinding' *CLASS* interface ############################
 
-    # Global dictionary used to keep ExtensionPointBinding objects alive
-    # without needing to keep a reference to them.
+    # Global dictionary used to keep ExtensionPointBinding objects alive.
     _bindings = {}
 
     #### 'ExtensionPointBinding' interface ####################################
@@ -168,8 +167,7 @@ def bind_extension_point(
     obj : HasTraits
         The HasTraits object that we're binding to
     trait_name : str
-        The name of the trait on obj to bind to. This trait should have
-        List type.
+        The name of the trait on obj to bind to.
     extension_point_id : str
         The id of the extension point.
     extension_registry : IExtensionRegistry
@@ -202,17 +200,16 @@ def unbind_extension_point(
     """
     Remove an extension point binding.
 
-    Changes to extension point contributions will no longer affect the
-    related trait. Also removes the matching ExtensionPointBinding
-    object from the global dictionary.
+    Changes to extension point contributions will no longer affect the target
+    trait. Also removes the matching ExtensionPointBinding object from the
+    global dictionary.
 
     Parameters
     ----------
     obj : HasTraits
         The HasTraits object that we're binding to
     trait_name : str
-        The name of the trait on obj to bind to. This trait should have
-        List type.
+        The name of the trait on obj to bind to.
     extension_point_id : str
         The id of the extension point.
     extension_registry : IExtensionRegistry


### PR DESCRIPTION
This PR adds an `unbind_extension_point` function that reverses the effects of `bind_extension_point`. In particular, `unbind_extension_point` removes references to the target `HasTraits` object from global state, allowing that object to be garbage collected in the usual way. (Previously, those references would live until the end of the process.)

## Detailed changes

- New `unbind_extension_point` function (exported via `envisage.api`), with parameters exactly matching those of `bind_extension_point`. This undoes listener changes, and removes the binding from the global `ExtensionPointBinding._bindings` dictionary.
- New private `ExtensionPointBinding._unbind` method that undoes listener changes. The `_initialize` method has been renamed to `_bind` to match.
- Creation of an `ExtensionPointBinding` object no longer modifies the global `ExtensionPointBinding._bindings` dictionary; instead, that mutation of global state is done in `bind_extension_point`. (At some point in the future, we may want to move this global state somewhere else - perhaps onto the extension registry.)
- `ExtensionPointBinding._bindings` is now a regular Python `dict` instead of a `WeakKeyDictionary`: the weak reference functionality never worked in the first place because our dictionary values had a strong reference to the corresponding keys, so there's no need for the additional complication introduced by the use of a `WeakKeyDictionary`.

Fixes #97

