### PR TITLE
Update black (CVE)

### DIFF
--- a/.github/workflows/style-requirements.txt
+++ b/.github/workflows/style-requirements.txt
@@ -1,4 +1,4 @@
-black ~= 23.0
+black ~= 24.3
 flake8
 flake8-ets
 isort


### PR DESCRIPTION
This PR updates black to silence dependabot warnings about a CVE (though it seems like a CVE that we're very unlikely to run into in practice).

xref: https://github.com/enthought/envisage/security/dependabot/1