### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.14'
         cache: 'pip'

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: 'ubuntu-latest'
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.14'
         cache: 'pip'

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -28,20 +28,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone the Envisage source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install packages for Qt support
         uses: ./.github/actions/install-qt-support
       - name: Cache EDM packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v4.1
+        uses: enthought/setup-edm-action@15aaa2509718d3db47a3105a1f924ffaf58aa9de # v4.1
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Set up bootstrap Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
     - name: Check out the release commit
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.14'
     - name: Install Python packages needed for build and upload

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.14'
         cache: 'pip'
@@ -18,7 +18,7 @@ jobs:
         python -m pip install .
     - run: |
         python -m sphinx -b html -d docs/build/doctrees docs/source docs/build/html
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: documentation
         path: |

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -27,20 +27,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone the Envisage source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install packages for Qt support
         uses: ./.github/actions/install-qt-support
       - name: Cache EDM packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.runtime }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v4.1
+        uses: enthought/setup-edm-action@15aaa2509718d3db47a3105a1f924ffaf58aa9de # v4.1
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Set up bootstrap Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.10'
           cache: 'pip'

--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone the Envisage source
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install packages for Qt support
         uses: ./.github/actions/install-qt-support
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install packages needed for testing

--- a/.github/workflows/update-gh-pages-on-release.yml
+++ b/.github/workflows/update-gh-pages-on-release.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.14'
         cache: 'pip'

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.14'
         cache: 'pip'


### PR DESCRIPTION
## Summary

Hardens CI supply-chain security by pinning all external GitHub Actions to immutable commit SHAs instead of mutable major-version tags, and adds a Dependabot cooldown.

### Why

A `uses: owner/repo@v7` reference resolves through a **mutable** git tag. If an attacker compromises an action's repository — or just gains the ability to move a tag — they can retarget `v7` at malicious code, and every workflow pinned to that tag runs it on the next CI run, with access to that job's secrets. This is exactly what happened in the **March 2025 `tj-actions/changed-files` compromise**, where version tags were retroactively moved to a commit that exfiltrated CI secrets. Full-SHA pins are immutable, so each run is reproducible and immune to tag-move attacks. This follows [GitHub's security-hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

### Changes

- Pin all external actions to commit SHAs with a trailing version comment:

  | Action | SHA | Version |
  |---|---|---|
  | `actions/checkout` | `9c091bb` | v7.0.0 |
  | `actions/setup-python` | `ece7cb0` | v6.3.0 |
  | `actions/cache` | `27d5ce7` | v5.0.5 |
  | `actions/upload-artifact` | `043fb46` | v7.0.1 |
  | `enthought/setup-edm-action` | `15aaa25` | v4.1 |

- Add a **7-day Dependabot cooldown** (`cooldown: default-days: 7`) so action updates aren't picked up until they've been published for a week — reducing exposure to a compromised release that gets yanked shortly after publication.

The local `./.github/actions/install-qt-support` action is in-repo and needs no pinning. Dependabot continues to maintain the SHA pins, bumping both the SHA and the version comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)