### PR TITLE
Add documentation build workflow

### DIFF
--- a/.github/workflows/doc-requirements.txt
+++ b/.github/workflows/doc-requirements.txt
@@ -1,0 +1,3 @@
+enthought-sphinx-theme
+sphinx
+sphinx-copybutton

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -1,0 +1,19 @@
+name: Test the documentation build
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+        cache-dependency-path: '.github/workflows/doc-requirements.txt'
+    - run: python -m pip install -r .github/workflows/doc-requirements.txt
+    - run: |
+        python -m sphinx.ext.apidoc --separate --no-toc -o docs/source/api -t docs/source/api/templates envisage */tests
+        python -m sphinx -b html docs/source docs/build


### PR DESCRIPTION
This PR adds a documentation build test workflow - the intent is to catch PRs that cause the documentation to be unbuildable for some reason.

Partly motivated by the fact that #513 broke the documentation build and we didn't notice, but it's good to have this anyway.