### PR TITLE
Review the 8.0.0 changelog for completeness

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,11 +52,11 @@ Build
   ``wheel`` from the build requirements. (#625)
 * Publish to PyPI using trusted publishing (OIDC) rather than a
   long-lived API token. (#608)
-* Pin third-party GitHub Actions to commit SHAs. (#604)
 * Update copyright header end years to 2026. The style check now uses a
   pinned end year, so it no longer starts failing when the year rolls
   over; a separate non-blocking check reports out-of-date end years.
   (#596, #597, #607)
+* Pin third-party GitHub Actions to commit SHAs. (#604)
 * Bump the GitHub Actions used by the CI workflows to their latest
   versions. (#591, #592, #593, #594, #595, #602, #603, #605, #606, #609,
   #610)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,62 +12,77 @@ Changes
   ``logging.lastResort``, and so suppressed Envisage's warnings and
   errors in applications that hadn't configured logging themselves.
   Applications that don't configure logging will now see Envisage's
-  warnings and errors on ``stderr``. (#574)
+  warnings and errors on ``stderr``. (#613)
 * Messages reporting that a default ``id`` or ``name`` has been used for
   a ``Plugin`` or an ``ActionSet`` are now logged at ``INFO`` level
   rather than ``WARNING`` level. Defaulting those attributes is normal,
-  supported behaviour, so there's no action for the user to take. (#574)
+  supported behaviour, so there's no action for the user to take. (#613)
 
 Removals
 --------
 * Drop support for Python 3.8 and 3.9. Envisage now requires Python 3.10
-  or later. (#616)
+  or later. (#622)
 * Remove the deprecated ``EggPluginManager``, ``EggBasketPluginManager``
   and ``PackagePluginManager`` classes, along with the supporting
-  ``egg_utils`` module and associated tests. (#548)
+  ``egg_utils`` module and associated tests. (#599)
 * Remove the deprecated ``include`` and ``exclude`` traits of
   ``PluginManager``, along with the associated plugin-filtering
-  machinery and tests. (#547)
+  machinery and tests. (#612)
 * Remove support for the long-deprecated ``service=True`` and
   ``service_protocol`` trait metadata, which registered a plugin's trait
   as a service when the plugin was started. Use the
   ``envisage.service_offers`` extension point of the ``CorePlugin``
   instead. The ``Plugin.register_services`` and
   ``Plugin.unregister_services`` methods have been removed along with it,
-  and the default ``PluginActivator`` no longer calls them. (#614)
+  and the default ``PluginActivator`` no longer calls them. (#617)
 
 Fixes
 -----
 * ``HTTPResourceProtocol.file`` now closes the ``HTTPError`` raised by
-  ``urlopen`` before converting it to a ``NoSuchResourceError``. (#615)
+  ``urlopen`` before converting it to a ``NoSuchResourceError``. (#618)
 * The ``NoSuchResourceError`` raised by ``HTTPResourceProtocol.file`` no
-  longer reports a malformed ``"http:://"`` URL scheme. (#615)
+  longer reports a malformed ``"http:://"`` URL scheme. (#618)
 
 Build
 -----
 * Remove all uses of ``pkg_resources`` and drop ``setuptools`` as a
   runtime dependency. ``setuptools`` is retained as a build dependency.
-  ``importlib.resources`` is used instead.
+  ``importlib.resources`` is used instead. (#600)
 * Drop the ``importlib-resources`` dependency, which was only needed for
-  Python versions earlier than 3.9. (#616)
+  Python versions earlier than 3.9. (#622)
 * Declare the license with the PEP 639 ``license`` and ``license-files``
   fields in place of the deprecated ``License ::`` classifier. (#625)
 * Raise the build-time setuptools requirement to 83 or later, and drop
   ``wheel`` from the build requirements. (#625)
+* Publish to PyPI using trusted publishing (OIDC) rather than a
+  long-lived API token, and pin third-party GitHub Actions to commit
+  SHAs. (#604, #608)
+* Update copyright header end years to 2026. The style check now uses a
+  pinned end year, so it no longer starts failing when the year rolls
+  over; a separate non-blocking check reports out-of-date end years.
+  (#596, #597, #607)
+* Bump the GitHub Actions used by the CI workflows to their latest
+  versions. (#591, #592, #593, #594, #595, #602, #603, #605, #606, #609,
+  #610)
+* The CI test matrix now includes pre-release Python versions, so that
+  incompatibilities with upcoming Python releases are caught early.
+  (#601, #624)
+* Add ``AGENTS.md``, describing the build, test, lint and code style
+  workflows for the repository. (#598, #626)
 
 Tests
 -----
 * Rename the ``TestPlugin`` helper class in ``envisage.tests.test_plugin``
   to ``SamplePlugin``, so that pytest no longer emits a
-  ``PytestCollectionWarning`` for it. (#615)
+  ``PytestCollectionWarning`` for it. (#618)
 * The test suite no longer writes ``WARNING``-level log messages to
-  ``stderr``. (#615)
+  ``stderr``. (#618, #621)
 * pytest is now configured to turn warnings into errors, so that a new
-  warning fails the test suite instead of passing unnoticed. (#615)
+  warning fails the test suite instead of passing unnoticed. (#619)
 * The ``TasksApplication`` tests now include the ``TasksPlugin``, which
   declares the extension points that ``TasksApplication`` reads. Without
   it, those tests logged a warning about an unknown extension point.
-  (#615)
+  (#621)
 
 Version 7.0.4
 =============

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,8 +51,8 @@ Build
 * Raise the build-time setuptools requirement to 83 or later, and drop
   ``wheel`` from the build requirements. (#625)
 * Publish to PyPI using trusted publishing (OIDC) rather than a
-  long-lived API token, and pin third-party GitHub Actions to commit
-  SHAs. (#604, #608)
+  long-lived API token. (#608)
+* Pin third-party GitHub Actions to commit SHAs. (#604)
 * Update copyright header end years to 2026. The style check now uses a
   pinned end year, so it no longer starts failing when the year rolls
   over; a separate non-blocking check reports out-of-date end years.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,7 @@ Changes
   warnings and errors on ``stderr``. (#613)
 * Messages reporting that a default ``id`` or ``name`` has been used for
   a ``Plugin`` or an ``ActionSet`` are now logged at ``INFO`` level
-  rather than ``WARNING`` level. Defaulting those attributes is normal,
-  supported behaviour, so there's no action for the user to take. (#613)
+  rather than ``WARNING`` level. (#613)
 
 Removals
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,6 @@ Version 8.0.0
 Changes
 -------
 * Envisage no longer adds a ``NullHandler`` to the ``"envisage"`` logger.
-  The ``NullHandler`` prevented log records from reaching
-  ``logging.lastResort``, and so suppressed Envisage's warnings and
-  errors in applications that hadn't configured logging themselves.
   Applications that don't configure logging will now see Envisage's
   warnings and errors on ``stderr``. (#613)
 * Messages reporting that a default ``id`` or ``name`` has been used for

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,9 +41,9 @@ Fixes
 
 Build
 -----
-* Remove all uses of ``pkg_resources`` and drop ``setuptools`` as a
-  runtime dependency. ``setuptools`` is retained as a build dependency.
-  ``importlib.resources`` is used instead. (#600)
+* Remove all uses of ``pkg_resources`` in favour of
+  ``importlib.resources``, and drop ``setuptools`` as a runtime
+  dependency. ``setuptools`` is retained as a build dependency. (#600)
 * Drop the ``importlib-resources`` dependency, which was only needed for
   Python versions earlier than 3.9. (#622)
 * Declare the license with the PEP 639 ``license`` and ``license-files``


### PR DESCRIPTION
A review of the 8.0.0 changelog against `7.0.4..main`. 7.0.4 was tagged
directly on main — `0c02d0b` is both the tag commit and the merge-base — so
that range is exact. It holds 30 non-merge commits: 11 touching the library or
packaging, 19 CI and infrastructure.

## The library side was already complete

All eight substantive changes had entries, and both deprecations 7.0.0 promised
to remove in 8.0 (#540, #544) are removed and listed. No `DeprecationWarning`
remains anywhere in the library, so nothing is left dangling for 9.0.

## References now point at PRs, not issues

The two `Fixes` entries for the `HTTPError` leak cited #615, whose title is
"Clean up test noise from warnings and WARNING-level log messages". The leak was
found *via* that cleanup, but a reader following the reference lands on a
test-hygiene issue rather than a resource-leak fix.

Rather than fix those two in isolation, every reference in the section now
points at the PR that made the change: #574→#613, #616→#622, #548→#599,
#547→#612, #614→#617, and #615→#618/#619/#621 as appropriate. This also supplies
the reference the `pkg_resources` entry was missing — #600, the PR, rather than
#515, the issue.

Two notes:

- The "no longer writes `WARNING`-level log messages" entry cites **both** #618
  and #621. #618 deliberately deferred the four `envisage.ui.tasks.tasks`
  records from the `TasksApplication` tests to a follow-up, so the claim only
  became true once #621 landed.
- Sections for 7.0.4 and earlier are untouched; they already cite PRs.

## CI and build work added

Nineteen PRs had no entry at all, in contrast with 7.0.4, which listed its
action bumps and copyright-header updates under `Build`. Five new entries cover
them, aggregated where the work was one theme:

| Entry | PRs |
| --- | --- |
| Trusted publishing (OIDC) and SHA-pinned actions | #604, #608 |
| Copyright end years, and the year-rollover fix to the style check | #596, #597, #607 |
| GitHub Action bumps | #591, #592, #593, #594, #595, #602, #603, #605, #606, #609, #610 |
| Pre-release Pythons in the CI matrix | #601, #624 |
| `AGENTS.md` | #598, #626 |

Trusted publishing changes how releases are authenticated, so it seemed worth
naming rather than folding into the general CI churn.

## Judgment calls worth a second opinion

**The CI matrix entry names no versions.** It reads "now includes pre-release
Python versions" rather than "3.14, and 3.15 pre-releases". Naming them is more
informative, but in a section whose `Removals` entry deliberately gives no
upper bound on supported Pythons, a `Build` line ending in "3.15" invites
exactly the reading that bound was left out to avoid. Easy to change if you'd
rather have the numbers.

**No upper bound on Python versions.** Considered and rejected: it means churn
on every Python release, and forwards compatibility is the reasonable default
expectation for a package that runs warning-free on the current version.

**Deliberate omissions.** #626's other cleanups — an `IServiceRegistry`
docstring, the legacy examples README, dead Traits<6.0 test code — change
nothing for users. There's no `Documentation` section because the doc edits in
#599 are just the egg-manager material going away with the classes, already
covered by the `Removals` entry. And `CorePlugin` gaining its own `stop()` to
unregister service offers is an implementation move; the #617 entry already
notes that `PluginActivator` no longer calls
`register_services`/`unregister_services`, which is the part a downstream
`Plugin` subclass would notice.

## Left to the release PR

The `Released:` date line, an introductory paragraph, a "Thanks to:" list, and
the `version = '7.0.4'` still in `pyproject.toml`. The date isn't settled yet.

## Verification

`CHANGES.rst` parses under docutils with no warnings at report level 2 or above,
and all lines stay within 79 characters. Changelog only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
