### PR TITLE
Use "current" copyright-end-year in the strict style check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,5 @@ max-line-length = 79
 exclude = build, .venv
 ignore = E203, E266, W503
 per-file-ignores = */api.py:F401
+# Pin the year so style checks don't fail when the year rolls over.
+copyright-end-year = 2026

--- a/.github/workflows/check-style-strict.yml
+++ b/.github/workflows/check-style-strict.yml
@@ -14,6 +14,5 @@ jobs:
         cache: 'pip'
         cache-dependency-path: '.github/workflows/style-requirements.txt'
     - run: python -m pip install -r .github/workflows/style-requirements.txt
-    - run: |
-        # Just report on out-of-date copyright end years.
-        python -m flake8 --select H102 .
+    - name: Report on out-of-date copyright end years
+      run: python -m flake8 --select H102 --copyright-end-year current .

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -17,8 +17,4 @@ jobs:
     - run: |
         python -m black --check --diff .
         python -m isort --check --diff .
-        # We hard-code the year here to give us a buffer on CI failures when
-        # January 1st rolls around. Nevertheless, this year and the copyright
-        # headers should be updated as early as possible in each new year,
-        # and definitely before any release.
-        python -m flake8 --copyright-end-year 2026 .
+        python -m flake8 .

--- a/.github/workflows/style-requirements.txt
+++ b/.github/workflows/style-requirements.txt
@@ -1,4 +1,4 @@
 black ~= 24.3
 flake8
-flake8-ets
+flake8-ets >= 1.1.0
 isort


### PR DESCRIPTION
Follow-up cleanup to #596.

That PR noted the solution was "a little bit awkward" because we couldn't give a value for `copyright-end-year` that means "use the current year". [ets-copyright-checker](https://github.com/enthought/ets-copyright-checker) (`flake8-ets`) 1.1.0 now supports `--copyright-end-year current`, so we can do the cleanup the PR wanted:

- Pin the buffered copyright end year in `.flake8` (`copyright-end-year = 2026`), so it's the single source of truth used by both the regular style check and local `flake8` runs.
- Drop the command-line `--copyright-end-year 2026` override from the regular style check — it just runs `flake8 .` now.
- Have the strict style check override the pinned value with `--copyright-end-year current` to report out-of-date copyright end years.

Pins `flake8-ets >= 1.1.0`, since the `current` value is only available from that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)