### PR TITLE
Add a name to the EventManagerPlugin

### DIFF
--- a/envisage/plugins/event_manager/plugin.py
+++ b/envisage/plugins/event_manager/plugin.py
@@ -24,7 +24,11 @@ from envisage.api import Plugin, ServiceOffer
 class EventManagerPlugin(Plugin):
     """Plugin to add event manager to the application."""
 
+    #: The plugin's unique identifier.
     id = "envisage.event_manager"
+
+    #: The plugin's name (suitable for displaying to the user).
+    name = "Event Manager"
 
     SERVICE_OFFERS = "envisage.service_offers"
     service_offers = List(contributes_to=SERVICE_OFFERS)


### PR DESCRIPTION
This tiny PR adds a name to the `EventManagerPlugin`, to prevent a WARNING being logged on computing the `repr` of the plugin.

On main:
```python
Python 3.11.9 (main, Apr  4 2024, 05:29:26) [Clang 15.0.0 (clang-1500.1.0.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging
>>> logging.basicConfig()
>>> from envisage.plugins.event_manager.api import EventManagerPlugin
>>> plugin = EventManagerPlugin()
>>> plugin
WARNING:envisage.plugin:plugin <envisage.plugins.event_manager.plugin.EventManagerPlugin object at 0x100d8a160> has no name - using <Event Manager Plugin>
EventManagerPlugin(id='envisage.event_manager', name='Event Manager Plugin')
```

On this branch:
```python
Python 3.11.9 (main, Apr  4 2024, 05:29:26) [Clang 15.0.0 (clang-1500.1.0.2.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging
>>> logging.basicConfig()
>>> from envisage.plugins.event_manager.api import EventManagerPlugin
>>> plugin = EventManagerPlugin()
>>> plugin
EventManagerPlugin(id='envisage.event_manager', name='Event Manager')
```