### PR TITLE
Clean up warnings and log noise from the test suite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,10 +37,10 @@ Removals
 Fixes
 -----
 * ``HTTPResourceProtocol.file`` now closes the ``HTTPError`` raised by
-  ``urlopen`` before converting it to a ``NoSuchResourceError``. An
-  ``HTTPError`` is itself a file-like object wrapping the error response,
-  so discarding it without closing left the underlying connection to be
-  reclaimed by the garbage collector. (#615)
+  ``urlopen`` before converting it to a ``NoSuchResourceError``, rather
+  than leaving the error response for the garbage collector. (#615)
+* The ``NoSuchResourceError`` raised by ``HTTPResourceProtocol.file`` no
+  longer reports a malformed ``"http:://"`` URL scheme. (#615)
 
 Build
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,12 +34,31 @@ Removals
   ``Plugin.unregister_services`` methods have been removed along with it,
   and the default ``PluginActivator`` no longer calls them. (#614)
 
+Fixes
+-----
+* ``HTTPResourceProtocol.file`` now closes the ``HTTPError`` raised by
+  ``urlopen`` before converting it to a ``NoSuchResourceError``. An
+  ``HTTPError`` is itself a file-like object wrapping the error response,
+  so discarding it without closing left the underlying connection to be
+  reclaimed by the garbage collector. (#615)
+
 Build
 -----
 * Remove all uses of ``pkg_resources`` and drop ``setuptools`` as a
   runtime dependency. ``setuptools`` is retained as a build dependency.
   ``importlib.resources`` (with ``importlib-resources`` as a backport
   for Python 3.8) is used instead.
+
+Tests
+-----
+* Rename the ``TestPlugin`` helper class in ``envisage.tests.test_plugin``
+  to ``SamplePlugin``, so that pytest no longer emits a
+  ``PytestCollectionWarning`` for it. (#615)
+* The test suite no longer writes ``WARNING``-level log messages to
+  ``stderr``. The two messages involved -- an unknown extension point
+  being requested, and a plugin's contribution raising an exception -- now
+  have tests that assert them; the tests that provoked them only
+  incidentally suppress them instead. (#615)
 
 Version 7.0.4
 =============

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,8 +37,7 @@ Removals
 Fixes
 -----
 * ``HTTPResourceProtocol.file`` now closes the ``HTTPError`` raised by
-  ``urlopen`` before converting it to a ``NoSuchResourceError``, rather
-  than leaving the error response for the garbage collector. (#615)
+  ``urlopen`` before converting it to a ``NoSuchResourceError``. (#615)
 * The ``NoSuchResourceError`` raised by ``HTTPResourceProtocol.file`` no
   longer reports a malformed ``"http:://"`` URL scheme. (#615)
 
@@ -55,10 +54,7 @@ Tests
   to ``SamplePlugin``, so that pytest no longer emits a
   ``PytestCollectionWarning`` for it. (#615)
 * The test suite no longer writes ``WARNING``-level log messages to
-  ``stderr``. The two messages involved -- an unknown extension point
-  being requested, and a plugin's contribution raising an exception -- now
-  have tests that assert them; the tests that provoked them only
-  incidentally suppress them instead. (#615)
+  ``stderr``. (#615)
 
 Version 7.0.4
 =============

--- a/envisage/resource/http_resource_protocol.py
+++ b/envisage/resource/http_resource_protocol.py
@@ -40,6 +40,6 @@ class HTTPResourceProtocol(HasTraits):
             # On Python 3.8 and 3.9, close() fails if the HTTPError has no fp.
             if exc.fp is not None:
                 exc.close()
-            raise NoSuchResourceError("http:://" + address)
+            raise NoSuchResourceError("http://" + address)
 
         return f

--- a/envisage/resource/http_resource_protocol.py
+++ b/envisage/resource/http_resource_protocol.py
@@ -36,7 +36,15 @@ class HTTPResourceProtocol(HasTraits):
         try:
             f = urlopen("http://" + address)
 
-        except HTTPError:
+        except HTTPError as exc:
+            # An HTTPError is itself a file-like object wrapping the error
+            # response, so close it rather than leaving the underlying
+            # connection to be reclaimed by the garbage collector. On Python
+            # 3.8 and 3.9, an HTTPError created with fp=None doesn't
+            # initialize its file-like base classes at all, and close() fails
+            # with a KeyError; there's nothing to close in that case anyway.
+            if exc.fp is not None:
+                exc.close()
             raise NoSuchResourceError("http:://" + address)
 
         return f

--- a/envisage/resource/http_resource_protocol.py
+++ b/envisage/resource/http_resource_protocol.py
@@ -37,12 +37,7 @@ class HTTPResourceProtocol(HasTraits):
             f = urlopen("http://" + address)
 
         except HTTPError as exc:
-            # An HTTPError is itself a file-like object wrapping the error
-            # response, so close it rather than leaving the underlying
-            # connection to be reclaimed by the garbage collector. On Python
-            # 3.8 and 3.9, an HTTPError created with fp=None doesn't
-            # initialize its file-like base classes at all, and close() fails
-            # with a KeyError; there's nothing to close in that case anyway.
+            # On Python 3.8 and 3.9, close() fails if the HTTPError has no fp.
             if exc.fp is not None:
                 exc.close()
             raise NoSuchResourceError("http:://" + address)

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -154,9 +154,6 @@ class PluginTestCase(unittest.TestCase):
 
         application = SimpleApplication(plugins=[a, b])
 
-        # We should get an error when we try to get the contributions to the
-        # extension point, and the failure should be logged along with its
-        # traceback before being re-raised.
         with self.assertLogs("envisage.plugin", level="ERROR") as watcher:
             with self.assertRaises(ZeroDivisionError):
                 application.get_extensions("x")

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -154,6 +154,8 @@ class PluginTestCase(unittest.TestCase):
 
         application = SimpleApplication(plugins=[a, b])
 
+        # We should get an when we try to get the contributions to the
+        # extension point.
         with self.assertLogs("envisage.plugin", level="ERROR") as watcher:
             with self.assertRaises(ZeroDivisionError):
                 application.get_extensions("x")

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -154,7 +154,7 @@ class PluginTestCase(unittest.TestCase):
 
         application = SimpleApplication(plugins=[a, b])
 
-        # We should get an when we try to get the contributions to the
+        # We should get an error when we try to get the contributions to the
         # extension point.
         with self.assertLogs("envisage.plugin", level="ERROR") as watcher:
             with self.assertRaises(ZeroDivisionError):

--- a/envisage/tests/test_plugin.py
+++ b/envisage/tests/test_plugin.py
@@ -23,7 +23,7 @@ from envisage.tests.ets_config_patcher import ETSConfigPatcher
 from envisage.tests.support import SimpleApplication
 
 
-class TestPlugin(Plugin):
+class SamplePlugin(Plugin):
     id = "test_plugin"
 
 
@@ -154,10 +154,17 @@ class PluginTestCase(unittest.TestCase):
 
         application = SimpleApplication(plugins=[a, b])
 
-        # We should get an when we try to get the contributions to the
-        # extension point.
-        with self.assertRaises(ZeroDivisionError):
-            application.get_extensions("x")
+        # We should get an error when we try to get the contributions to the
+        # extension point, and the failure should be logged along with its
+        # traceback before being re-raised.
+        with self.assertLogs("envisage.plugin", level="ERROR") as watcher:
+            with self.assertRaises(ZeroDivisionError):
+                application.get_extensions("x")
+
+        self.assertEqual(len(watcher.records), 1)
+        record = watcher.records[0]
+        self.assertIn("trait <x>", record.getMessage())
+        self.assertIsNotNone(record.exc_info)
 
     def test_contributes_to(self):
         """contributes to"""
@@ -304,7 +311,7 @@ class PluginTestCase(unittest.TestCase):
 
     def test_plugin_str_representation(self):
         """test the string representation of the plugin"""
-        plugin_repr = "TestPlugin(id={!r}, name={!r})"
-        plugin = TestPlugin(id="Fred", name="Wilma")
+        plugin_repr = "SamplePlugin(id={!r}, name={!r})"
+        plugin = SamplePlugin(id="Fred", name="Wilma")
         self.assertEqual(str(plugin), plugin_repr.format("Fred", "Wilma"))
         self.assertEqual(repr(plugin), plugin_repr.format("Fred", "Wilma"))

--- a/envisage/tests/test_provider_extension_registry.py
+++ b/envisage/tests/test_provider_extension_registry.py
@@ -41,13 +41,9 @@ class ProviderExtensionRegistryTestCase(
 
         self.registry = ProviderExtensionRegistry()
 
-        # Several tests here and in the shared mixin ask for the extensions of
-        # an extension point that isn't in the registry, which logs a warning.
-        # That warning is the subject of
-        # test_get_extensions_of_unknown_extension_point; everywhere else it's
-        # incidental, so suppress it to keep the test output clean. Note that
-        # assertLogs overrides the level set here, so tests that do want to
-        # check for the warning still work.
+        # Several tests here and in the shared mixin provoke the unknown
+        # extension point warning incidentally; it's asserted directly in
+        # test_get_extensions_of_unknown_extension_point.
         logger = logging.getLogger(LOGGER_NAME)
         old_level = logger.level
         logger.setLevel(logging.ERROR)

--- a/envisage/tests/test_provider_extension_registry.py
+++ b/envisage/tests/test_provider_extension_registry.py
@@ -10,6 +10,7 @@
 """ Tests for the provider extension registry. """
 
 # Standard library imports.
+import logging
 import unittest
 
 from traits.api import Int, List
@@ -26,6 +27,9 @@ from envisage.tests.test_extension_registry_mixin import (
     ExtensionRegistryTestMixin,
 )
 
+# Logger used by the code under test.
+LOGGER_NAME = "envisage.provider_extension_registry"
+
 
 class ProviderExtensionRegistryTestCase(
     ExtensionRegistryTestMixin, unittest.TestCase
@@ -36,6 +40,32 @@ class ProviderExtensionRegistryTestCase(
         """Prepares the test fixture before each test method is called."""
 
         self.registry = ProviderExtensionRegistry()
+
+        # Several tests here and in the shared mixin ask for the extensions of
+        # an extension point that isn't in the registry, which logs a warning.
+        # That warning is the subject of
+        # test_get_extensions_of_unknown_extension_point; everywhere else it's
+        # incidental, so suppress it to keep the test output clean. Note that
+        # assertLogs overrides the level set here, so tests that do want to
+        # check for the warning still work.
+        logger = logging.getLogger(LOGGER_NAME)
+        old_level = logger.level
+        logger.setLevel(logging.ERROR)
+        self.addCleanup(logger.setLevel, old_level)
+
+    def test_get_extensions_of_unknown_extension_point(self):
+        """getting extensions of an unknown extension point"""
+
+        registry = self.registry
+
+        # Asking for the extensions of an extension point that was never
+        # added gives an empty list, and warns.
+        with self.assertLogs(LOGGER_NAME, level="WARNING") as watcher:
+            extensions = registry.get_extensions("my.ep")
+
+        self.assertEqual(extensions, [])
+        self.assertEqual(len(watcher.records), 1)
+        self.assertIn("my.ep", watcher.records[0].getMessage())
 
     def test_providers(self):
         """providers"""


### PR DESCRIPTION
Towards #615. This covers the parts of that issue that are unambiguous; the `TasksApplication` warnings are deliberately left for a follow-up (see the end).

## Why this wasn't visible in CI

The noise appears under `python -W default -m unittest discover -v envisage` — what `etstool.py:357` runs. The GitHub Actions jobs run bare `python -m pytest`, which captures logging and shows it only on failure, and which hides `ResourceWarning` by default. So the suite has looked clean on GitHub while the EDM runs have not been.

## 1. `ResourceWarning` from the resource manager tests

```
tempfile.py:484: ResourceWarning: Implicitly cleaning up <HTTPError 404: 'No such resource'>
```

This one is a real defect, not a test artifact. `urllib.response.addbase` subclasses `tempfile._TemporaryFileWrapper`, so an `HTTPError` **is** a temp-file wrapper and warns if it's collected unclosed. `HTTPResourceProtocol.file` caught `HTTPError` and discarded it without closing, which in real use leaves the connection underlying the error response to the garbage collector rather than releasing it promptly.

The fix closes it, with a guard that matters:

| Python | `HTTPError(..., fp=None)` | `.close()` |
| --- | --- | --- |
| 3.8, 3.9 | `self.fp` stays `None`, file-like bases never initialized | `KeyError: 'file'` |
| 3.10+ | `self.fp` becomes an `io.BytesIO` | works |

3.8 is in the `test-with-pypi` matrix, so an unguarded `exc.close()` would have broken CI there — and would have been a genuine regression for any caller raising `HTTPError` with `fp=None` on those versions. Hence `if exc.fp is not None`. This also explains why the warning is recent: on 3.8/3.9 the `fp=None` case produced no wrapper and so no warning at all.

Verified on 3.8, 3.10 and 3.14.

## 2. `PytestCollectionWarning`

`envisage.tests.test_plugin.TestPlugin` matched pytest's `Test*` collection glob but has an `__init__`. It's only used for a `__repr__` assertion, so it's renamed to `SamplePlugin`.

## 3. Log records reaching `stderr`

Eleven records at `WARNING` and above, from two call sites:

| site | records | tests |
| --- | --- | --- |
| `provider_extension_registry.py:85` — unknown extension point | 6 | 5 tests in `test_provider_extension_registry` (2 via the shared mixin) |
| `plugin.py:287` — `logger.exception` on a failing contribution | 1 | `test_exception_in_trait_contribution` |
| `provider_extension_registry.py:85` — as above | 4 | 4 tests in `test_tasks_application` — **left alone, see below** |

Every one of these is expected behaviour being deliberately provoked. The review that preceded this PR also found that **no** test in the suite asserted any log output (`assertLogs` count: 0), even though these are exactly the `WARNING`+ messages worth pinning down. So rather than only silencing them:

- `test_exception_in_trait_contribution` now asserts the `ERROR` record and that it carries `exc_info` — i.e. that `logger.exception` really attaches the traceback before re-raising.
- A new `test_get_extensions_of_unknown_extension_point` asserts the `WARNING` and the empty return value.
- The remaining sites provoke the warning only incidentally — including two in `ExtensionRegistryTestMixin`, which is shared with `test_extension_registry.py` where the plain `ExtensionRegistry` is silent for the same input. Wrapping those in `assertLogs` would either need the mixin to grow a registry-specific hook or would assert a coincidence of the mixin's implementation, so they're suppressed at the level of `ProviderExtensionRegistryTestCase.setUp` instead, with a comment pointing at the test that does assert the behaviour. `assertLogs` overrides a logger level set that way, so the assertions above still work.

The tradeoff worth flagging: that suppression is scoped to one logger and one test class, but it would hide an unexpected new `WARNING` from that logger in those tests. I think that's acceptable now that the behaviour has a dedicated test, but say the word if you'd rather have the mixin hook.

## Deliberately not addressed

The four `getting extensions of unknown extension point <envisage.ui.tasks.tasks>` records from `test_tasks_application`. `TasksApplication` declares `task_factories = ExtensionPoint(id="envisage.ui.tasks.tasks")` (`tasks_application.py:85`), but the point is only *registered* by `TasksPlugin` (`tasks_plugin.py:88`). The tests build a bare `TasksApplication` with no plugins, `_default_layout_default` reads `self.task_factories`, and the registry warns — which means any real application subclassing `TasksApplication` without including `TasksPlugin` gets the same warning at startup. That looks like a wart to fix rather than noise to silence, and it sits next to a related asymmetry (`ExtensionRegistry.get_extensions` on an unknown id is silent; `ProviderExtensionRegistry`'s warns; `set_extensions` and `remove_extension_point` *raise* `UnknownExtensionPoint`). Both deserve their own discussion.

## Verification

- `pytest`: 178 passed, **0 warnings** (was 177 passed, 1 warning).
- `python -W default -m unittest discover -t . -s envisage` on 3.8, 3.10, 3.14: OK, with only the four deferred `tasks` records remaining.
- `black --check`, `isort --check`, `flake8` clean, using the pinned `black ~= 24.3` from `style-requirements.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)