### PR TITLE
Be less strict about the copyright end year

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,4 +3,3 @@ max-line-length = 79
 exclude = build, .venv
 ignore = E203, E266, W503
 per-file-ignores = */api.py:F401
-copyright-end-year = 2026

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 79
-exclude = build,.venv
+exclude = build, .venv
 ignore = E203, E266, W503
 per-file-ignores = */api.py:F401

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 max-line-length = 79
-exclude = build
+exclude = build,.venv
 ignore = E203, E266, W503
 per-file-ignores = */api.py:F401

--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -3,7 +3,7 @@ name: Run strict style checks
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  style:
+  strict-style:
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -1,4 +1,4 @@
-name: Run style checks
+name: Run strict style checks
 
 on: [pull_request, workflow_dispatch]
 
@@ -15,6 +15,5 @@ jobs:
         cache-dependency-path: '.github/workflows/style-requirements.txt'
     - run: python -m pip install -r .github/workflows/style-requirements.txt
     - run: |
-        python -m black --check --diff .
-        python -m isort --check --diff .
-        python -m flake8 --copyright-end-year 2025 .
+        # Just report on out-of-date copyright end years.
+        python -m flake8 --select H102 .

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -17,4 +17,8 @@ jobs:
     - run: |
         python -m black --check --diff .
         python -m isort --check --diff .
-        python -m flake8 --copyright-end-year 2025 .
+        # We hard-code the year here to give us a buffer on CI failures when
+        # January 1st rolls around. Nevertheless, this year and the copyright
+        # headers should be updated as early as possible in each new year,
+        # and definitely before any release.
+        python -m flake8 --copyright-end-year 2026 .


### PR DESCRIPTION
Issue: on many of our ETS repositories, we have a check for the copyright end year. However, that means that when each new year rolls around, whichever PR is first created in that new year can't be merged (e.g., see #594 on this repository), because of the failed style check resulting from out-of-date copyright years.

This PR attempts to fix that issue by hard-coding the current copyright end year in the style-check workflow, and having a separate "strict" workflow that requires the copyright end year to match the current year. The idea is that the regular style check gets applied to PRs as usual, and is required to pass for PR merge, while the strict style check still runs (so we still get a prominent red cross in our CI run  results) but doesn't prevent merge.

The goal is that the arrival of a new year doesn't abruptly turn passing CI into failing CI. The strict style check should still be required to pass before any _release_ of the package.

While we're touching the workflows, we also update the version of Python used to 3.14, and exclude any `.venv` directory from flake8 checks (useful if you're using `uv` to create a venv locally).

Note: the solution is a little bit awkward: I would have liked to include the `copyright-end-year` in the config file and overridden it in the workflows. But we can't give a value for `copyright-end-year` that means "use the current year". In hindsight, that would have been useful to have.