### PR TITLE
Remove long-deprecated use of service=True metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,13 @@ Removals
 * Remove the deprecated ``include`` and ``exclude`` traits of
   ``PluginManager``, along with the associated plugin-filtering
   machinery and tests. (#547)
+* Remove support for the long-deprecated ``service=True`` and
+  ``service_protocol`` trait metadata, which registered a plugin's trait
+  as a service when the plugin was started. Use the
+  ``envisage.service_offers`` extension point of the ``CorePlugin``
+  instead. The ``Plugin.register_services`` and
+  ``Plugin.unregister_services`` methods have been removed along with it,
+  and the default ``PluginActivator`` no longer calls them. (#614)
 
 Build
 -----

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -130,6 +130,11 @@ class CorePlugin(Plugin):
 
     # None.
 
+    #### Private interface ####################################################
+
+    # The Ids of the services that were registered when the plugin started.
+    _service_ids = List
+
     ###########################################################################
     # 'IPlugin' interface.
     ###########################################################################
@@ -140,12 +145,26 @@ class CorePlugin(Plugin):
         # preferences node.
         self._load_preferences(self.preferences)
 
-        # Register all service offers.
-        #
-        # These services are unregistered by the default plugin activation
-        # strategy (due to the fact that we store the service ids in this
-        # specific trait!).
+        # Register all service offers. These services are unregistered again
+        # when the plugin is stopped.
         self._service_ids = self._register_service_offers(self.service_offers)
+
+    def stop(self):
+        """Stop the plugin."""
+
+        # Unregister the services in the reverse order that we registered
+        # them.
+        for service_id in reversed(self._service_ids):
+            try:
+                self.application.get_service_from_id(service_id)
+            except ValueError:
+                # the service may have already been individually unregistered
+                pass
+            else:
+                self.application.unregister_service(service_id)
+
+        # Just in case the plugin is started again!
+        self._service_ids = []
 
     ###########################################################################
     # Private interface.

--- a/envisage/core_plugin.py
+++ b/envisage/core_plugin.py
@@ -152,16 +152,8 @@ class CorePlugin(Plugin):
     def stop(self):
         """Stop the plugin."""
 
-        # Unregister the services in the reverse order that we registered
-        # them.
-        for service_id in reversed(self._service_ids):
-            try:
-                self.application.get_service_from_id(service_id)
-            except ValueError:
-                # the service may have already been individually unregistered
-                pass
-            else:
-                self.application.unregister_service(service_id)
+        # Unregister all service offers.
+        self._unregister_service_offers(self._service_ids)
 
         # Just in case the plugin is started again!
         self._service_ids = []
@@ -204,3 +196,17 @@ class CorePlugin(Plugin):
         )
 
         return service_id
+
+    def _unregister_service_offers(self, service_ids):
+        """Unregister a list of service offers."""
+
+        # Unregister the services in the reverse order that we registered
+        # them.
+        for service_id in reversed(service_ids):
+            try:
+                self.application.get_service_from_id(service_id)
+            except ValueError:
+                # the service may have already been individually unregistered
+                pass
+            else:
+                self.application.unregister_service(service_id)

--- a/envisage/plugin.py
+++ b/envisage/plugin.py
@@ -15,7 +15,7 @@ import os
 from os.path import exists, join
 
 # Enthought library imports.
-from traits.api import Instance, List, Property, provides, Str
+from traits.api import Instance, Property, provides, Str
 from traits.util.camel_case import camel_case_to_words
 
 # Local imports.
@@ -81,11 +81,6 @@ class Plugin(ExtensionProvider):
 
     #: The service registry that the object's services are stored in.
     service_registry = Property(Instance(IServiceRegistry))
-
-    #### Private interface ####################################################
-
-    # The Ids of the services that were automatically registered.
-    _service_ids = List
 
     ###########################################################################
     # 'IExtensionPointUser' interface.
@@ -238,45 +233,6 @@ class Plugin(ExtensionProvider):
 
         ExtensionPoint.disconnect_extension_point_traits(self)
 
-    def register_services(self):
-        """Register the services offered by the plugin."""
-
-        for trait_name, trait in self.traits(service=True).items():
-            logger.warning(
-                'DEPRECATED: Do not use the "service=True" metadata anymore. '
-                "Services should now be offered using the service "
-                "offer extension point (envisage.service_offers) "
-                "from the core plugin. "
-                "Plugin %s trait <%s>" % (self, trait_name)
-            )
-
-            # Register a service factory for the trait.
-            service_id = self._register_service_factory(trait_name, trait)
-
-            # We save the service Id so that so that we can unregister the
-            # service when the plugin is stopped.
-            self._service_ids.append(service_id)
-
-    def unregister_services(self):
-        """Unregister any service offered by the plugin."""
-
-        # Unregister the services in the reverse order that we registered
-        # them.
-        service_ids = self._service_ids[:]
-        service_ids.reverse()
-
-        for service_id in service_ids:
-            try:
-                self.application.get_service_from_id(service_id)
-            except ValueError:
-                # the service may have already been individually unregistered
-                pass
-            else:
-                self.application.unregister_service(service_id)
-
-        # Just in case the plugin is started again!
-        self._service_ids = []
-
     ###########################################################################
     # Private interface.
     ###########################################################################
@@ -334,43 +290,6 @@ class Plugin(ExtensionProvider):
             raise
 
         return extensions
-
-    def _get_service_protocol(self, trait):
-        """Determine the protocol to register a service trait with."""
-
-        # If a specific protocol was specified then use it.
-        if trait.service_protocol is not None:
-            protocol = trait.service_protocol
-
-        # Otherwise, use the type of the objects that can be assigned to the
-        # trait.
-        #
-        # fixme: This works for 'Instance' traits, but what about 'AdaptsTo'
-        # and 'Supports' traits?
-        else:
-            # Note that in traits the protocol can be an actual class or
-            # interfacem or the *name* of a class or interface. This allows
-            # us to lazy load them!
-            protocol = trait.trait_type.klass
-
-        return protocol
-
-    def _register_service_factory(self, trait_name, trait):
-        """Register a service factory for the specified trait."""
-
-        # Determine the protocol that the service should be registered with.
-        protocol = self._get_service_protocol(trait)
-
-        # Register a factory for the service so that it will be lazily loaded
-        # the first time somebody asks for a service with the same protocol
-        # (this could obviously be a lambda function, but I thought it best to
-        # be more explicit 8^).
-        def factory(**properties):
-            """A service factory."""
-
-            return getattr(self, trait_name)
-
-        return self.application.register_service(protocol, factory)
 
     ###########################################################################
     # 'object' interface.

--- a/envisage/plugin_activator.py
+++ b/envisage/plugin_activator.py
@@ -32,9 +32,6 @@ class PluginActivator(HasTraits):
         # will be notified if and when contributions are added or removed.
         plugin.connect_extension_point_traits()
 
-        # Register all services.
-        plugin.register_services()
-
         # Plugin specific start.
         plugin.start()
 
@@ -43,9 +40,6 @@ class PluginActivator(HasTraits):
 
         # Plugin specific stop.
         plugin.stop()
-
-        # Unregister all service.
-        plugin.unregister_services()
 
         # Disconnect all of the plugin's extension point traits.
         plugin.disconnect_extension_point_traits()

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -15,7 +15,7 @@ import unittest
 # Standard library imports.
 from os.path import exists, join
 
-from traits.api import HasTraits, Instance, Int, Interface, List, provides
+from traits.api import HasTraits, Int, List, provides
 
 # Enthought library imports.
 from envisage.api import Application, ExtensionPoint, IPluginActivator, Plugin
@@ -108,77 +108,6 @@ class PluginTestCase(unittest.TestCase):
 
         # Make sure A's plugin activator was called.
         self.assertEqual(a, plugin_activator.stopped)
-
-    def test_service(self):
-        """service"""
-
-        class Foo(HasTraits):
-            pass
-
-        class Bar(HasTraits):
-            pass
-
-        class Baz(HasTraits):
-            pass
-
-        class PluginA(Plugin):
-            id = "A"
-            foo = Instance(Foo, (), service=True)
-            bar = Instance(Bar, (), service=True)
-            baz = Instance(Baz, (), service=True)
-
-        a = PluginA()
-
-        application = SimpleApplication(plugins=[a])
-        application.start()
-
-        # Make sure the services were registered.
-        self.assertNotEqual(None, application.get_service(Foo))
-        self.assertEqual(a.foo, application.get_service(Foo))
-
-        self.assertNotEqual(None, application.get_service(Bar))
-        self.assertEqual(a.bar, application.get_service(Bar))
-
-        self.assertNotEqual(None, application.get_service(Baz))
-        self.assertEqual(a.baz, application.get_service(Baz))
-
-        application.stop()
-
-        # Make sure the service was unregistered.
-        self.assertEqual(None, application.get_service(Foo))
-        self.assertEqual(None, application.get_service(Bar))
-        self.assertEqual(None, application.get_service(Baz))
-
-    def test_service_protocol(self):
-        """service protocol"""
-
-        class IFoo(Interface):
-            pass
-
-        class IBar(Interface):
-            pass
-
-        @provides(IFoo, IBar)
-        class Foo(HasTraits):
-            pass
-
-        class PluginA(Plugin):
-            id = "A"
-            foo = Instance(Foo, (), service=True, service_protocol=IBar)
-
-        a = PluginA()
-
-        application = SimpleApplication(plugins=[a])
-        application.start()
-
-        # Make sure the service was registered with the 'IBar' protocol.
-        self.assertNotEqual(None, application.get_service(IBar))
-        self.assertEqual(a.foo, application.get_service(IBar))
-
-        application.stop()
-
-        # Make sure the service was unregistered.
-        self.assertEqual(None, application.get_service(IBar))
 
     def test_multiple_trait_contributions(self):
         """multiple trait contributions"""

--- a/envisage/tests/test_service.py
+++ b/envisage/tests/test_service.py
@@ -13,9 +13,15 @@
 import unittest
 
 # Enthought library imports.
-from traits.api import HasTraits, Instance, Int, TraitError
+from traits.api import HasTraits, Instance, List, TraitError
 
-from envisage.api import Plugin, Service
+from envisage.api import (
+    CorePlugin,
+    Plugin,
+    Service,
+    SERVICE_OFFERS,
+    ServiceOffer,
+)
 from envisage.tests.support import SimpleApplication
 
 
@@ -29,38 +35,45 @@ class ServiceTestCase(unittest.TestCase):
             pass
 
         class PluginA(Plugin):
+            """A plugin that offers a service."""
+
             id = "A"
+
             foo = Instance(Foo, ())
 
-            # The Id of the service registered when the plugin started.
-            _service_id = Int()
+            service_offers = List(contributes_to=SERVICE_OFFERS)
 
-            def start(self):
-                self._service_id = self.application.register_service(
-                    Foo, self.foo
-                )
+            def _service_offers_default(self):
+                """Trait initializer."""
 
-            def stop(self):
-                self.application.unregister_service(self._service_id)
+                return [ServiceOffer(protocol=Foo, factory=self._foo_factory)]
+
+            def _foo_factory(self, **properties):
+                """Service factory."""
+
+                return self.foo
 
         class PluginB(Plugin):
+            """A plugin that uses the service."""
+
             id = "B"
+
             foo = Service(Foo)
 
         a = PluginA()
         b = PluginB()
 
-        application = SimpleApplication(plugins=[a, b])
+        application = SimpleApplication(plugins=[CorePlugin(), a, b])
         application.start()
 
-        # Make sure the services were registered.
-        self.assertEqual(a.foo, b.foo)
+        # The 'Service' trait finds the service that PluginA offers.
+        self.assertEqual(b.foo, a.foo)
 
         # Stop the application.
         application.stop()
 
-        # Make sure the service was unregistered.
-        self.assertEqual(None, b.foo)
+        # The 'Service' trait re-reads the registry, so the service has gone.
+        self.assertIsNone(b.foo)
 
         # You can't set service traits!
         with self.assertRaises(TraitError):

--- a/envisage/tests/test_service.py
+++ b/envisage/tests/test_service.py
@@ -13,7 +13,7 @@
 import unittest
 
 # Enthought library imports.
-from traits.api import HasTraits, Instance, TraitError
+from traits.api import HasTraits, Instance, Int, TraitError
 
 from envisage.api import Plugin, Service
 from envisage.tests.support import SimpleApplication
@@ -30,7 +30,18 @@ class ServiceTestCase(unittest.TestCase):
 
         class PluginA(Plugin):
             id = "A"
-            foo = Instance(Foo, (), service=True)
+            foo = Instance(Foo, ())
+
+            # The Id of the service registered when the plugin started.
+            _service_id = Int()
+
+            def start(self):
+                self._service_id = self.application.register_service(
+                    Foo, self.foo
+                )
+
+            def stop(self):
+                self.application.unregister_service(self._service_id)
 
         class PluginB(Plugin):
             id = "B"


### PR DESCRIPTION
Closes #614.

Registering a plugin trait as a service by tagging it with `service=True` metadata has been deprecated since before Envisage moved out of the `enthought` namespace. The supported mechanism is the `envisage.service_offers` extension point of the `CorePlugin`.

## Changes

**`envisage/plugin.py`**
- Removed `register_services` and `unregister_services`, along with the private helpers `_get_service_protocol` and `_register_service_factory` that only the former used.
- Removed the `_service_ids` trait and the now-unused `List` import.

**`envisage/plugin_activator.py`**
- `start_plugin` is now connect-then-`start()`; `stop_plugin` is `stop()`-then-disconnect.

**`envisage/core_plugin.py`**
- `CorePlugin` declares its own `_service_ids`, and registers and unregisters its service offers from `start` and `stop` via the private `_register_service_offers` and `_unregister_service_offers` pair. Unregistration keeps the reverse ordering and the tolerance for offers that were already unregistered individually.
- See the note below on why this was needed.

**`envisage/tests/`**
- Deleted `test_plugin.test_service` and `test_plugin.test_service_protocol`, plus the `Instance` and `Interface` imports that only they used.
- `test_service.test_service_trait_type` used `service=True` only as a way to get a service into the registry. `PluginA` now contributes a `ServiceOffer` to the `envisage.service_offers` extension point instead, so the test documents the mechanism that `service=True` was deprecated in favour of, and additionally covers the lazy creation of the service by the offer's factory on first access through the `Service` trait.

**`CHANGES.rst`** — added an entry under the 8.0.0 "Removals" section.

## Note on `unregister_services`

The registration side could not be removed on its own. `CorePlugin.start` deliberately stashed its service-offer ids in the inherited `Plugin._service_ids` so that the activator's `unregister_services` would tear them down at stop time — the old comment there admitted as much ("*due to the fact that we store the service ids in this specific trait!*"). Deleting `unregister_services` without moving that responsibility would have silently stopped service offers from being unregistered, which downstream applications do depend on. Hence `CorePlugin.stop`.

Dynamically added offers (`_register_new_services`) are still not tracked, and so are still not unregistered. That is pre-existing behaviour and is left alone here.

## Notes on downstream impact

A survey of the ETS ecosystem and of other codebases known to build on Envisage found no live uses of `service=True`, `service_protocol`, `register_services` or `unregister_services` anywhere outside Envisage itself. Envisage-based applications register services through `ServiceOffer` and the `envisage.service_offers` extension point; the searches turned up no custom plugin activators and no overrides of either removed method.

Neither `service=True` nor the two removed methods are mentioned anywhere in the documentation.

## Testing

- Full suite passes: 177 passed (179 before, minus the two deleted tests), including the GUI-toolkit tests under PySide6.
- `black --check`, `isort --check` and `flake8` are all clean.
- I confirmed the moved teardown is genuinely covered rather than passing vacuously: disabling `CorePlugin.stop` fails `test_core_plugin.test_service_offers`, and dropping its `ValueError` guard fails `test_core_plugin.test_unregister_service_offer` (the #251 regression test). No new test was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
