### PR TITLE
Minor cleanups ahead of the 8.0 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ python -m pytest envisage/tests/test_service_registry.py::ServiceRegistryTestCas
 python -m pytest envisage/tests/test_service_registry.py::ServiceRegistryTestCase::test_should_get_required_service
 
 # Run with unittest directly
-python -m unittest discover -v envisage
+python -m unittest discover -v -t . -s envisage
 
 # Run a single test via unittest
 python -m unittest envisage.tests.test_application.ApplicationTestCase.test_home

--- a/envisage/i_service_registry.py
+++ b/envisage/i_service_registry.py
@@ -19,7 +19,7 @@ class IServiceRegistry(Interface):
 
     The service registry provides a 'Yellow Pages' style mechanism, in that
     services are published and looked up by protocol (meaning, *interface*,
-    *type*, or *class* (for old-style classes!). It is called a 'Yellow Pages'
+    *type*, or *class*). It is called a 'Yellow Pages'
     mechanism because it is just like looking up a telephone number in the
     'Yellow Pages' phone book. You use the 'Yellow Pages' instead of the
     'White Pages' when you don't know the *name* of the person you want to

--- a/envisage/i_service_registry.py
+++ b/envisage/i_service_registry.py
@@ -18,18 +18,17 @@ class IServiceRegistry(Interface):
     """The service registry interface.
 
     The service registry provides a 'Yellow Pages' style mechanism, in that
-    services are published and looked up by protocol (meaning, *interface*,
-    *type*, or *class*). It is called a 'Yellow Pages'
-    mechanism because it is just like looking up a telephone number in the
-    'Yellow Pages' phone book. You use the 'Yellow Pages' instead of the
-    'White Pages' when you don't know the *name* of the person you want to
-    call but you do know what *kind* of service you require. For example, if
-    you have a leaking pipe, you know you need a plumber, so you pick up your
-    'Yellow Pages', go to the 'Plumbers' section and choose one that seems to
-    fit the bill based on price, location, certification, etc. The service
-    registry does exactly the same thing as the 'Yellow Pages', only with
-    objects, and it even allows you to publish your own entries for free
-    (unlike the *real* one)!
+    services are published and looked up by protocol (meaning, *interface* or
+    *class*). It is called a 'Yellow Pages' mechanism because it is just like
+    looking up a telephone number in the 'Yellow Pages' phone book. You use
+    the 'Yellow Pages' instead of the 'White Pages' when you don't know the
+    *name* of the person you want to call but you do know what *kind* of
+    service you require. For example, if you have a leaking pipe, you know you
+    need a plumber, so you pick up your 'Yellow Pages', go to the 'Plumbers'
+    section and choose one that seems to fit the bill based on price,
+    location, certification, etc. The service registry does exactly the same
+    thing as the 'Yellow Pages', only with objects, and it even allows you to
+    publish your own entries for free (unlike the *real* one)!
 
     """
 

--- a/envisage/tests/test_slice.py
+++ b/envisage/tests/test_slice.py
@@ -37,10 +37,7 @@ def listener(obj, trait_name, old, event):
             del clone[event.index]
 
         else:
-            # workaroud for traits bug in Python 3
-            # https://github.com/enthought/traits/issues/334
-            index = event.index if event.index is not None else 0
-            del clone[index : index + len(event.removed)]
+            del clone[event.index : event.index + len(event.removed)]
 
     # If nothing was removed then it is an 'append', 'insert' or 'extend'
     # operation.

--- a/envisage/tests/test_slice.py
+++ b/envisage/tests/test_slice.py
@@ -30,12 +30,6 @@ def listener(obj, trait_name, old, event):
     clone = TEST_LIST[:]
 
     added = event.added
-    # Backwards compatibility for Traits < 6.0, where event.added may
-    # be a list containing a list containing the added elements. This
-    # block can be removed once compatibility with Traits < 6.0 is no
-    # longer needed. Ref: enthought/traits#300.
-    if len(added) == 1 and isinstance(added[0], list):
-        added = added[0]
 
     # If nothing was added then this is a 'del' or 'remove' operation.
     if len(added) == 0:

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,3 +1,2 @@
-Examples have been moved to sit in envisage/examples/demo. The examples
-remaining here in the legacy directory have known problems.  See
-enthought/envisage#329, enthought/envisage#330, enthought/envisage#381
+Examples have been moved to sit in envisage/examples/demo. The Workbench-based
+AcmeLab example remaining here in the legacy directory is unmaintained.


### PR DESCRIPTION
Five small independent cleanups turned up by the deprecation audit, one per
commit so any single one can be dropped without disturbing the others. None of
them changes behaviour for users of Envisage.

**Dead Traits < 6.0 compatibility code in `test_slice`.** The block unwrapped
a list-of-one-list form of `event.added` that Traits produced before 6.0. The
declared floor is `traits>=6.2`, so the branch is unreachable, and its own
comment asked for removal once support for Traits < 6.0 was dropped.
`listener()` is a test helper used only by this module's tests, all of which
still pass without it.

**The enthought/traits#334 workaround in the same helper.** It substituted 0
for a `None` `event.index` on `del` and `remove` operations. That issue is
closed, and the other two branches of `listener()` already use `event.index`
directly with no such guard. Probed against traits 7.1.0 using the same
`on_trait_change(listener, "elts_items")` mechanism the tests use: `del`,
`remove`, `pop`, del-all and del-slice each report a concrete integer index
and none reports `None`. Had a `None` survived, the arithmetic would now raise
`TypeError` rather than pass silently, so the tests would catch it.

**Python 2 residue in the `IServiceRegistry` docstring.** It described a
protocol as an "*interface*, *type*, or *class* (for old-style classes!)".
Both halves of that are Python 2: old-style classes are gone, and the
type/class pair *was* the distinction between new-style and old-style classes,
so one term now suffices. It reads "*interface* or *class*", matching the
wording `get_service`, `get_services` and `register_service` already use in the
same file. This also closes the parenthesis opened by `(meaning, ...`, which
had been left dangling, and the paragraph is reflowed.

**Closed issues cited in the legacy examples README.** It pointed at #329,
#330 and #381 for "known problems". All three are closed, and the examples
two of them described are gone: `MOTD_Using_Eggs` went with the egg-based
plugin managers, `ipython_kernel` with the IPython plugins. Only the
Workbench-based AcmeLab example is left, so the README now says that.

**A broken test command in `AGENTS.md`.** `python -m unittest discover -v
envisage` fails when run from the repository root, which is exactly where a
contributor following the docs will run it: discovery puts `envisage/` on
`sys.path`, so its `resource` subpackage collides with the standard library
`resource` module and the run errors on `resource.tests`. It covers 171 of 178
tests and reports `FAILED (errors=1)`. Giving discovery an explicit top-level
directory avoids the collision and reports all 178.

`etstool.py:341` uses the same short form and is deliberately left alone —
verified that it works there, because it runs from a temporary directory where
`envisage` resolves as an installed package name rather than a local
directory, so no shadowing occurs. That is also why the EDM jobs have never
shown this.

## Deliberately not included

Removing the legacy dotted `foo.bar.baz` symbol-path form from
`import_manager.py:44-54`, documented at `i_import_manager.py:26-52` as
"retained for backwards compatability". It has never emitted a deprecation
warning, so dropping it is a behavioural break — and Envisage itself still
relies on it, at `envisage/plugins/text_editor/text_editor_action_set.py:25`
and `:32`, which reach `import_symbol` through the Workbench action manager
builder. `envisage/tests/test_import_manager.py:34` covers the form directly
too. Everywhere else in the tree already uses the recommended colon form. So a
removal is three coordinated edits plus a hard break for downstream callers,
which wants a decision rather than a tidy-up.

## Verification

`pytest` passes 171 with 7 skipped (no toolkit installed);
`python -m unittest discover -v -t . -s envisage` reports all 178 OK; `black`,
`isort` and `flake8` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
