### PR TITLE
Require apptools 5.3 or later, Python 3.8 or later

### DIFF
--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.10', '3.11']
+        python-version: ['3.8', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ framework. You are free to use:
 Prerequisites
 -------------
 
-The supported versions of Python are Python >= 3.7.  Envisage requires:
+The supported versions of Python are Python >= 3.8.  Envisage requires:
 
 * `apptools <https://pypi.org/project/apptools/>`_
 * `traits <https://pypi.org/project/traits/>`_

--- a/etstool.py
+++ b/etstool.py
@@ -104,6 +104,7 @@ supported_combinations = {
 
 dependencies = {
     "apptools",
+    "configobj",
     "coverage",
     "enthought_sphinx_theme",
     "pyface",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = 'envisage'
 version = '7.0.3'
 description = 'Extensible application framework'
 readme = 'README.rst'
-requires-python = '>= 3.7'
+requires-python = '>= 3.8'
 license = {file = 'LICENSE.txt'}
 authors = [{name = 'Enthought', email = 'info@enthought.com'}]
 keywords = ['extensible', 'plugin', 'application', 'framework']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 dependencies = [
     'apptools',
+    'configobj',
     'pyface',
     'setuptools',
     'traits>=6.2',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ classifiers = [
     'Topic :: Software Development :: User Interfaces',
 ]
 dependencies = [
-    'apptools',
-    'configobj',
+    'apptools[preferences]>=5.3',
     'pyface',
     'setuptools',
     'traits>=6.2',


### PR DESCRIPTION
This PR updates the apptools dependency to apptools >= 5.3, and deals with various pieces of fallout from that change:

Detailed changes:

- require `apptools >= 5.3`, which contains some fixes that we need for some upcoming bugfixes on this repository (see #583)
- require `apptools[preferences]` rather than just plain `apptools`, since version 5.3.0 of `apptools` no longer declares `configobj` as an explicit dependency, and Envisage preferences depend on `configobj`
- similarly, require `configobj` explicitly in `etstool.py`, since EDS doesn't support optional requirements
- require Python >= 3.8, since `apptools` now also requires Python >= 3.8, and `apptools >= 5.3.0` is not available for Python 3.7
