### PR TITLE
Prepare the 8.0.0 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,25 @@
 Version 8.0.0
 =============
 
+Released: 2026-08-06
+
+This is a major release focused on removing long-deprecated functionality.
+The egg-based plugin managers, the ``include`` and ``exclude`` traits of
+``PluginManager``, and support for ``service=True`` trait metadata have all
+been removed, along with the last uses of ``pkg_resources``. Support for
+Python 3.8 and 3.9 has been dropped; Envisage now requires Python 3.10 or
+later.
+
+One behaviour change is worth noting when upgrading: Envisage no longer
+installs a ``NullHandler`` on the ``"envisage"`` logger, so an application
+that doesn't configure logging will now see Envisage's warnings and errors
+on ``stderr``.
+
+Thanks to:
+
+* Mark Dickinson
+* jychuah
+
 Changes
 -------
 * Envisage no longer adds a ``NullHandler`` to the ``"envisage"`` logger.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ on ``stderr``.
 Thanks to:
 
 * Mark Dickinson
-* jychuah
+* Joon-Yee Chuah
 
 Changes
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,12 +7,16 @@ Version 8.0.0
 
 Released: 2026-08-06
 
-This is a major release focused on removing long-deprecated functionality.
-The egg-based plugin managers, the ``include`` and ``exclude`` traits of
-``PluginManager``, and support for ``service=True`` trait metadata have all
-been removed, along with the last uses of ``pkg_resources``. Support for
-Python 3.8 and 3.9 has been dropped; Envisage now requires Python 3.10 or
-later.
+This release restores compatibility with current versions of setuptools.
+Envisage previously relied on ``pkg_resources``, which setuptools no longer
+ships as of version 82; Envisage now uses ``importlib.resources`` instead,
+and no longer depends on ``setuptools`` at run time.
+
+The release also removes long-deprecated functionality: the egg-based
+plugin managers, the ``include`` and ``exclude`` traits of
+``PluginManager``, and support for ``service=True`` trait metadata are all
+gone. Support for Python 3.8 and 3.9 has been dropped, so Envisage now
+requires Python 3.10 or later.
 
 One behaviour change is worth noting when upgrading: Envisage no longer
 installs a ``NullHandler`` on the ``"envisage"`` logger, so an application

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,11 @@ Version 8.0.0
 
 Released: 2026-08-06
 
-This release restores compatibility with current versions of setuptools.
-Envisage previously relied on ``pkg_resources``, which setuptools no longer
-ships as of version 82; Envisage now uses ``importlib.resources`` instead,
-and no longer depends on ``setuptools`` at run time.
+This is a major release aimed at restoring compatibility with current
+versions of setuptools, which no longer ship the ``pkg_resources`` package
+that earlier versions of Envisage depended on. Envisage now uses
+``importlib.resources`` instead, and no longer requires ``setuptools`` at
+run time.
 
 The release also removes long-deprecated functionality: the egg-based
 plugin managers, the ``include`` and ``exclude`` traits of

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,9 +15,9 @@ run time.
 
 The release also removes long-deprecated functionality: the egg-based
 plugin managers, the ``include`` and ``exclude`` traits of
-``PluginManager``, and support for ``service=True`` trait metadata are all
-gone. Support for Python 3.8 and 3.9 has been dropped, so Envisage now
-requires Python 3.10 or later.
+``PluginManager``, and support for ``service=True`` trait metadata.
+Support for Python 3.8 and 3.9 has been dropped, so Envisage now requires
+Python 3.10 or later.
 
 One behaviour change is worth noting when upgrading: Envisage no longer
 installs a ``NullHandler`` on the ``"envisage"`` logger, so an application

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,8 +21,8 @@ on ``stderr``.
 
 Thanks to:
 
-* Mark Dickinson
 * Joon-Yee Chuah
+* Mark Dickinson
 
 Changes
 -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'envisage'
-version = '7.0.4'
+version = '8.0.0'
 description = 'Extensible application framework'
 readme = 'README.rst'
 requires-python = '>= 3.10'


### PR DESCRIPTION
Prepares the 8.0.0 release:

* Add `Released: 2026-08-06` and an overview to the 8.0.0 changelog section,
  following the style used for earlier major releases.
* Credit contributors since 7.0.4 under `Thanks to`.
* Bump the version in `pyproject.toml` from 7.0.4 to 8.0.0.

The changelog already accounts for every PR merged since the 7.0.4 tag, so no
new entries were needed. #628 is deliberately excluded: it is still open, and
we would rather not change the CI machinery immediately before a major
release. Its changelog entries will need re-filing under a later version once
it merges.

*This PR was created with the assistance of an AI coding agent.*