### PR TITLE
Update copyright header end years for 2024

### DIFF
--- a/docs/source/api/envisage.api.rst
+++ b/docs/source/api/envisage.api.rst
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+   (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/modules.rst_t
+++ b/docs/source/api/templates/modules.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+   (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/api/templates/package.rst_t
+++ b/docs/source/api/templates/package.rst_t
@@ -1,5 +1,5 @@
 ..
-   (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+   (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
    All rights reserved.
 
    This software is provided without warranty under the terms of the BSD

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -54,7 +54,7 @@ master_doc = "index"
 
 # General substitutions.
 project = "envisage"
-copyright = "2007-2023, Enthought"
+copyright = "2007-2024, Enthought"
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.

--- a/docs/update_gh_pages.py
+++ b/docs/update_gh_pages.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/__init__.py
+++ b/envisage/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/api.py
+++ b/envisage/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/application.py
+++ b/envisage/application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/application_event.py
+++ b/envisage/application_event.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/composite_plugin_manager.py
+++ b/envisage/composite_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/egg_basket_plugin_manager.py
+++ b/envisage/egg_basket_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/egg_plugin_manager.py
+++ b/envisage/egg_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/egg_utils.py
+++ b/envisage/egg_utils.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/_demo.py
+++ b/envisage/examples/_demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/_etsdemo_info.py
+++ b/envisage/examples/_etsdemo_info.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/GUI_Application/traitsui_gui_app.py
+++ b/envisage/examples/demo/GUI_Application/traitsui_gui_app.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/Hello_World/hello_world.py
+++ b/envisage/examples/demo/Hello_World/hello_world.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/__init__.py
+++ b/envisage/examples/demo/MOTD/acme/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/__init__.py
+++ b/envisage/examples/demo/MOTD/acme/motd/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/api.py
+++ b/envisage/examples/demo/MOTD/acme/motd/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/i_message.py
+++ b/envisage/examples/demo/MOTD/acme/motd/i_message.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/i_motd.py
+++ b/envisage/examples/demo/MOTD/acme/motd/i_motd.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/message.py
+++ b/envisage/examples/demo/MOTD/acme/motd/message.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/motd.py
+++ b/envisage/examples/demo/MOTD/acme/motd/motd.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/motd_plugin.py
+++ b/envisage/examples/demo/MOTD/acme/motd/motd_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/software_quotes/__init__.py
+++ b/envisage/examples/demo/MOTD/acme/motd/software_quotes/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/software_quotes/messages.py
+++ b/envisage/examples/demo/MOTD/acme/motd/software_quotes/messages.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/acme/motd/software_quotes/software_quotes_plugin.py
+++ b/envisage/examples/demo/MOTD/acme/motd/software_quotes/software_quotes_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/MOTD/run.py
+++ b/envisage/examples/demo/MOTD/run.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/attractors_application.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/attractors_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/attractors_plugin.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/attractors_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/attractors_preferences.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/attractors_preferences.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model/henon.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/henon.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model/i_model_2d.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/i_model_2d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model/i_model_3d.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/i_model_3d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model/i_plottable_2d.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/i_plottable_2d.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model/lorenz.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/lorenz.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model/rossler.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model/rossler.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model_config_pane.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model_config_pane.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/model_help_pane.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/model_help_pane.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/plot_2d_pane.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/plot_2d_pane.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/plot_3d_pane.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/plot_3d_pane.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/visualize_2d_task.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/visualize_2d_task.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/attractors/visualize_3d_task.py
+++ b/envisage/examples/demo/plugins/tasks/attractors/visualize_3d_task.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/demo/plugins/tasks/run_attractor.py
+++ b/envisage/examples/demo/plugins/tasks/run_attractor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/tests/test__demo.py
+++ b/envisage/examples/tests/test__demo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/examples/tests/test_etsdemo_info.py
+++ b/envisage/examples/tests/test_etsdemo_info.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/extension_point.py
+++ b/envisage/extension_point.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/extension_point_binding.py
+++ b/envisage/extension_point_binding.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/extension_point_changed_event.py
+++ b/envisage/extension_point_changed_event.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/extension_provider.py
+++ b/envisage/extension_provider.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/extension_registry.py
+++ b/envisage/extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_application.py
+++ b/envisage/i_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_extension_point.py
+++ b/envisage/i_extension_point.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_extension_point_user.py
+++ b/envisage/i_extension_point_user.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_extension_provider.py
+++ b/envisage/i_extension_provider.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_extension_registry.py
+++ b/envisage/i_extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_import_manager.py
+++ b/envisage/i_import_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_plugin.py
+++ b/envisage/i_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_plugin_activator.py
+++ b/envisage/i_plugin_activator.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_plugin_manager.py
+++ b/envisage/i_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_provider_extension_registry.py
+++ b/envisage/i_provider_extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_service_registry.py
+++ b/envisage/i_service_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/i_service_user.py
+++ b/envisage/i_service_user.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ids.py
+++ b/envisage/ids.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/import_manager.py
+++ b/envisage/import_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/package_plugin_manager.py
+++ b/envisage/package_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugin_activator.py
+++ b/envisage/plugin_activator.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugin_event.py
+++ b/envisage/plugin_event.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugin_extension_registry.py
+++ b/envisage/plugin_extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugin_manager.py
+++ b/envisage/plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/event_manager/api.py
+++ b/envisage/plugins/event_manager/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/event_manager/plugin.py
+++ b/envisage/plugins/event_manager/plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/python_shell/api.py
+++ b/envisage/plugins/python_shell/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/python_shell/i_python_shell.py
+++ b/envisage/plugins/python_shell/i_python_shell.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/python_shell/python_shell_plugin.py
+++ b/envisage/plugins/python_shell/python_shell_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/python_shell/view/api.py
+++ b/envisage/plugins/python_shell/view/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/python_shell/view/namespace_view.py
+++ b/envisage/plugins/python_shell/view/namespace_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/python_shell/view/python_shell_view.py
+++ b/envisage/plugins/python_shell/view/python_shell_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/tasks/python_shell_plugin.py
+++ b/envisage/plugins/tasks/python_shell_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/text_editor/actions.py
+++ b/envisage/plugins/text_editor/actions.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/text_editor/api.py
+++ b/envisage/plugins/text_editor/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/text_editor/editor/text_editor.py
+++ b/envisage/plugins/text_editor/editor/text_editor.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/text_editor/editor/text_editor_handler.py
+++ b/envisage/plugins/text_editor/editor/text_editor_handler.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/text_editor/text_editor_action_set.py
+++ b/envisage/plugins/text_editor/text_editor_action_set.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/plugins/text_editor/text_editor_plugin.py
+++ b/envisage/plugins/text_editor/text_editor_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/provider_extension_registry.py
+++ b/envisage/provider_extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/api.py
+++ b/envisage/resource/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/file_resource_protocol.py
+++ b/envisage/resource/file_resource_protocol.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/http_resource_protocol.py
+++ b/envisage/resource/http_resource_protocol.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/i_resource_manager.py
+++ b/envisage/resource/i_resource_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/i_resource_protocol.py
+++ b/envisage/resource/i_resource_protocol.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/no_such_resource_error.py
+++ b/envisage/resource/no_such_resource_error.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/package_resource_protocol.py
+++ b/envisage/resource/package_resource_protocol.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/resource_manager.py
+++ b/envisage/resource/resource_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/resource/tests/test_resource_manager.py
+++ b/envisage/resource/tests/test_resource_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/service.py
+++ b/envisage/service.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/service_offer.py
+++ b/envisage/service_offer.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/service_registry.py
+++ b/envisage/service_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/bad_eggs/acme-bad/acme_bad/__init__.py
+++ b/envisage/tests/bad_eggs/acme-bad/acme_bad/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/bad_eggs/acme-bad/acme_bad/bad_plugin.py
+++ b/envisage/tests/bad_eggs/acme-bad/acme_bad/bad_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/bad_eggs/acme-bad/setup.py
+++ b/envisage/tests/bad_eggs/acme-bad/setup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-bar/acme_bar/__init__.py
+++ b/envisage/tests/eggs/acme-bar/acme_bar/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-bar/acme_bar/bar_plugin.py
+++ b/envisage/tests/eggs/acme-bar/acme_bar/bar_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-bar/setup.py
+++ b/envisage/tests/eggs/acme-bar/setup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-baz/acme_baz/__init__.py
+++ b/envisage/tests/eggs/acme-baz/acme_baz/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-baz/acme_baz/baz_plugin.py
+++ b/envisage/tests/eggs/acme-baz/acme_baz/baz_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-baz/setup.py
+++ b/envisage/tests/eggs/acme-baz/setup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-foo/acme_foo/__init__.py
+++ b/envisage/tests/eggs/acme-foo/acme_foo/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-foo/acme_foo/foo_plugin.py
+++ b/envisage/tests/eggs/acme-foo/acme_foo/foo_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/eggs/acme-foo/setup.py
+++ b/envisage/tests/eggs/acme-foo/setup.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/ets_config_patcher.py
+++ b/envisage/tests/ets_config_patcher.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/event_tracker.py
+++ b/envisage/tests/event_tracker.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/foo.py
+++ b/envisage/tests/foo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/i_foo.py
+++ b/envisage/tests/i_foo.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/mutable_extension_registry.py
+++ b/envisage/tests/mutable_extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/plugins/banana/banana_plugin.py
+++ b/envisage/tests/plugins/banana/banana_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/plugins/banana/plugins.py
+++ b/envisage/tests/plugins/banana/plugins.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/plugins/orange/orange_plugin.py
+++ b/envisage/tests/plugins/orange/orange_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/plugins/orange/plugins.py
+++ b/envisage/tests/plugins/orange/plugins.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/plugins/pear/pear_plugin.py
+++ b/envisage/tests/plugins/pear/pear_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/support.py
+++ b/envisage/tests/support.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_api.py
+++ b/envisage/tests/test_api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_application.py
+++ b/envisage/tests/test_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_composite_plugin_manager.py
+++ b/envisage/tests/test_composite_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_egg_basket_plugin_manager.py
+++ b/envisage/tests/test_egg_basket_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_egg_plugin_manager.py
+++ b/envisage/tests/test_egg_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_extension_point.py
+++ b/envisage/tests/test_extension_point.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_extension_point_binding.py
+++ b/envisage/tests/test_extension_point_binding.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_extension_point_changed.py
+++ b/envisage/tests/test_extension_point_changed.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_extension_registry.py
+++ b/envisage/tests/test_extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_extension_registry_mixin.py
+++ b/envisage/tests/test_extension_registry_mixin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_ids.py
+++ b/envisage/tests/test_ids.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_import_manager.py
+++ b/envisage/tests/test_import_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_package_plugin_manager.py
+++ b/envisage/tests/test_package_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_plugin_manager.py
+++ b/envisage/tests/test_plugin_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_provider_extension_registry.py
+++ b/envisage/tests/test_provider_extension_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_service.py
+++ b/envisage/tests/test_service.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_service_registry.py
+++ b/envisage/tests/test_service_registry.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_slice.py
+++ b/envisage/tests/test_slice.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/tests/test_workbench.py
+++ b/envisage/tests/test_workbench.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/abstract_action_manager_builder.py
+++ b/envisage/ui/action/abstract_action_manager_builder.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/action.py
+++ b/envisage/ui/action/action.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/action_set.py
+++ b/envisage/ui/action/action_set.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/action_set_manager.py
+++ b/envisage/ui/action/action_set_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/api.py
+++ b/envisage/ui/action/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/group.py
+++ b/envisage/ui/action/group.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/i_action_manager_builder.py
+++ b/envisage/ui/action/i_action_manager_builder.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/i_action_set.py
+++ b/envisage/ui/action/i_action_set.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/location.py
+++ b/envisage/ui/action/location.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/menu.py
+++ b/envisage/ui/action/menu.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/tests/dummy_action_manager_builder.py
+++ b/envisage/ui/action/tests/dummy_action_manager_builder.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/tests/test_action_manager_builder.py
+++ b/envisage/ui/action/tests/test_action_manager_builder.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/action/tool_bar.py
+++ b/envisage/ui/action/tool_bar.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/gui_application.py
+++ b/envisage/ui/gui_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/action/api.py
+++ b/envisage/ui/tasks/action/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/action/exit_action.py
+++ b/envisage/ui/tasks/action/exit_action.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/action/preferences_action.py
+++ b/envisage/ui/tasks/action/preferences_action.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/action/task_window_launch_group.py
+++ b/envisage/ui/tasks/action/task_window_launch_group.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/action/task_window_toggle_group.py
+++ b/envisage/ui/tasks/action/task_window_toggle_group.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/api.py
+++ b/envisage/ui/tasks/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/preferences_category.py
+++ b/envisage/ui/tasks/preferences_category.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/preferences_dialog.py
+++ b/envisage/ui/tasks/preferences_dialog.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/preferences_pane.py
+++ b/envisage/ui/tasks/preferences_pane.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/task_extension.py
+++ b/envisage/ui/tasks/task_extension.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/task_factory.py
+++ b/envisage/ui/tasks/task_factory.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/task_window.py
+++ b/envisage/ui/tasks/task_window.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/task_window_event.py
+++ b/envisage/ui/tasks/task_window_event.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/tasks_application.py
+++ b/envisage/ui/tasks/tasks_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/tasks_plugin.py
+++ b/envisage/ui/tasks/tasks_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/tests/data/create_pickles.py
+++ b/envisage/ui/tasks/tests/data/create_pickles.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/action/about_action.py
+++ b/envisage/ui/workbench/action/about_action.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/action/api.py
+++ b/envisage/ui/workbench/action/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/action/edit_preferences_action.py
+++ b/envisage/ui/workbench/action/edit_preferences_action.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/action/exit_action.py
+++ b/envisage/ui/workbench/action/exit_action.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/api.py
+++ b/envisage/ui/workbench/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/default_action_set.py
+++ b/envisage/ui/workbench/default_action_set.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench.py
+++ b/envisage/ui/workbench/workbench.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_action_manager_builder.py
+++ b/envisage/ui/workbench/workbench_action_manager_builder.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_action_set.py
+++ b/envisage/ui/workbench/workbench_action_set.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_application.py
+++ b/envisage/ui/workbench/workbench_application.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_editor_manager.py
+++ b/envisage/ui/workbench/workbench_editor_manager.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_plugin.py
+++ b/envisage/ui/workbench/workbench_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_preferences.py
+++ b/envisage/ui/workbench/workbench_preferences.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_preferences_page.py
+++ b/envisage/ui/workbench/workbench_preferences_page.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/ui/workbench/workbench_window.py
+++ b/envisage/ui/workbench/workbench_window.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/unknown_extension.py
+++ b/envisage/unknown_extension.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/envisage/unknown_extension_point.py
+++ b/envisage/unknown_extension_point.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/etstool.py
+++ b/etstool.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/__init__.py
+++ b/examples/legacy/workbench/AcmeLab/acme/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/acmelab/__init__.py
+++ b/examples/legacy/workbench/AcmeLab/acme/acmelab/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/acmelab/acmelab.py
+++ b/examples/legacy/workbench/AcmeLab/acme/acmelab/acmelab.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/acmelab/api.py
+++ b/examples/legacy/workbench/AcmeLab/acme/acmelab/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/__init__.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/__init__.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/acme_preferences_page.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/acme_preferences_page.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/acme_workbench_plugin.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/acme_workbench_plugin.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/action/new_view_action.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/action/new_view_action.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/example_action_set.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/example_action_set.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/api.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/bar_perspective.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/bar_perspective.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/foo_perspective.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/foo_perspective.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/api.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/api.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/black_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/black_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/blue_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/blue_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/color_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/color_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/green_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/green_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/red_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/red_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/yellow_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/yellow_view.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/examples/legacy/workbench/AcmeLab/run.py
+++ b/examples/legacy/workbench/AcmeLab/run.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2007-2023 Enthought, Inc., Austin, TX
+# (C) Copyright 2007-2024 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD


### PR DESCRIPTION
This simple find-and-replace PR updates copyright header end years from 2023 to 2024.