### PR TITLE
Remove the sphinx.ext.githubpages extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,6 @@ import enthought_sphinx_theme
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.extlinks",
-    "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",


### PR DESCRIPTION
This PR removes the `sphinx.ext.githubpages` extension from the Sphinx configuration file. That extension supplies a `.nojekyll` file, that it's useless in practice because of the way we're managing docs in this repository - we only need a single `.nojekyll` file at the root of the repository.