### PR TITLE
Remove uses of pkg_resources; drop setuptools as a runtime dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ python -m pip install -e .
 ```
 
 Dependencies: `traits>=6.2`, `apptools[preferences]>=5.3`, `pyface`,
-`traitsui`, `setuptools`.
+`traitsui`.
 
 ## Running Tests
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,13 @@ Removals
   and ``PackagePluginManager`` classes, along with the supporting
   ``egg_utils`` module and associated tests. (#548)
 
+Build
+-----
+* Remove all uses of ``pkg_resources`` and drop ``setuptools`` as a
+  runtime dependency. ``setuptools`` is retained as a build dependency.
+  ``importlib.resources`` (with ``importlib-resources`` as a backport
+  for Python 3.8) is used instead.
+
 Version 7.0.4
 =============
 

--- a/envisage/examples/_etsdemo_info.py
+++ b/envisage/examples/_etsdemo_info.py
@@ -8,11 +8,14 @@
 #
 # Thanks for using Enthought open source!
 
-""" This module provides functions to be advertised in the distribution
+"""This module provides functions to be advertised in the distribution
 entry points.
 """
 
-import pkg_resources
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 
 def info(request):
@@ -30,5 +33,5 @@ def info(request):
     return dict(
         version=1,
         name="Envisage Examples",
-        root=(pkg_resources.resource_filename("envisage.examples", "demo")),
+        root=str(files("envisage.examples").joinpath("demo")),
     )

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -7,17 +7,19 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the core plugin. """
+"""Tests for the core plugin."""
 
 # Standard library imports.
 import unittest
 
-# Major package imports.
-from pkg_resources import resource_filename
-
-from traits.api import HasTraits, Interface, List, on_trait_change, Str
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 # Enthought library imports.
+from traits.api import HasTraits, Interface, List, on_trait_change, Str
+
 from envisage.api import CorePlugin, Plugin, ServiceOffer
 from envisage.tests.support import SimpleApplication
 
@@ -134,7 +136,9 @@ class CorePluginTestCase(unittest.TestCase):
             def _preferences_default(self):
                 """Trait initializer."""
 
-                return ["file://" + resource_filename(PKG, "preferences.ini")]
+                return [
+                    "file://" + str(files(PKG).joinpath("preferences.ini"))
+                ]
 
         core = CorePlugin()
         a = PluginA()
@@ -155,7 +159,9 @@ class CorePluginTestCase(unittest.TestCase):
             def _preferences_default(self):
                 """Trait initializer."""
 
-                return ["file://" + resource_filename(PKG, "preferences.ini")]
+                return [
+                    "file://" + str(files(PKG).joinpath("preferences.ini"))
+                ]
 
         core = CorePlugin()
         a = PluginA()

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -138,7 +138,7 @@ class CorePluginTestCase(unittest.TestCase):
                 def _preferences_default(self):
                     """Trait initializer."""
 
-                    return [preferences_file.as_uri()]
+                    return ["file://" + str(preferences_file)]
 
             core = CorePlugin()
             a = PluginA()
@@ -163,7 +163,7 @@ class CorePluginTestCase(unittest.TestCase):
                 def _preferences_default(self):
                     """Trait initializer."""
 
-                    return [preferences_file.as_uri()]
+                    return ["file://" + str(preferences_file)]
 
             core = CorePlugin()
             a = PluginA()

--- a/envisage/tests/test_core_plugin.py
+++ b/envisage/tests/test_core_plugin.py
@@ -129,8 +129,7 @@ class CorePluginTestCase(unittest.TestCase):
     def test_preferences(self):
         """preferences"""
 
-        preferences_resource = files(PKG) / "preferences.ini"
-        with as_file(preferences_resource) as preferences_file:
+        with as_file(files(PKG) / "preferences.ini") as preferences_file:
 
             class PluginA(Plugin):
                 id = "A"
@@ -155,8 +154,7 @@ class CorePluginTestCase(unittest.TestCase):
     def test_dynamically_added_preferences(self):
         """dynamically added preferences"""
 
-        preferences_resource = files(PKG) / "preferences.ini"
-        with as_file(preferences_resource) as preferences_file:
+        with as_file(files(PKG) / "preferences.ini") as preferences_file:
 
             class PluginA(Plugin):
                 id = "A"

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -126,14 +126,10 @@ class TestTasksApplication(unittest.TestCase):
         # Check we can load a previously-created state. That previous state
         # has an main window size of (492, 743) (to allow us to check that
         # we're actually using the file).
-        stored_state_location = (
-            files("envisage.ui.tasks.tests")
-            / "data"
-            / "application_memento_v2.pkl"
-        )
+        stored_state_location = files("envisage.ui.tasks.tests") / "data"
         state_location = pathlib.Path(self.tmpdir)
         (state_location / DEFAULT_STATE_FILENAME).write_bytes(
-            stored_state_location.read_bytes()
+            (stored_state_location / "application_memento_v2.pkl").read_bytes()
         )
 
         app = TasksApplication(state_location=state_location)
@@ -146,15 +142,11 @@ class TestTasksApplication(unittest.TestCase):
     def test_layout_load_pickle_protocol_3(self):
         # Same as the above test, but using a state stored with pickle
         # protocol 3.
-        stored_state_location = (
-            files("envisage.ui.tasks.tests")
-            / "data"
-            / "application_memento_v3.pkl"
-        )
+        stored_state_location = files("envisage.ui.tasks.tests") / "data"
 
         state_location = pathlib.Path(self.tmpdir)
         (state_location / "fancy_state.pkl").write_bytes(
-            stored_state_location.read_bytes()
+            (stored_state_location / "application_memento_v3.pkl").read_bytes()
         )
 
         # Use a non-standard filename, to exercise that machinery.

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -126,15 +126,13 @@ class TestTasksApplication(unittest.TestCase):
         # Check we can load a previously-created state. That previous state
         # has an main window size of (492, 743) (to allow us to check that
         # we're actually using the file).
-        stored_state_location = str(
-            files("envisage.ui.tasks.tests").joinpath("data")
+        stored_state_location = (
+            files("envisage.ui.tasks.tests")
+            / "data"
+            / "application_memento_v2.pkl"
         )
-
-        state_location = self.tmpdir
-        shutil.copyfile(
-            os.path.join(stored_state_location, "application_memento_v2.pkl"),
-            os.path.join(state_location, DEFAULT_STATE_FILENAME),
-        )
+        state_location = pathlib.Path(self.tmpdir) / DEFAULT_STATE_FILENAME
+        state_location.write_bytes(stored_state_location.read_bytes())
 
         app = TasksApplication(state_location=state_location)
         app.on_trait_change(app.exit, "application_initialized")
@@ -146,15 +144,14 @@ class TestTasksApplication(unittest.TestCase):
     def test_layout_load_pickle_protocol_3(self):
         # Same as the above test, but using a state stored with pickle
         # protocol 3.
-        stored_state_location = str(
-            files("envisage.ui.tasks.tests").joinpath("data")
+        stored_state_location = (
+            files("envisage.ui.tasks.tests")
+            / "data"
+            / "application_memento_v3.pkl"
         )
 
-        state_location = self.tmpdir
-        shutil.copyfile(
-            os.path.join(stored_state_location, "application_memento_v3.pkl"),
-            os.path.join(state_location, "fancy_state.pkl"),
-        )
+        state_location = pathlib.Path(self.tmpdir) / "fancy_state.pkl"
+        state_location.write_bytes(stored_state_location.read_bytes())
 
         # Use a non-standard filename, to exercise that machinery.
         app = TasksApplication(

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -8,14 +8,19 @@
 #
 # Thanks for using Enthought open source!
 
+# Standard library imports.
 import os
 import pathlib
 import shutil
 import tempfile
 import unittest
 
-import pkg_resources
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
+# Enthought library imports.
 from pyface.gui import GUI
 from pyface.i_gui import IGUI
 from traits.api import Event, HasTraits, provides
@@ -121,8 +126,8 @@ class TestTasksApplication(unittest.TestCase):
         # Check we can load a previously-created state. That previous state
         # has an main window size of (492, 743) (to allow us to check that
         # we're actually using the file).
-        stored_state_location = pkg_resources.resource_filename(
-            "envisage.ui.tasks.tests", "data"
+        stored_state_location = str(
+            files("envisage.ui.tasks.tests").joinpath("data")
         )
 
         state_location = self.tmpdir
@@ -141,8 +146,8 @@ class TestTasksApplication(unittest.TestCase):
     def test_layout_load_pickle_protocol_3(self):
         # Same as the above test, but using a state stored with pickle
         # protocol 3.
-        stored_state_location = pkg_resources.resource_filename(
-            "envisage.ui.tasks.tests", "data"
+        stored_state_location = str(
+            files("envisage.ui.tasks.tests").joinpath("data")
         )
 
         state_location = self.tmpdir

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -131,8 +131,10 @@ class TestTasksApplication(unittest.TestCase):
             / "data"
             / "application_memento_v2.pkl"
         )
-        state_location = pathlib.Path(self.tmpdir) / DEFAULT_STATE_FILENAME
-        state_location.write_bytes(stored_state_location.read_bytes())
+        state_location = pathlib.Path(self.tmpdir)
+        (state_location / DEFAULT_STATE_FILENAME).write_bytes(
+            stored_state_location.read_bytes()
+        )
 
         app = TasksApplication(state_location=state_location)
         app.on_trait_change(app.exit, "application_initialized")
@@ -150,8 +152,10 @@ class TestTasksApplication(unittest.TestCase):
             / "application_memento_v3.pkl"
         )
 
-        state_location = pathlib.Path(self.tmpdir) / "fancy_state.pkl"
-        state_location.write_bytes(stored_state_location.read_bytes())
+        state_location = pathlib.Path(self.tmpdir)
+        (state_location / "fancy_state.pkl").write_bytes(
+            stored_state_location.read_bytes()
+        )
 
         # Use a non-standard filename, to exercise that machinery.
         app = TasksApplication(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
 dependencies = [
     'apptools[preferences]>=5.3',
     'pyface',
-    'setuptools',
     'traits>=6.2',
     'traitsui',
     'importlib-resources>=1.1.0; python_version<"3.9"',


### PR DESCRIPTION
## Summary

- Replace all uses of `pkg_resources.resource_filename` with `importlib.resources.files().joinpath()`, using the `importlib_resources` backport for Python 3.8 compatibility (consistent with the existing pattern in `PackageResourceProtocol`).
- Remove `setuptools` from the runtime `dependencies` in `pyproject.toml`; it is retained as a build dependency.
- Update `AGENTS.md` and `CHANGES.rst` accordingly.

## Files changed

| File | Change |
|------|--------|
| `envisage/examples/_etsdemo_info.py` | Replace `pkg_resources.resource_filename` with `importlib.resources.files` |
| `envisage/tests/test_core_plugin.py` | Replace `pkg_resources.resource_filename` with `importlib.resources.files` |
| `envisage/ui/tasks/tests/test_tasks_application.py` | Replace `pkg_resources.resource_filename` with `importlib.resources.files` |
| `pyproject.toml` | Remove `setuptools` from runtime `dependencies` |
| `AGENTS.md` | Remove `setuptools` from listed runtime dependencies |
| `CHANGES.rst` | Add changelog entry under `Version 8.0.0` |

*This PR was created with the assistance of an AI coding agent.*