### PR TITLE
IT-6150: switch PyPI publishing to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
 
     steps:

--- a/.github/workflows/publish-on-pypi.yml
+++ b/.github/workflows/publish-on-pypi.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
 
     steps:
     - name: Check out the release commit
@@ -22,10 +25,8 @@ jobs:
     - name: Build sdist and wheel
       run: |
         python -m build
-    - name: Publish to PyPI
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+    - name: Check the distribution
       run: |
         python -m twine check --strict dist/*
-        python -m twine upload dist/*
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1


### PR DESCRIPTION
Part of **IT-6150** — move PyPI release uploads to GitHub Actions OIDC **trusted publishing**, removing the long-lived `PYPI_USERNAME` / `PYPI_PASSWORD` token from repo secrets.

## What changed (`.github/workflows/publish-on-pypi.yml`)
- Added `permissions: id-token: write` (required for OIDC).
- Added `environment: pypi` (must match the Environment field in the PyPI trusted-publisher config).
- Replaced the `twine upload` step — which used `secrets.PYPI_USERNAME` / `secrets.PYPI_PASSWORD` — with `pypa/gh-action-pypi-publish` (pinned to `v1.14.1`).
- Kept `twine check --strict` as its own step.

## ⚠️ DO NOT MERGE YET — ordering matters
This workflow only authenticates **after** a trusted publisher is configured on the PyPI project. Because this PR **removes the token auth**, merging it before PyPI is configured will **break the next release**.

Required order:
1. IT configures the trusted publisher on PyPI: owner `enthought`, this repository, workflow filename `publish-on-pypi.yml`, environment `pypi`.
2. Cut a validation release / re-run the workflow and confirm the OIDC upload succeeds.
3. **Then** merge this PR.

Kept as a **draft** until step 1 is done. /cc @mdickinson
