### PR TITLE
Include the TasksPlugin in the TasksApplication tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ Tests
   ``stderr``. (#615)
 * pytest is now configured to turn warnings into errors, so that a new
   warning fails the test suite instead of passing unnoticed. (#615)
+* The ``TasksApplication`` tests now include the ``TasksPlugin``, which
+  declares the extension points that ``TasksApplication`` reads. Without
+  it, those tests logged a warning about an unknown extension point.
+  (#615)
 
 Version 7.0.4
 =============

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -27,8 +27,18 @@ from traits.api import Event, HasTraits, provides
 
 from envisage.api import Plugin
 from envisage.tests.support import requires_gui
-from envisage.ui.tasks.api import TasksApplication
+from envisage.ui.tasks.api import TasksApplication, TasksPlugin
 from envisage.ui.tasks.tasks_application import DEFAULT_STATE_FILENAME
+
+
+def create_tasks_application(plugins=(), **traits):
+    """
+    Create a TasksApplication for testing.
+
+    The extension points that TasksApplication reads are declared by
+    TasksPlugin, so every Tasks application needs that plugin.
+    """
+    return TasksApplication(plugins=[TasksPlugin(), *plugins], **traits)
 
 
 @provides(IGUI)
@@ -85,7 +95,7 @@ class TestTasksApplication(unittest.TestCase):
         state_location = self.tmpdir
 
         # Create application, and set it up to exit as soon as it's launched.
-        app = TasksApplication(
+        app = create_tasks_application(
             state_location=state_location,
             layout_save_protocol=3,
         )
@@ -112,7 +122,7 @@ class TestTasksApplication(unittest.TestCase):
         self.assertFalse(state_path.exists())
 
         # Create application and set it up to exit as soon as it's launched.
-        app = TasksApplication(
+        app = create_tasks_application(
             state_location=state_location,
             state_filename=state_filename,
         )
@@ -132,7 +142,7 @@ class TestTasksApplication(unittest.TestCase):
             (stored_state_location / "application_memento_v2.pkl").read_bytes()
         )
 
-        app = TasksApplication(state_location=state_location)
+        app = create_tasks_application(state_location=state_location)
         app.on_trait_change(app.exit, "application_initialized")
         app.run()
 
@@ -150,7 +160,7 @@ class TestTasksApplication(unittest.TestCase):
         )
 
         # Use a non-standard filename, to exercise that machinery.
-        app = TasksApplication(
+        app = create_tasks_application(
             state_location=state_location,
             state_filename="fancy_state.pkl",
         )
@@ -163,11 +173,11 @@ class TestTasksApplication(unittest.TestCase):
     def test_gui_trait_expects_IGUI_interface(self):
         # Trivial test where we simply set the trait
         # and the test passes because no errors are raised.
-        app = TasksApplication()
+        app = create_tasks_application()
         app.gui = DummyGUI()
 
     def test_simple_lifecycle(self):
-        app = TasksApplication(state_location=self.tmpdir)
+        app = create_tasks_application(state_location=self.tmpdir)
         app.observe(lambda event: app.exit(), "application_initialized")
         app.run()
 
@@ -179,7 +189,7 @@ class TestTasksApplication(unittest.TestCase):
         gui = LifecycleRecordingGUI()
         gui.observe(events.append, "starting,stopped")
 
-        app = TasksApplication(
+        app = create_tasks_application(
             gui=gui, state_location=self.tmpdir, plugins=[plugin]
         )
         app.observe(events.append, "starting,started,stopping,stopped")

--- a/envisage/ui/tasks/tests/test_tasks_application.py
+++ b/envisage/ui/tasks/tests/test_tasks_application.py
@@ -31,7 +31,7 @@ from envisage.ui.tasks.api import TasksApplication, TasksPlugin
 from envisage.ui.tasks.tasks_application import DEFAULT_STATE_FILENAME
 
 
-def create_tasks_application(plugins=(), **traits):
+def create_tasks_application(plugins=[], **traits):
     """
     Create a TasksApplication for testing.
 


### PR DESCRIPTION
Closes #615. This removes the last four WARNING-level log records from
the test suite — the ones #618 deliberately deferred.

## The behaviour is fine; the tests were misconfigured

#618 predicted this was "a wart to fix rather than noise to silence",
on the grounds that any application subclassing `TasksApplication`
without `TasksPlugin` warns at startup. Investigating that under #620
turned up the opposite conclusion: `TasksApplication` needs
`TasksPlugin`, so an application without it is misconfigured, and the
warning is doing its job.

The registration path, for the record:

1. `Application.extension_registry` defaults to
   `PluginExtensionRegistry(plugin_manager=self)`.
2. Each plugin is added as a provider;
   `ProviderExtensionRegistry._add_provider_extension_points`
   (`provider_extension_registry.py:159`) stores whatever
   `provider.get_extension_points()` returns.
3. `Plugin.get_extension_points` (`plugin.py:107`) returns the trait
   *type* of every trait marked `__extension_point__=True`.
4. `TasksPlugin.tasks` (`tasks_plugin.py:88`) carries
   `id = "envisage.ui.tasks.tasks"`, which is exactly
   `TasksApplication.TASK_FACTORIES` (`tasks_application.py:48`). Same
   for `task_extensions`.

What makes the dependency easy to miss is that the two sides share no
*name* — the consumer trait is `task_factories`, the provider trait is
`tasks`. Only the id string ties them together.

That the plugin is required is not a novel claim:

* `run_attractor.py:23`, the only complete Tasks example in the tree,
  builds `[CorePlugin(), TasksPlugin(), AttractorsPlugin()]`, and
  `AttractorsPlugin` is a pure contributor — `tasks =
  List(contributes_to="envisage.ui.tasks.tasks")` — relying on
  `TasksPlugin` to have declared the point.
* `docs/source/tasks_user_manual/extensibility.rst:22` has a section
  headed "The Tasks Plugin" describing it as the owner of those
  extension points.

So the pattern of declaring a read-only `ExtensionPoint` trait on a
consumer is not penalised by the warning: it is silent whenever the
companion plugin is present, which supported usage ensures. Verified
both ways — with `TasksPlugin` in the plugin list, no warning and no
ordering hazard; without it, the warning.

## The change

The four noisy tests built a bare `TasksApplication` with no plugins,
`_default_layout_default` read `self.task_factories`, and the registry
warned. All seven constructions in the file now go through a
`create_tasks_application` helper that supplies `TasksPlugin`.

A helper rather than seven copies of `plugins=[TasksPlugin()]`, so the
invariant is stated once in the place that explains why — otherwise it
reads as incidental boilerplate that could be stripped out, bringing
the noise back. Applied to all seven sites, not just the four noisy
ones, so tests added later inherit it.

`test_lifecycle_with_plugin` asserts an exact event sequence; that is
undisturbed, as `TasksPlugin` fires no lifecycle events of its own.

## Not changed

`ProviderExtensionRegistry._get_extensions` keeps the warning, so the
test-side coupling #618 introduced stays correct and needs no edit:
both `test_get_extensions_of_unknown_extension_point` and the `setUp`
logger suppression in `test_provider_extension_registry.py` remain
valid. That suppression is not dead code under this resolution.

The API asymmetry #618 also flagged — `ExtensionRegistry.get_extensions`
silent on an unknown id, `ProviderExtensionRegistry`'s warning,
`set_extensions` and `remove_extension_point` raising
`UnknownExtensionPoint` — is untouched and still deserves its own
discussion.

## Verification

The seven tests in this file are `@requires_gui`, so they skip silently
without a toolkit installed; runs below inject PySide6.

* Before: exactly the four tests named in #620 emitted `getting
  extensions of unknown extension point <envisage.ui.tasks.tasks>`.
* After: zero occurrences anywhere in the suite under
  `--log-cli-level=WARNING`; 178 passed, none skipped, no warnings.
* `black --check`, `isort --check` and `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
