### PR TITLE
Add changelog, bump version for Envisage 7.0.2 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,34 @@
  Release history
 =================
 
+Version 7.0.2
+=============
+
+Released: 2023-04-03
+
+This is a bugfix release that fixes some test interaction issues and
+automates the documentation build.
+
+Fixes
+-----
+* Fix test-ordering issues with egg-based tests that modify ``pkg_resources``
+  global state. (#564)
+
+Documentation
+-------------
+* Reorganise the gh-pages documentation. The main gh-pages page
+  (https://docs.enthought.com/envisage) now matches the contents of the GitHub
+  ``main`` branch, while subdirectories (e.g.,
+  https://docs.enthought.com/envisage/7.0) provide documentation for released
+  versions. (#565)
+
+Build
+-----
+* Add GitHub Actions workflows to automate documentation updates. The main
+  documentation is updated on every push to ``main``, while the release
+  documentation is updated on each GitHub release creation. (#565)
+
+
 Version 7.0.1
 =============
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,9 @@ Documentation
   (https://docs.enthought.com/envisage) now matches the contents of the GitHub
   ``main`` branch, while subdirectories (e.g.,
   https://docs.enthought.com/envisage/7.0) provide documentation for released
-  versions. (#565)
+  versions. A 'latest' symlink is in place, so
+  https://docs.enthought.com/envisage/latest will bring up the documentation
+  for the latest release. (#565)
 
 Build
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'envisage'
-version = '7.0.1'
+version = '7.0.2'
 description = 'Extensible application framework'
 readme = 'README.rst'
 requires-python = '>= 3.7'


### PR DESCRIPTION
[Note: PR is intentionally against the `main` branch: there haven't been any feature-level changes since Envisage 7.0, so I'll tag directly from the main branch.]

This PR updates the changelog and version in preparation for a 7.0.2 release.

The ulterior motive is to find out whether our gh-pages documentation build for releases is working as hoped.