### PR TITLE
Modernize Python versions used in CI workflows

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up bootstrap Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: '.github/workflows/bootstrap-requirements.txt'
       - name: Install click to the bootstrap environment

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up bootstrap Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.10'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: '.github/workflows/bootstrap-requirements.txt'
       - name: Install click to the bootstrap environment

--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Install packages needed for testing
         run: python -m pip install pytest
       - name: Install toolkit
-        run: python -m pip install pyside6
+        # PySide6 caps Requires-Python below the newest version in the
+        # matrix, but its abi3 wheels work there regardless.
+        run: python -m pip install --ignore-requires-python pyside6
       - name: Install package under test
         run: python -m pip install .
       - name: List installed packages

--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.15']
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install packages needed for testing
         run: python -m pip install pytest
       - name: Install toolkit


### PR DESCRIPTION
The workflows using `actions/setup-python` fall into two groups: those that
just need a single Python, and the one that tests across a matrix. This brings
the first group up to 3.14 and adds 3.15 to the second.

Six of the single-version jobs were already on 3.14: `check-style`,
`check-style-strict`, `test-doc-build`, `publish-on-pypi`, `update-gh-pages`
and `update-gh-pages-on-release`. The two that were not are the bootstrap
Pythons that run `etstool.py` for the EDM workflows, both still on 3.10. Those
environments only install `click` and shell out to `edm`, which supplies its
own interpreter, so nothing there was version-sensitive.

`test-with-pypi` gains Python 3.15. Since 3.15 has no stable release yet,
`setup-python` will not resolve it without `allow-prereleases`; that flag is a
no-op for the entries that do have a stable release, so it can stay in place
unchanged once 3.15 ships. At the moment it resolves to 3.15.0rc1.

Installing the Qt toolkit there needs `--ignore-requires-python`. Every
PySide6 release caps `Requires-Python` below the newest matrix entry — 6.11.1
declares `>=3.10,<3.15` — and pip honours that cap, so a plain
`pip install pyside6` fails outright on 3.15. The cap reflects conservatism
about untested Python versions rather than a real incompatibility: PySide6
ships abi3 wheels, and 6.11.1 installed that way runs the whole Envisage suite
on 3.15 without failures, GUI tests included. uv arrives at the same outcome by
ignoring `Requires-Python` upper bounds, which is why this never surfaces when
running the tests locally under uv.

Verified by reproducing the job's steps with pip in a Python 3.15 virtual
environment: PySide6 6.11.1 installs, `traits` builds from sdist, and the full
suite passes all 178 tests. `traits` publishes no cp315 wheel for either
linux-x86_64 or macos-arm64, so the 3.15 job compiles it and will be
correspondingly slower than its siblings. That check ran on macOS arm64 against
3.15.0b2, so it differs from the runner's ubuntu x86_64 and 3.15.0rc1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
