### PR TITLE
Don't skip GUI-using tests if we have a recent enough PySide6

### DIFF
--- a/envisage/tests/support.py
+++ b/envisage/tests/support.py
@@ -42,8 +42,10 @@ try:
     import PySide6
 except ImportError:
     pyside6_available = False
+    pyside6_version = None
 else:
     pyside6_available = True
+    pyside6_version = PySide6.__version_info__
     del PySide6
 
 

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -21,7 +21,11 @@ from pyface.i_gui import IGUI
 from traits.api import Event, HasTraits, provides
 
 from envisage.api import Plugin
-from envisage.tests.support import pyside6_available, requires_gui
+from envisage.tests.support import (
+    pyside6_available,
+    pyside6_version,
+    requires_gui,
+)
 from envisage.ui.tasks.api import TasksApplication
 from envisage.ui.tasks.tasks_application import DEFAULT_STATE_FILENAME
 
@@ -34,6 +38,7 @@ skip_with_flaky_pyside = unittest.skipIf(
         os.getenv("GITHUB_ACTIONS") == "true"
         and sys.platform == "linux"
         and pyside6_available
+        and pyside6_version < (6, 4, 3)
     ),
     "Skipping segfault-causing test on Linux. See enthought/envisage#476",
 )


### PR DESCRIPTION
We're currently skipping some GUI-using tests in GitHub Actions runs because of an end-of-process segfault caused by a PySide6 bug. That bug is now fixed in the latest release (6.4.3) of PySide6, so this PR tweaks the skip condition so that the tests will only be skipped with versions of PySide6 that are older than 6.4.3.

xref: #476
xref: https://bugreports.qt.io/browse/PYSIDE-2254
