### PR TITLE
Reformat the codebase with ruff format

### DIFF
--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -16,3 +16,4 @@ jobs:
         cache-suffix: style
     - run: |
         uv run --locked --only-group style -m ruff check .
+        uv run --locked --only-group style -m ruff format --check --diff .

--- a/docs/update_gh_pages.py
+++ b/docs/update_gh_pages.py
@@ -78,9 +78,7 @@ def subdir_from_tagname(version: str) -> str:
     """
     subdir = ".".join(version.split(".")[:2])
     if not RELEASE_DOCS_DIR_MATCHER(subdir):
-        raise RuntimeError(
-            f"tagname {version} does not have the expected form"
-        )
+        raise RuntimeError(f"tagname {version} does not have the expected form")
     return subdir
 
 

--- a/examples/legacy/workbench/AcmeLab/acme/acmelab/acmelab.py
+++ b/examples/legacy/workbench/AcmeLab/acme/acmelab/acmelab.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The Acme Lab application. """
-
+"""The Acme Lab application."""
 
 # Standard library imports.
 from logging import DEBUG

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/acme_preferences_page.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/acme_preferences_page.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The preferences for the Acme workbench. """
-
+"""The preferences for the Acme workbench."""
 
 # Enthought library imports.
 from apptools.preferences.ui.api import PreferencesPage

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/acme_workbench_plugin.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/acme_workbench_plugin.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The AcmeLab Workbench plugin. """
-
+"""The AcmeLab Workbench plugin."""
 
 from traits.api import List
 

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/action/new_view_action.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/action/new_view_action.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" An action that dynamically creates and adds a view. """
-
+"""An action that dynamically creates and adds a view."""
 
 # Enthought library imports.
 from pyface.action.api import Action

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/example_action_set.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/example_action_set.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A test action set. """
-
+"""A test action set."""
 
 # Enthought library imports.
 from envisage.ui.action.api import Action, Group, Menu, ToolBar

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/bar_perspective.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/bar_perspective.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" An example perspective. """
-
+"""An example perspective."""
 
 # Enthought library imports.
 from pyface.workbench.api import Perspective, PerspectiveItem

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/foo_perspective.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/perspective/foo_perspective.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" An example perspective. """
-
+"""An example perspective."""
 
 # Enthought library imports.
 from pyface.workbench.api import Perspective, PerspectiveItem

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/black_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/black_view.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A view containing a black panel! """
-
+"""A view containing a black panel!"""
 
 # Local imports.
 from .color_view import ColorView

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/blue_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/blue_view.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A view containing a blue panel! """
-
+"""A view containing a blue panel!"""
 
 # Local imports.
 from .color_view import ColorView

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/color_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/color_view.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A view containing a colored panel! """
-
+"""A view containing a colored panel!"""
 
 from pyface.workbench.api import View
 

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/green_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/green_view.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A view containing a green panel! """
-
+"""A view containing a green panel!"""
 
 # Local imports.
 from .color_view import ColorView

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/red_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/red_view.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A view containing a red panel! """
-
+"""A view containing a red panel!"""
 
 # Local imports.
 from .color_view import ColorView

--- a/examples/legacy/workbench/AcmeLab/acme/workbench/view/yellow_view.py
+++ b/examples/legacy/workbench/AcmeLab/acme/workbench/view/yellow_view.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A view containing a yellow panel! """
-
+"""A view containing a yellow panel!"""
 
 # Local imports.
 from .color_view import ColorView

--- a/examples/legacy/workbench/AcmeLab/run.py
+++ b/examples/legacy/workbench/AcmeLab/run.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Run the AcmeLab example application. """
-
+"""Run the AcmeLab example application."""
 
 # Standard library imports.
 import logging
@@ -35,9 +34,7 @@ def main():
     """Run the application."""
 
     # Create an application with the specified plugins.
-    acmelab = Acmelab(
-        plugins=[CorePlugin(), WorkbenchPlugin(), AcmeWorkbenchPlugin()]
-    )
+    acmelab = Acmelab(plugins=[CorePlugin(), WorkbenchPlugin(), AcmeWorkbenchPlugin()])
 
     # Run it! This starts the application, starts the GUI event loop, and when
     # that terminates, stops the application.

--- a/src/envisage/application.py
+++ b/src/envisage/application.py
@@ -175,9 +175,7 @@ class Application(HasTraits):
         """Trait initializer."""
 
         return ScopedPreferences(
-            application_preferences_filename=os.path.join(
-                self.home, "preferences.ini"
-            )
+            application_preferences_filename=os.path.join(self.home, "preferences.ini")
         )
 
     #### Methods ##############################################################
@@ -219,9 +217,7 @@ class Application(HasTraits):
 
         return self.extension_registry.get_extension_points()
 
-    def remove_extension_point_listener(
-        self, listener, extension_point_id=None
-    ):
+    def remove_extension_point_listener(self, listener, extension_point_id=None):
         """Remove a listener for extensions being added/removed."""
 
         self.extension_registry.remove_extension_point_listener(
@@ -346,9 +342,7 @@ class Application(HasTraits):
     # 'IServiceRegistry' interface.
     ###########################################################################
 
-    def get_required_service(
-        self, protocol, query="", minimize="", maximize=""
-    ):
+    def get_required_service(self, protocol, query="", minimize="", maximize=""):
         """Return the service that matches the specified query.
 
         Raise a 'NoSuchServiceError' exception if no such service exists.
@@ -364,9 +358,7 @@ class Application(HasTraits):
     def get_service(self, protocol, query="", minimize="", maximize=""):
         """Return at most one service that matches the specified query."""
 
-        service = self.service_registry.get_service(
-            protocol, query, minimize, maximize
-        )
+        service = self.service_registry.get_service(protocol, query, minimize, maximize)
 
         return service
 
@@ -392,9 +384,7 @@ class Application(HasTraits):
     def register_service(self, protocol, obj, properties=None):
         """Register a service."""
 
-        service_id = self.service_registry.register_service(
-            protocol, obj, properties
-        )
+        service_id = self.service_registry.register_service(protocol, obj, properties)
 
         return service_id
 

--- a/src/envisage/application_event.py
+++ b/src/envisage/application_event.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An application event. """
-
+"""An application event."""
 
 # Enthought library imports.
 from traits.api import Instance, Vetoable

--- a/src/envisage/core_plugin.py
+++ b/src/envisage/core_plugin.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The Envisage core plugin. """
+"""The Envisage core plugin."""
 
 from contextlib import closing
 

--- a/src/envisage/examples/_demo.py
+++ b/src/envisage/examples/_demo.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Utilities for supporting Envisage's demo examples.
-"""
+"""Utilities for supporting Envisage's demo examples."""
 
 import contextlib
 import os

--- a/src/envisage/examples/demo/GUI_Application/traitsui_gui_app.py
+++ b/src/envisage/examples/demo/GUI_Application/traitsui_gui_app.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" A simple example of a GUIApplication which wraps a TraitsUI """
+"""A simple example of a GUIApplication which wraps a TraitsUI"""
 
 from traits.api import Enum, HasTraits, Instance, Int, on_trait_change, Str
 from traitsui.api import Item, OKCancelButtons, View
@@ -57,9 +57,7 @@ class PersonViewPlugin(Plugin):
 # Application entry point.
 if __name__ == "__main__":
     # Create the application.
-    application = GUIApplication(
-        id="person_view", plugins=[PersonViewPlugin()]
-    )
+    application = GUIApplication(id="person_view", plugins=[PersonViewPlugin()])
 
     # Run it!
     application.run()

--- a/src/envisage/examples/demo/Hello_World/hello_world.py
+++ b/src/envisage/examples/demo/Hello_World/hello_world.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The Envisage version of the old chestnut. """
+"""The Envisage version of the old chestnut."""
 
 from traits.api import List, Str
 

--- a/src/envisage/examples/demo/MOTD/acme/motd/i_message.py
+++ b/src/envisage/examples/demo/MOTD/acme/motd/i_message.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The interface for 'Message of the Day' messages. """
-
+"""The interface for 'Message of the Day' messages."""
 
 # Enthought library imports.
 from traits.api import Interface, Str

--- a/src/envisage/examples/demo/MOTD/acme/motd/i_motd.py
+++ b/src/envisage/examples/demo/MOTD/acme/motd/i_motd.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The 'Message of the Day' interface. """
-
+"""The 'Message of the Day' interface."""
 
 # Enthought library imports.
 from traits.api import Interface

--- a/src/envisage/examples/demo/MOTD/acme/motd/message.py
+++ b/src/envisage/examples/demo/MOTD/acme/motd/message.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The default implementation of the 'IMessage' interface. """
-
+"""The default implementation of the 'IMessage' interface."""
 
 # Local imports.
 from acme.motd.i_message import IMessage

--- a/src/envisage/examples/demo/MOTD/acme/motd/motd.py
+++ b/src/envisage/examples/demo/MOTD/acme/motd/motd.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The 'Message of the Day' implementation! """
-
+"""The 'Message of the Day' implementation!"""
 
 # Standard library imports.
 from random import choice

--- a/src/envisage/examples/demo/MOTD/acme/motd/motd_plugin.py
+++ b/src/envisage/examples/demo/MOTD/acme/motd/motd_plugin.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The 'Message of the Day' plugin """
+"""The 'Message of the Day' plugin"""
 
 
 # In the interest of lazy loading you should only import from the following
@@ -18,7 +18,6 @@
 # - traits
 #
 # Eveything else should be imported when it is actually required.
-
 
 from traits.api import Instance, List, on_trait_change
 

--- a/src/envisage/examples/demo/MOTD/acme/motd/software_quotes/messages.py
+++ b/src/envisage/examples/demo/MOTD/acme/motd/software_quotes/messages.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Some messages! """
+"""Some messages!"""
 
 from acme.motd.api import Message
 
@@ -31,8 +31,7 @@ messages = [
     ),
     Message(
         author="Tom Gilb",
-        text="If you don't know what you're doing, don't do it on a large"
-        " scale.",
+        text="If you don't know what you're doing, don't do it on a large scale.",
     ),
     Message(
         author="Arthur Norman",

--- a/src/envisage/examples/demo/MOTD/acme/motd/software_quotes/software_quotes_plugin.py
+++ b/src/envisage/examples/demo/MOTD/acme/motd/software_quotes/software_quotes_plugin.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" The 'Software Quotes' plugin """
-
+"""The 'Software Quotes' plugin"""
 
 from traits.api import List
 

--- a/src/envisage/examples/demo/MOTD/run.py
+++ b/src/envisage/examples/demo/MOTD/run.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Run the MOTD example application. """
+"""Run the MOTD example application."""
 
 # Enthought library imports.
 from envisage.api import Application, CorePlugin

--- a/src/envisage/examples/demo/plugins/tasks/attractors/attractors_application.py
+++ b/src/envisage/examples/demo/plugins/tasks/attractors/attractors_application.py
@@ -51,9 +51,7 @@ class AttractorsApplication(TasksApplication):
     def _default_layout_default(self):
         active_task = self.preferences_helper.default_task
         tasks = [factory.id for factory in self.task_factories]
-        return [
-            TaskWindowLayout(*tasks, active_task=active_task, size=(800, 600))
-        ]
+        return [TaskWindowLayout(*tasks, active_task=active_task, size=(800, 600))]
 
     def _preferences_helper_default(self):
         return AttractorsPreferences(preferences=self.preferences)

--- a/src/envisage/examples/demo/plugins/tasks/attractors/attractors_preferences.py
+++ b/src/envisage/examples/demo/plugins/tasks/attractors/attractors_preferences.py
@@ -55,9 +55,7 @@ class AttractorsPreferencesPane(PreferencesPane):
             ),
             HGroup(
                 Label("Default active task:"),
-                Item(
-                    "default_task", editor=EnumEditor(name="handler.task_map")
-                ),
+                Item("default_task", editor=EnumEditor(name="handler.task_map")),
                 enabled_when="always_use_default_layout",
                 show_labels=False,
             ),

--- a/src/envisage/examples/demo/plugins/tasks/attractors/model/lorenz.py
+++ b/src/envisage/examples/demo/plugins/tasks/attractors/model/lorenz.py
@@ -40,9 +40,7 @@ class Lorenz(HasTraits):
     #### 'IModel3d' interface #################################################
 
     name = Str("Lorenz Attractor")
-    points = Property(
-        Array, observe="prandtl, rayleigh, beta, initial_point, times"
-    )
+    points = Property(Array, observe="prandtl, rayleigh, beta, initial_point, times")
 
     #### 'Lorenz' interface ###################################################
 

--- a/src/envisage/examples/demo/plugins/tasks/attractors/model_config_pane.py
+++ b/src/envisage/examples/demo/plugins/tasks/attractors/model_config_pane.py
@@ -28,6 +28,4 @@ class ModelConfigPane(TraitsDockPane):
 
     model = Instance(HasTraits)
 
-    view = View(
-        Item("pane.model", style="custom", show_label=False), resizable=True
-    )
+    view = View(Item("pane.model", style="custom", show_label=False), resizable=True)

--- a/src/envisage/extension_point.py
+++ b/src/envisage/extension_point.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A trait type used to declare and access extension points. """
-
+"""A trait type used to declare and access extension points."""
 
 # Standard library imports.
 import inspect
@@ -176,9 +175,7 @@ class ExtensionPoint(TraitType):
         listener = self._obj_to_listeners_map[obj].get(trait_name)
         if listener is not None:
             # Remove the listener from the extension registry.
-            extension_registry.remove_extension_point_listener(
-                listener, self.id
-            )
+            extension_registry.remove_extension_point_listener(listener, self.id)
 
             # Clean up.
             del self._obj_to_listeners_map[obj][trait_name]

--- a/src/envisage/extension_point_binding.py
+++ b/src/envisage/extension_point_binding.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A binding between a trait on an object and an extension point. """
-
+"""A binding between a trait on an object and an extension point."""
 
 # Enthought library imports.
 from traits.api import Any, HasTraits, Instance, Str, Undefined
@@ -122,9 +121,7 @@ class ExtensionPointBinding(HasTraits):
             remove=True,
         )
 
-        self.obj.on_trait_change(
-            self._on_trait_changed, self.trait_name, remove=True
-        )
+        self.obj.on_trait_change(self._on_trait_changed, self.trait_name, remove=True)
 
     def _set_trait(self, notify):
         """Set the object's trait to the value of the extension point."""
@@ -139,22 +136,16 @@ class ExtensionPointBinding(HasTraits):
 
         self._set_trait(notify=False)
 
-        self.obj.trait_property_changed(
-            self.trait_name + "_items", Undefined, event
-        )
+        self.obj.trait_property_changed(self.trait_name + "_items", Undefined, event)
 
     def _set_extensions(self, extensions):
         """Set the extensions to an extension point."""
 
-        self.extension_registry.set_extensions(
-            self.extension_point_id, extensions
-        )
+        self.extension_registry.set_extensions(self.extension_point_id, extensions)
 
 
 # Factory function for creating bindings.
-def bind_extension_point(
-    obj, trait_name, extension_point_id, extension_registry
-):
+def bind_extension_point(obj, trait_name, extension_point_id, extension_registry):
     """Create a binding to an extension point.
 
     The returned ExtensionPointBinding object is also stored in a (private)
@@ -194,9 +185,7 @@ def bind_extension_point(
     return binding
 
 
-def unbind_extension_point(
-    obj, trait_name, extension_point_id, extension_registry
-):
+def unbind_extension_point(obj, trait_name, extension_point_id, extension_registry):
     """
     Remove an extension point binding.
 

--- a/src/envisage/extension_point_changed_event.py
+++ b/src/envisage/extension_point_changed_event.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An event fired when an extension point's extensions have changed. """
-
+"""An event fired when an extension point's extensions have changed."""
 
 # Enthought library imports.
 from traits.api import TraitListEvent

--- a/src/envisage/extension_provider.py
+++ b/src/envisage/extension_provider.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The default base class for extension providers. """
-
+"""The default base class for extension providers."""
 
 # Enthought library imports.
 from traits.api import Event, HasTraits, provides
@@ -41,9 +40,7 @@ class ExtensionProvider(HasTraits):
 
     ##### Protected 'ExtensionProvider' interface #############################
 
-    def _fire_extension_point_changed(
-        self, extension_point_id, added, removed, index
-    ):
+    def _fire_extension_point_changed(self, extension_point_id, added, removed, index):
         """Fire an extension point changed event."""
 
         self.extension_point_changed = ExtensionPointChangedEvent(

--- a/src/envisage/extension_registry.py
+++ b/src/envisage/extension_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A base class for extension registry implementation. """
-
+"""A base class for extension registry implementation."""
 
 # Standard library imports.
 import logging
@@ -118,9 +117,7 @@ class ExtensionRegistry(HasTraits):
 
         return list(self._extension_points.values())
 
-    def remove_extension_point_listener(
-        self, listener, extension_point_id=None
-    ):
+    def remove_extension_point_listener(self, listener, extension_point_id=None):
         """Remove a listener for extensions being added or removed."""
 
         listeners = self._listeners.setdefault(extension_point_id, [])

--- a/src/envisage/i_application.py
+++ b/src/envisage/i_application.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The application interface. """
-
+"""The application interface."""
 
 # Enthought library imports.
 from apptools.preferences.api import IPreferences

--- a/src/envisage/i_extension_point.py
+++ b/src/envisage/i_extension_point.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for extension points. """
-
+"""The interface for extension points."""
 
 # Enthought library imports.
 from traits.api import Instance, Interface, Str, TraitType

--- a/src/envisage/i_extension_point_user.py
+++ b/src/envisage/i_extension_point_user.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for objects using the 'ExtensionPoint' trait type. """
-
+"""The interface for objects using the 'ExtensionPoint' trait type."""
 
 # Enthought library imports.
 from traits.api import Instance, Interface

--- a/src/envisage/i_extension_provider.py
+++ b/src/envisage/i_extension_provider.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for extension providers. """
-
+"""The interface for extension providers."""
 
 # Enthought library imports.
 from traits.api import Event, Interface

--- a/src/envisage/i_extension_registry.py
+++ b/src/envisage/i_extension_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for extension registries. """
-
+"""The interface for extension registries."""
 
 # Enthought library imports.
 from traits.api import Interface
@@ -65,9 +64,7 @@ class IExtensionRegistry(Interface):
     def get_extension_points(self):
         """Return all extension points that have been added to the registry."""
 
-    def remove_extension_point_listener(
-        self, listener, extension_point_id=None
-    ):
+    def remove_extension_point_listener(self, listener, extension_point_id=None):
         """Remove a listener for extensions being added or removed.
 
         Raise a 'ValueError' if the listener does not exist.

--- a/src/envisage/i_import_manager.py
+++ b/src/envisage/i_import_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for import managers. """
-
+"""The interface for import managers."""
 
 # Enthought library imports.
 from traits.api import Interface

--- a/src/envisage/i_plugin.py
+++ b/src/envisage/i_plugin.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The plugin interface. """
-
+"""The plugin interface."""
 
 # Enthought library imports.
 from traits.api import Instance, Interface, Str

--- a/src/envisage/i_plugin_activator.py
+++ b/src/envisage/i_plugin_activator.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The plugin activator interface. """
-
+"""The plugin activator interface."""
 
 # Enthought library imports.
 from traits.api import Interface

--- a/src/envisage/i_plugin_manager.py
+++ b/src/envisage/i_plugin_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The plugin manager interface. """
-
+"""The plugin manager interface."""
 
 # Enthought library imports.
 from traits.api import Event, Interface

--- a/src/envisage/i_provider_extension_registry.py
+++ b/src/envisage/i_provider_extension_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The provider extension registry interface. """
-
+"""The provider extension registry interface."""
 
 # Local imports.
 from .i_extension_registry import IExtensionRegistry

--- a/src/envisage/i_service_registry.py
+++ b/src/envisage/i_service_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The service registry interface. """
-
+"""The service registry interface."""
 
 # Enthought library imports.
 from traits.api import Event, Interface

--- a/src/envisage/i_service_user.py
+++ b/src/envisage/i_service_user.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for objects using the 'Service' trait type. """
-
+"""The interface for objects using the 'Service' trait type."""
 
 # Enthought library imports.
 from traits.api import Instance, Interface

--- a/src/envisage/ids.py
+++ b/src/envisage/ids.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" This module redefines the Extension Point IDs and Service IDs defined on
+"""This module redefines the Extension Point IDs and Service IDs defined on
 Plugins provided by Envisage. Note that this module does not contain IDs
 defined by all of the Plugins available in Envisage.
 

--- a/src/envisage/import_manager.py
+++ b/src/envisage/import_manager.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The default import manager implementation. """
+"""The default import manager implementation."""
 
 import importlib
 
@@ -47,9 +47,7 @@ class ImportManager(HasTraits):
             module_name = ".".join(components[:-1])
             symbol_name = components[-1]
 
-            module = __import__(
-                module_name, globals(), locals(), [symbol_name]
-            )
+            module = __import__(module_name, globals(), locals(), [symbol_name])
 
             symbol = getattr(module, symbol_name)
 

--- a/src/envisage/plugin.py
+++ b/src/envisage/plugin.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The default implementation of the 'IPlugin' interface. """
+"""The default implementation of the 'IPlugin' interface."""
 
 # Standard library imports.
 import logging
@@ -108,8 +108,7 @@ class Plugin(ExtensionProvider):
         """Return the extension points offered by the provider."""
 
         extension_points = [
-            trait.trait_type
-            for trait in self.traits(__extension_point__=True).values()
+            trait.trait_type for trait in self.traits(__extension_point__=True).values()
         ]
 
         return extension_points
@@ -165,9 +164,7 @@ class Plugin(ExtensionProvider):
 
         id = "%s.%s" % (type(self).__module__, type(self).__name__)
         logger.info(
-            "plugin {} has no Id - using <{}>".format(
-                object.__repr__(self), id
-            )
+            "plugin {} has no Id - using <{}>".format(object.__repr__(self), id)
         )
 
         return id
@@ -177,9 +174,7 @@ class Plugin(ExtensionProvider):
 
         name = camel_case_to_words(type(self).__name__)
         logger.info(
-            "plugin {} has no name - using <{}>".format(
-                object.__repr__(self), name
-            )
+            "plugin {} has no name - using <{}>".format(object.__repr__(self), name)
         )
 
         return name

--- a/src/envisage/plugin_activator.py
+++ b/src/envisage/plugin_activator.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The default plugin activator. """
-
+"""The default plugin activator."""
 
 # Enthought library imports.
 from traits.api import HasTraits, provides

--- a/src/envisage/plugin_event.py
+++ b/src/envisage/plugin_event.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A plugin event. """
-
+"""A plugin event."""
 
 # Enthought library imports.
 from traits.api import Instance, Vetoable

--- a/src/envisage/plugin_extension_registry.py
+++ b/src/envisage/plugin_extension_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An extension registry that uses plugins as extension providers. """
-
+"""An extension registry that uses plugins as extension providers."""
 
 # Enthought library imports.
 from traits.api import Instance, observe, on_trait_change

--- a/src/envisage/plugin_manager.py
+++ b/src/envisage/plugin_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A simple plugin manager implementation. """
-
+"""A simple plugin manager implementation."""
 
 import logging
 

--- a/src/envisage/plugins/event_manager/api.py
+++ b/src/envisage/plugins/event_manager/api.py
@@ -10,4 +10,5 @@
 """
 - :class:`~.EventManagerPlugin`
 """
+
 from envisage.plugins.event_manager.plugin import EventManagerPlugin

--- a/src/envisage/plugins/event_manager/plugin.py
+++ b/src/envisage/plugins/event_manager/plugin.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" This module provides a plugin which adds an EventManager to application.
+"""This module provides a plugin which adds an EventManager to application.
 
 If the application does not already have an evt_mgr attribute which is an
 instance of EventManager, the plugin creates a new EventManager instance,

--- a/src/envisage/plugins/python_shell/i_python_shell.py
+++ b/src/envisage/plugins/python_shell/i_python_shell.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A simple interface for the Python shell. """
-
+"""A simple interface for the Python shell."""
 
 # Enthought library imports.
 from traits.api import Interface

--- a/src/envisage/plugins/python_shell/python_shell_plugin.py
+++ b/src/envisage/plugins/python_shell/python_shell_plugin.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interactive Python shell plugin. """
-
+"""The interactive Python shell plugin."""
 
 from traits.api import Dict, List, Str
 

--- a/src/envisage/plugins/python_shell/view/namespace_view.py
+++ b/src/envisage/plugins/python_shell/view/namespace_view.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A view containing the contents of a Python shell namespace. """
+"""A view containing the contents of a Python shell namespace."""
 
 # Enthought library imports.
 
@@ -159,9 +159,7 @@ class NamespaceView(View):
             module = Str
 
         data = [
-            item(
-                name=name, type=type_to_str(value), module=module_to_str(value)
-            )
+            item(name=name, type=type_to_str(value), module=module_to_str(value))
             for name, value in self.shell_view.namespace.items()
         ]
 

--- a/src/envisage/plugins/python_shell/view/python_shell_view.py
+++ b/src/envisage/plugins/python_shell/view/python_shell_view.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A view containing an interactive Python shell. """
-
+"""A view containing an interactive Python shell."""
 
 # Standard library imports.
 import logging
@@ -110,9 +109,7 @@ class PythonShellView(View):
         shell.on_trait_change(self._on_command_executed, "command_executed")
 
         # Write application standard out to this shell instead of to DOS window
-        self.on_trait_change(
-            self._on_write_stdout, "stdout_text", dispatch="ui"
-        )
+        self.on_trait_change(self._on_write_stdout, "stdout_text", dispatch="ui")
         self.original_stdout = sys.stdout
         sys.stdout = PseudoFile(self._write_stdout)
 

--- a/src/envisage/plugins/text_editor/actions.py
+++ b/src/envisage/plugins/text_editor/actions.py
@@ -30,9 +30,7 @@ class NewFileAction(Action):
 
     def perform(self, event=None):
         logger.info("NewFileAction.perform()")
-        self.window.workbench.edit(
-            File(""), kind=TextEditor, use_existing=False
-        )
+        self.window.workbench.edit(File(""), kind=TextEditor, use_existing=False)
 
 
 class OpenFileAction(Action):

--- a/src/envisage/plugins/text_editor/editor/text_editor.py
+++ b/src/envisage/plugins/text_editor/editor/text_editor.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A text editor. """
-
+"""A text editor."""
 
 # Standard library imports.
 from os.path import basename
@@ -112,9 +111,7 @@ class TextEditor(TraitsUIEditor):
 
         # Execute the code.
         if len(self.obj.path) > 0:
-            view = self.window.get_view_by_id(
-                "envisage.plugins.python_shell_view"
-            )
+            view = self.window.get_view_by_id("envisage.plugins.python_shell_view")
 
             if view is not None:
                 view.execute_command(
@@ -200,9 +197,7 @@ class TextEditor(TraitsUIEditor):
 
         view = View(
             Group(
-                Item(
-                    "text", editor=CodeEditor(key_bindings=self.key_bindings)
-                ),
+                Item("text", editor=CodeEditor(key_bindings=self.key_bindings)),
                 show_labels=False,
             ),
             id="envisage.editor.text_editor",

--- a/src/envisage/plugins/text_editor/editor/text_editor_handler.py
+++ b/src/envisage/plugins/text_editor/editor/text_editor_handler.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The traits UI handler for the text editor. """
-
+"""The traits UI handler for the text editor."""
 
 # Enthought library imports.
 from traitsui.api import Handler

--- a/src/envisage/plugins/text_editor/text_editor_action_set.py
+++ b/src/envisage/plugins/text_editor/text_editor_action_set.py
@@ -14,9 +14,7 @@ from envisage.ui.action.api import Action, ActionSet, Group
 class TextEditorActionSet(ActionSet):
     """The default action set for the Text Editor plugin."""
 
-    groups = [
-        Group(id="TextFileGroup", path="MenuBar/File", before="ExitGroup")
-    ]
+    groups = [Group(id="TextFileGroup", path="MenuBar/File", before="ExitGroup")]
 
     actions = [
         Action(

--- a/src/envisage/plugins/text_editor/text_editor_plugin.py
+++ b/src/envisage/plugins/text_editor/text_editor_plugin.py
@@ -7,9 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Text Editor plugin for the Workbench UI.
-"""
-
+"""Text Editor plugin for the Workbench UI."""
 
 # Enthought library imports.
 from traits.api import List

--- a/src/envisage/provider_extension_registry.py
+++ b/src/envisage/provider_extension_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An extension registry implementation with multiple providers. """
-
+"""An extension registry implementation with multiple providers."""
 
 # Standard library imports.
 import logging
@@ -285,9 +284,7 @@ class ProviderExtensionRegistry(ExtensionRegistry):
         """Translate an event index by the given offset."""
 
         if isinstance(index, slice):
-            index = slice(
-                index.start + offset, index.stop + offset, index.step
-            )
+            index = slice(index.start + offset, index.stop + offset, index.step)
 
         else:
             index = index + offset

--- a/src/envisage/resource/file_resource_protocol.py
+++ b/src/envisage/resource/file_resource_protocol.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A resource protocol for a local file system. """
-
+"""A resource protocol for a local file system."""
 
 # Standard library imports.
 import errno

--- a/src/envisage/resource/http_resource_protocol.py
+++ b/src/envisage/resource/http_resource_protocol.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A resource protocol for HTTP documents. """
+"""A resource protocol for HTTP documents."""
 
 # Enthought library imports.
 from traits.api import HasTraits, provides

--- a/src/envisage/resource/i_resource_manager.py
+++ b/src/envisage/resource/i_resource_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The resource manager interface. """
-
+"""The resource manager interface."""
 
 # Enthought library imports.
 from traits.api import Instance, Interface

--- a/src/envisage/resource/i_resource_protocol.py
+++ b/src/envisage/resource/i_resource_protocol.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for protocols that handle resource URLs. """
-
+"""The interface for protocols that handle resource URLs."""
 
 # Enthought library imports.
 from traits.api import Interface

--- a/src/envisage/resource/no_such_resource_error.py
+++ b/src/envisage/resource/no_such_resource_error.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The exception raised when trying to open a non-existent resource. """
+"""The exception raised when trying to open a non-existent resource."""
 
 
 class NoSuchResourceError(Exception):

--- a/src/envisage/resource/package_resource_protocol.py
+++ b/src/envisage/resource/package_resource_protocol.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A resource protocol for package resources. """
-
+"""A resource protocol for package resources."""
 
 # Standard library imports.
 from importlib.resources import files

--- a/src/envisage/resource/resource_manager.py
+++ b/src/envisage/resource/resource_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The default resource manager. """
-
+"""The default resource manager."""
 
 # Enthought library imports.
 from traits.api import Dict, HasTraits, provides, Str

--- a/src/envisage/resource/tests/test_resource_manager.py
+++ b/src/envisage/resource/tests/test_resource_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the resource manager. """
-
+"""Tests for the resource manager."""
 
 # Standard library imports.
 import unittest

--- a/src/envisage/service.py
+++ b/src/envisage/service.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A trait type used to access services. """
-
+"""A trait type used to access services."""
 
 # Standard library imports.
 import logging
@@ -32,9 +31,7 @@ class Service(TraitType):
     # 'object' interface.
     ###########################################################################
 
-    def __init__(
-        self, protocol=None, query="", minimize="", maximize="", **metadata
-    ):
+    def __init__(self, protocol=None, query="", minimize="", maximize="", **metadata):
         """Constructor."""
 
         super().__init__(**metadata)

--- a/src/envisage/service_offer.py
+++ b/src/envisage/service_offer.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An offer to provide a service. """
-
+"""An offer to provide a service."""
 
 # Enthought library imports.
 from traits.api import Callable, Dict, HasTraits, Str, Type, Union

--- a/src/envisage/service_registry.py
+++ b/src/envisage/service_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The service registry. """
-
+"""The service registry."""
 
 # Standard library imports.
 import logging
@@ -65,9 +64,7 @@ class ServiceRegistry(HasTraits):
     # 'IServiceRegistry' interface.
     ###########################################################################
 
-    def get_required_service(
-        self, protocol, query="", minimize="", maximize=""
-    ):
+    def get_required_service(self, protocol, query="", minimize="", maximize=""):
         """Return the service that matches the specified query.
 
         Raise a 'NoSuchServiceError' exception if no such service exists.

--- a/src/envisage/tests/ets_config_patcher.py
+++ b/src/envisage/tests/ets_config_patcher.py
@@ -33,14 +33,10 @@ class ETSConfigPatcher(object):
         tmpdir = self.tmpdir = tempfile.mkdtemp()
 
         self.old_application_data = self.etsconfig._application_data
-        self.etsconfig._application_data = os.path.join(
-            tmpdir, "application_data"
-        )
+        self.etsconfig._application_data = os.path.join(tmpdir, "application_data")
 
         self.old_application_home = self.etsconfig._application_home
-        self.etsconfig._application_home = os.path.join(
-            tmpdir, "application_home"
-        )
+        self.etsconfig._application_home = os.path.join(tmpdir, "application_home")
 
         self.old_user_data = self.etsconfig._user_data
         self.etsconfig._user_data = os.path.join(tmpdir, "user_home")

--- a/src/envisage/tests/event_tracker.py
+++ b/src/envisage/tests/event_tracker.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Used to track events in tests. """
-
+"""Used to track events in tests."""
 
 # Enthought library imports.
 from traits.api import HasTraits, List, Str, Tuple

--- a/src/envisage/tests/foo.py
+++ b/src/envisage/tests/foo.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A test class used in the service registry tests! """
-
+"""A test class used in the service registry tests!"""
 
 # Enthought library imports.
 from traits.api import HasTraits, provides

--- a/src/envisage/tests/i_foo.py
+++ b/src/envisage/tests/i_foo.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A test class used to test adapters. """
-
+"""A test class used to test adapters."""
 
 # Enthought library imports.
 from traits.api import Interface

--- a/src/envisage/tests/mutable_extension_registry.py
+++ b/src/envisage/tests/mutable_extension_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A mutable, manually populated extension registry used for testing. """
-
+"""A mutable, manually populated extension registry used for testing."""
 
 # Enthought library imports.
 from envisage.api import ExtensionRegistry, UnknownExtension

--- a/src/envisage/tests/test_api.py
+++ b/src/envisage/tests/test_api.py
@@ -21,9 +21,7 @@ class TestApi(unittest.TestCase):
         self.assertEqual(api.BINDINGS, ids.BINDINGS)
         self.assertEqual(api.COMMANDS, ids.COMMANDS)
         self.assertEqual(api.PREFERENCES, ids.PREFERENCES)
-        self.assertEqual(
-            api.PREFERENCES_CATEGORIES, ids.PREFERENCES_CATEGORIES
-        )
+        self.assertEqual(api.PREFERENCES_CATEGORIES, ids.PREFERENCES_CATEGORIES)
         self.assertEqual(api.PREFERENCES_PANES, ids.PREFERENCES_PANES)
         self.assertEqual(api.SERVICE_OFFERS, ids.SERVICE_OFFERS)
         self.assertEqual(api.TASKS, ids.TASKS)

--- a/src/envisage/tests/test_application.py
+++ b/src/envisage/tests/test_application.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for applications and plugins. """
-
+"""Tests for applications and plugins."""
 
 # Standard library imports.
 import os
@@ -464,9 +463,7 @@ class ApplicationTestCase(unittest.TestCase):
         c = PluginC()
 
         # Start off with just two of the plugins.
-        application = SimpleApplication(
-            plugin_manager=PluginManager(plugins=[a, b, c])
-        )
+        application = SimpleApplication(plugin_manager=PluginManager(plugins=[a, b, c]))
         application.start()
 
         # Make sure we can get the plugins.

--- a/src/envisage/tests/test_composite_plugin_manager.py
+++ b/src/envisage/tests/test_composite_plugin_manager.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the composite plugin manager. """
+"""Tests for the composite plugin manager."""
 
 import unittest
 
@@ -123,9 +123,7 @@ class CompositePluginManagerTestCase(unittest.TestCase):
         a = PluginManager()
         b = PluginManager()
 
-        composite_plugin_manager = CompositePluginManager(
-            plugin_managers=[a, b]
-        )
+        composite_plugin_manager = CompositePluginManager(plugin_managers=[a, b])
         composite_plugin_manager._plugins
 
         def added(obj, trait_name, old, new):

--- a/src/envisage/tests/test_core_plugin.py
+++ b/src/envisage/tests/test_core_plugin.py
@@ -41,9 +41,7 @@ class CorePluginTestCase(unittest.TestCase):
                 """Trait initializer."""
 
                 service_offers = [
-                    ServiceOffer(
-                        protocol=IMyService, factory=self._my_service_factory
-                    )
+                    ServiceOffer(protocol=IMyService, factory=self._my_service_factory)
                 ]
 
                 return service_offers
@@ -83,9 +81,7 @@ class CorePluginTestCase(unittest.TestCase):
                 """Trait initializer."""
 
                 service_offers = [
-                    ServiceOffer(
-                        protocol=IMyService, factory=self._my_service_factory
-                    )
+                    ServiceOffer(protocol=IMyService, factory=self._my_service_factory)
                 ]
 
                 return service_offers
@@ -143,9 +139,7 @@ class CorePluginTestCase(unittest.TestCase):
             application.run()
 
             # Make sure we can get one of the preferences.
-            self.assertEqual(
-                "42", application.preferences.get("enthought.test.x")
-            )
+            self.assertEqual("42", application.preferences.get("enthought.test.x"))
 
     def test_dynamically_added_preferences(self):
         """dynamically added preferences"""
@@ -172,9 +166,7 @@ class CorePluginTestCase(unittest.TestCase):
             application.add_plugin(a)
 
             # Make sure we can get one of the preferences.
-            self.assertEqual(
-                "42", application.preferences.get("enthought.test.x")
-            )
+            self.assertEqual("42", application.preferences.get("enthought.test.x"))
 
     # regression test for enthought/envisage#251
     def test_unregister_service_offer(self):

--- a/src/envisage/tests/test_extension_point.py
+++ b/src/envisage/tests/test_extension_point.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for extension points. """
+"""Tests for extension points."""
 
 # Standard library imports.
 import unittest

--- a/src/envisage/tests/test_extension_point_binding.py
+++ b/src/envisage/tests/test_extension_point_binding.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for extension point bindings. """
+"""Tests for extension point bindings."""
 
 # Standard library imports.
 import unittest
@@ -203,9 +203,7 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
 
         # Add 2 extension points.
         registry.add_extension_point(self._create_extension_point("my.ep"))
-        registry.add_extension_point(
-            self._create_extension_point("another.ep")
-        )
+        registry.add_extension_point(self._create_extension_point("another.ep"))
 
         # Declare a class that consumes both of the extension points.
         class Foo(HasTraits):
@@ -256,18 +254,14 @@ class ExtensionPointBindingTestCase(unittest.TestCase):
         extension_point = self._create_extension_point("my.ep")
         self.extension_registry.add_extension_point(extension_point)
         target = BindingTarget()
-        bind_extension_point(
-            target, "target", "my.ep", self.extension_registry
-        )
+        bind_extension_point(target, "target", "my.ep", self.extension_registry)
 
         # Use a weakref finalizer to keep track of whether 'target' still
         # has references keeping it alive.
         target_monitor = weakref.finalize(target, lambda: None)
 
         # When we unbind and delete the target object
-        unbind_extension_point(
-            target, "target", "my.ep", self.extension_registry
-        )
+        unbind_extension_point(target, "target", "my.ep", self.extension_registry)
         del target
 
         # Then 'target' should no longer be alive.

--- a/src/envisage/tests/test_extension_point_changed.py
+++ b/src/envisage/tests/test_extension_point_changed.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the events fired when extension points are changed. """
+"""Tests for the events fired when extension points are changed."""
 
 # Standard library imports.
 import unittest

--- a/src/envisage/tests/test_extension_registry.py
+++ b/src/envisage/tests/test_extension_registry.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the base extension registry. """
+"""Tests for the base extension registry."""
 
 # Standard library imports.
 import contextlib

--- a/src/envisage/tests/test_import_manager.py
+++ b/src/envisage/tests/test_import_manager.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the import manager. """
+"""Tests for the import manager."""
 
 # Standard library imports.
 import unittest
@@ -45,7 +45,5 @@ class ImportManagerTestCase(unittest.TestCase):
     def test_import_dotted_module(self):
         """import dotted module"""
 
-        symbol = self.import_manager.import_symbol(
-            "envisage.api:ImportManager"
-        )
+        symbol = self.import_manager.import_symbol("envisage.api:ImportManager")
         self.assertEqual(symbol, ImportManager)

--- a/src/envisage/tests/test_plugin.py
+++ b/src/envisage/tests/test_plugin.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for plugins. """
-
+"""Tests for plugins."""
 
 import unittest
 

--- a/src/envisage/tests/test_plugin_manager.py
+++ b/src/envisage/tests/test_plugin_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the plugin manager. """
-
+"""Tests for the plugin manager."""
 
 # Standard library imports.
 import unittest
@@ -103,9 +102,7 @@ class PluginManagerTestCase(unittest.TestCase):
         plugin_manager = PluginManager(plugins=[first, second])
         iterator = iter(plugin_manager)
         plugin_manager.remove_plugin(second)
-        self.assertEqual(
-            ["first", "second"], [plugin.id for plugin in iterator]
-        )
+        self.assertEqual(["first", "second"], [plugin.id for plugin in iterator])
 
         # A plugin added after the iterator is created is not visited.
         plugin_manager = PluginManager(plugins=[first])

--- a/src/envisage/tests/test_provider_extension_registry.py
+++ b/src/envisage/tests/test_provider_extension_registry.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the provider extension registry. """
+"""Tests for the provider extension registry."""
 
 # Standard library imports.
 import logging
@@ -31,9 +31,7 @@ from envisage.tests.test_extension_registry_mixin import (
 LOGGER_NAME = "envisage.provider_extension_registry"
 
 
-class ProviderExtensionRegistryTestCase(
-    ExtensionRegistryTestMixin, unittest.TestCase
-):
+class ProviderExtensionRegistryTestCase(ExtensionRegistryTestMixin, unittest.TestCase):
     """Tests for the provider extension registry."""
 
     def setUp(self):

--- a/src/envisage/tests/test_service.py
+++ b/src/envisage/tests/test_service.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the 'Service' trait type. """
+"""Tests for the 'Service' trait type."""
 
 # Standard library imports.
 import unittest

--- a/src/envisage/tests/test_service_registry.py
+++ b/src/envisage/tests/test_service_registry.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the service registry. """
-
+"""Tests for the service registry."""
 
 # Standard library imports.
 import sys
@@ -113,9 +112,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
             return Foo(**properties)
 
         # Register a service factory.
-        self.service_registry.register_service(
-            IFoo, foo_factory, {"price": 100}
-        )
+        self.service_registry.register_service(IFoo, foo_factory, {"price": 100})
 
         # Create a query that matches the registered object.
         service = self.service_registry.get_service(IFoo, "price <= 100")
@@ -387,9 +384,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
 
         # This one has properties.
         goo = Foo(price=10)
-        goo_id = self.service_registry.register_service(
-            IFoo, goo, {"price": 200}
-        )
+        goo_id = self.service_registry.register_service(IFoo, goo, {"price": 200})
 
         # Get the properties.
         foo_properties = self.service_registry.get_service_properties(foo_id)
@@ -441,9 +436,7 @@ class ServiceRegistryTestCase(unittest.TestCase):
         # This one shows how properties can be specified that *take precedence*
         # over the object's attributes when evaluating a query.
         goo = Foo(price=10)
-        goo_id = self.service_registry.register_service(
-            IFoo, goo, {"price": 200}
-        )
+        goo_id = self.service_registry.register_service(IFoo, goo, {"price": 200})
 
         # Create a query that doesn't match any registered object.
         service = self.service_registry.get_service(IFoo, "price < 100")

--- a/src/envisage/tests/test_slice.py
+++ b/src/envisage/tests/test_slice.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests to help find out how trait list events work.
+"""Tests to help find out how trait list events work.
 
 These tests exist because when we are using the 'ExtensionPoint' trait type
 we try to mimic trait list events when extensions are added or removed.

--- a/src/envisage/ui/action/abstract_action_manager_builder.py
+++ b/src/envisage/ui/action/abstract_action_manager_builder.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Builds menus, menu bars and tool bars from action sets. """
-
+"""Builds menus, menu bars and tool bars from action sets."""
 
 # Enthought library imports.
 from pyface.action.api import ActionManager, MenuManager

--- a/src/envisage/ui/action/action.py
+++ b/src/envisage/ui/action/action.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The *definition* of an action in a tool bar or menu. """
-
+"""The *definition* of an action in a tool bar or menu."""
 
 # Enthought library imports.
 from traits.api import Str

--- a/src/envisage/ui/action/action_set.py
+++ b/src/envisage/ui/action/action_set.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An action set is a collection of menus, groups, and actions. """
-
+"""An action set is a collection of menus, groups, and actions."""
 
 # Standard library imports.
 import logging

--- a/src/envisage/ui/action/action_set_manager.py
+++ b/src/envisage/ui/action/action_set_manager.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Manages a collection of action sets. """
-
+"""Manages a collection of action sets."""
 
 # Enthought library imports.
 from traits.api import HasTraits, List

--- a/src/envisage/ui/action/group.py
+++ b/src/envisage/ui/action/group.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The *definition* of a group in a tool bar or menu. """
-
+"""The *definition* of a group in a tool bar or menu."""
 
 # Enthought library imports.
 from traits.api import Bool, Str

--- a/src/envisage/ui/action/i_action_manager_builder.py
+++ b/src/envisage/ui/action/i_action_manager_builder.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The interface for action manager builders. """
-
+"""The interface for action manager builders."""
 
 # Enthought library imports.
 from traits.api import Interface, List

--- a/src/envisage/ui/action/i_action_set.py
+++ b/src/envisage/ui/action/i_action_set.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The action set interface. """
-
+"""The action set interface."""
 
 # Enthought library imports.
 from traits.api import Dict, Interface, List, Str

--- a/src/envisage/ui/action/location.py
+++ b/src/envisage/ui/action/location.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The location of a group, menu, or action, within an action hierarchy. """
-
+"""The location of a group, menu, or action, within an action hierarchy."""
 
 # Enthought library imports.
 from traits.api import HasTraits, Str

--- a/src/envisage/ui/action/menu.py
+++ b/src/envisage/ui/action/menu.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The *definition* of a menu in a menu bar or menu. """
+"""The *definition* of a menu in a menu bar or menu."""
 
 # Enthought library imports.
 from traits.api import Instance, List, Str

--- a/src/envisage/ui/action/tests/dummy_action_manager_builder.py
+++ b/src/envisage/ui/action/tests/dummy_action_manager_builder.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" A menu builder that doesn't build real actions! """
+"""A menu builder that doesn't build real actions!"""
 
 from pyface.action.api import Action, Group, MenuBarManager, MenuManager
 

--- a/src/envisage/ui/action/tests/test_action_manager_builder.py
+++ b/src/envisage/ui/action/tests/test_action_manager_builder.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Tests for the action manager builder. """
+"""Tests for the action manager builder."""
 
 # Standard library imports.
 import unittest
@@ -28,9 +28,7 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         action_sets = [
             ActionSet(
                 actions=[
-                    Action(
-                        class_name="Exit", path="MenuBar/File", group="Bogus"
-                    ),
+                    Action(class_name="Exit", path="MenuBar/File", group="Bogus"),
                 ]
             ),
         ]
@@ -69,9 +67,7 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
 
         action_sets = [
             ActionSet(
-                groups=[
-                    Group(id="FileMenuGroup", path="MenuBar", before="Bogus")
-                ]
+                groups=[Group(id="FileMenuGroup", path="MenuBar", before="Bogus")]
             )
         ]
 
@@ -86,9 +82,7 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         """menu with non-existent sibling"""
 
         action_sets = [
-            ActionSet(
-                menus=[Menu(name="&File", path="MenuBar", before="Bogus")]
-            )
+            ActionSet(menus=[Menu(name="&File", path="MenuBar", before="Bogus")])
         ]
 
         # Create a builder containing the action set.
@@ -139,9 +133,7 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
     def test_single_top_level_group(self):
         """single top level group"""
 
-        action_sets = [
-            ActionSet(groups=[Group(id="FileMenuGroup", path="MenuBar")])
-        ]
+        action_sets = [ActionSet(groups=[Group(id="FileMenuGroup", path="MenuBar")])]
 
         # Create a builder containing the action set.
         builder = DummyActionManagerBuilder(action_sets=action_sets)
@@ -449,12 +441,8 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
             ActionSet(
                 groups=[
                     Group(id="ExitGroup", path="MenuBar/File"),
-                    Group(
-                        id="SaveGroup", path="MenuBar/File", after="NewGroup"
-                    ),
-                    Group(
-                        id="NewGroup", path="MenuBar/File", before="ExitGroup"
-                    ),
+                    Group(id="SaveGroup", path="MenuBar/File", after="NewGroup"),
+                    Group(id="NewGroup", path="MenuBar/File", before="ExitGroup"),
                 ]
             ),
         ]
@@ -479,9 +467,7 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         self.assertEqual(4, len(menu.groups))
 
         ids = [group.id for group in menu.groups]
-        self.assertEqual(
-            ["NewGroup", "SaveGroup", "ExitGroup", "additions"], ids
-        )
+        self.assertEqual(["NewGroup", "SaveGroup", "ExitGroup", "additions"], ids)
 
         # Make sure the 'New' sub-menu got added to the 'NewGroup' group
         # of the 'File' menu.
@@ -622,9 +608,7 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         self.assertEqual(4, len(menu.groups))
 
         ids = [group.id for group in menu.groups]
-        self.assertEqual(
-            ["NewGroup", "ExitGroup", "ExtraGroup", "additions"], ids
-        )
+        self.assertEqual(["NewGroup", "ExitGroup", "ExtraGroup", "additions"], ids)
 
     def test_duplicate_group(self):
         """duplicate group"""

--- a/src/envisage/ui/action/tool_bar.py
+++ b/src/envisage/ui/action/tool_bar.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The *definition* of a tool bar. """
+"""The *definition* of a tool bar."""
 
 # Enthought library imports.
 from traits.api import Instance, List, Str

--- a/src/envisage/ui/tasks/action/task_window_toggle_group.py
+++ b/src/envisage/ui/tasks/action/task_window_toggle_group.py
@@ -64,9 +64,7 @@ class TaskWindowToggleGroup(Group):
     #### 'TaskWindowToggleGroup' interface ####################################
 
     # The application that contains the group.
-    application = Instance(
-        "envisage.ui.tasks.tasks_application." "TasksApplication"
-    )
+    application = Instance("envisage.ui.tasks.tasks_application.TasksApplication")
 
     # The ActionManager to which the group belongs.
     manager = Any
@@ -110,9 +108,7 @@ class TaskWindowToggleGroup(Group):
         return self.manager.controller.task.window.application
 
     def _items_default(self):
-        self.application.on_trait_change(
-            self._rebuild, "window_opened, window_closed"
-        )
+        self.application.on_trait_change(self._rebuild, "window_opened, window_closed")
         return self._get_items()
 
     def _manager_default(self):

--- a/src/envisage/ui/tasks/api.py
+++ b/src/envisage/ui/tasks/api.py
@@ -21,6 +21,7 @@
 - :class:`~.TasksApplicationState`
 - :class:`~.TasksPlugin`
 """
+
 from .preferences_category import PreferencesCategory
 from .preferences_dialog import PreferencesDialog, PreferencesTab
 from .preferences_pane import PreferencesPane

--- a/src/envisage/ui/tasks/task_factory.py
+++ b/src/envisage/ui/tasks/task_factory.py
@@ -40,7 +40,5 @@ class TaskFactory(HasTraits):
         task = self.create(**traits)
         for extension in extensions:
             task.extra_actions.extend(extension.actions)
-            task.extra_dock_pane_factories.extend(
-                extension.dock_pane_factories
-            )
+            task.extra_dock_pane_factories.extend(extension.dock_pane_factories)
         return task

--- a/src/envisage/ui/tasks/tasks_application.py
+++ b/src/envisage/ui/tasks/tasks_application.py
@@ -97,9 +97,7 @@ class TasksApplication(Application):
 
     #: The default layout for the application. If not specified, a single
     #: window will be created with the first available task factory.
-    default_layout = List(
-        Instance("pyface.tasks.task_window_layout.TaskWindowLayout")
-    )
+    default_layout = List(Instance("pyface.tasks.task_window_layout.TaskWindowLayout"))
 
     #: Whether to always apply the default *application level* layout when the
     #: application is started. Even if this is True, the layout state of
@@ -148,9 +146,7 @@ class TasksApplication(Application):
     _explicit_exit = Bool(False)
 
     # Application state.
-    _state = Instance(
-        "envisage.ui.tasks.tasks_application.TasksApplicationState"
-    )
+    _state = Instance("envisage.ui.tasks.tasks_application.TasksApplicationState")
 
     ###########################################################################
     # 'IApplication' interface.
@@ -200,9 +196,7 @@ class TasksApplication(Application):
 
         # Create the task using suitable task extensions.
         extensions = [
-            ext
-            for ext in self.task_extensions
-            if ext.task_id == id or not ext.task_id
+            ext for ext in self.task_extensions if ext.task_id == id or not ext.task_id
         ]
         task = factory.create_with_extensions(extensions)
         task.id = factory.id
@@ -257,9 +251,7 @@ class TasksApplication(Application):
                 if task:
                     window.add_task(task)
                 else:
-                    logger.error(
-                        "Missing factory for task with ID %r", task_id
-                    )
+                    logger.error("Missing factory for task with ID %r", task_id)
 
             # Apply a suitable layout.
             if restore:
@@ -324,10 +316,7 @@ class TasksApplication(Application):
         """
         # Build a list of TaskWindowLayouts.
         self._load_state()
-        if (
-            self.always_use_default_layout
-            or not self._state.previous_window_layouts
-        ):
+        if self.always_use_default_layout or not self._state.previous_window_layouts:
             window_layouts = self.default_layout
         else:
             # Choose the stored TaskWindowLayouts, but only if all the task IDs
@@ -482,9 +471,7 @@ class TasksApplication(Application):
         from .task_window_event import VetoableTaskWindowEvent
 
         # Event notification.
-        self.window_opening = window_event = VetoableTaskWindowEvent(
-            window=window
-        )
+        self.window_opening = window_event = VetoableTaskWindowEvent(window=window)
 
         if window_event.veto:
             event.veto = True
@@ -501,9 +488,7 @@ class TasksApplication(Application):
         from .task_window_event import VetoableTaskWindowEvent
 
         # Event notification.
-        self.window_closing = window_event = VetoableTaskWindowEvent(
-            window=window
-        )
+        self.window_closing = window_event = VetoableTaskWindowEvent(window=window)
 
         if window_event.veto:
             event.veto = True
@@ -543,9 +528,7 @@ class TasksApplicationState(HasStrictTraits):
 
     # A list of TaskWindowLayouts accumulated throughout the application's
     # lifecycle.
-    window_layouts = List(
-        Instance("pyface.tasks.task_window_layout.TaskWindowLayout")
-    )
+    window_layouts = List(Instance("pyface.tasks.task_window_layout.TaskWindowLayout"))
 
     # The "version" for the state data. This should be incremented whenever a
     # backwards incompatible change is made to this class or any of the layout

--- a/src/envisage/ui/tasks/tasks_plugin.py
+++ b/src/envisage/ui/tasks/tasks_plugin.py
@@ -158,8 +158,6 @@ class TasksPlugin(Plugin):
         dialog = PreferencesDialog(application=self.application)
         dialog.trait_set(
             categories=self.preferences_categories,
-            panes=[
-                factory(dialog=dialog) for factory in self.preferences_panes
-            ],
+            panes=[factory(dialog=dialog) for factory in self.preferences_panes],
         )
         return dialog

--- a/src/envisage/ui/workbench/action/about_action.py
+++ b/src/envisage/ui/workbench/action/about_action.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An action that shows the 'About' dialog. """
-
+"""An action that shows the 'About' dialog."""
 
 # Enthought library imports.
 from pyface.action.api import Action

--- a/src/envisage/ui/workbench/action/edit_preferences_action.py
+++ b/src/envisage/ui/workbench/action/edit_preferences_action.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An action that displays the preferences dialog. """
-
+"""An action that displays the preferences dialog."""
 
 from pyface.action.api import Action
 

--- a/src/envisage/ui/workbench/action/exit_action.py
+++ b/src/envisage/ui/workbench/action/exit_action.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An action that exits the workbench. """
-
+"""An action that exits the workbench."""
 
 from pyface.action.api import Action
 

--- a/src/envisage/ui/workbench/api.py
+++ b/src/envisage/ui/workbench/api.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" Envisage package Copyright 2003, 2004, 2005 Enthought, Inc. """
-
+"""Envisage package Copyright 2003, 2004, 2005 Enthought, Inc."""
 
 from .workbench import Workbench
 from .workbench_action_set import WorkbenchActionSet

--- a/src/envisage/ui/workbench/default_action_set.py
+++ b/src/envisage/ui/workbench/default_action_set.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The default workbench action set. """
-
+"""The default workbench action set."""
 
 # Enthought library imports.
 from envisage.ui.action.api import Action, ActionSet, Group, Menu

--- a/src/envisage/ui/workbench/workbench.py
+++ b/src/envisage/ui/workbench/workbench.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The Envisage workbench. """
-
+"""The Envisage workbench."""
 
 # Enthought library imports.
 import pyface.workbench.api as pyface

--- a/src/envisage/ui/workbench/workbench_action_manager_builder.py
+++ b/src/envisage/ui/workbench/workbench_action_manager_builder.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The action manager builder used to build the workbench menu/tool bars. """
-
+"""The action manager builder used to build the workbench menu/tool bars."""
 
 # Standard library imports.
 import weakref

--- a/src/envisage/ui/workbench/workbench_action_set.py
+++ b/src/envisage/ui/workbench/workbench_action_set.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An action set in a workbench window. """
-
+"""An action set in a workbench window."""
 
 from traits.api import Instance, List, Str
 
@@ -124,16 +123,14 @@ class WorkbenchActionSet(ActionSet):
             self.enabled = (
                 window is not None
                 and window.active_perspective is not None
-                and window.active_perspective.id
-                in self.enabled_for_perspectives
+                and window.active_perspective.id in self.enabled_for_perspectives
             )
 
         if len(self.visible_for_perspectives) > 0:
             self.visible = (
                 window is not None
                 and window.active_perspective is not None
-                and window.active_perspective.id
-                in self.visible_for_perspectives
+                and window.active_perspective.id in self.visible_for_perspectives
             )
 
         if len(self.enabled_for_views) > 0:

--- a/src/envisage/ui/workbench/workbench_application.py
+++ b/src/envisage/ui/workbench/workbench_application.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The entry point for an Envisage Workbench application. """
-
+"""The entry point for an Envisage Workbench application."""
 
 # Standard library imports.
 import logging

--- a/src/envisage/ui/workbench/workbench_editor_manager.py
+++ b/src/envisage/ui/workbench/workbench_editor_manager.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An editor manager that uses contributed editors. """
+"""An editor manager that uses contributed editors."""
 
 # Enthought library imports.
 from pyface.workbench.api import EditorManager, TraitsUIEditor

--- a/src/envisage/ui/workbench/workbench_plugin.py
+++ b/src/envisage/ui/workbench/workbench_plugin.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The Envisage workbench plugin. """
-
+"""The Envisage workbench plugin."""
 
 from traits.api import Callable, List
 
@@ -208,8 +207,7 @@ class WorkbenchPlugin(Plugin):
         """Trait initializer."""
 
         preferences_manager_service_offer = ServiceOffer(
-            protocol="apptools.preferences.ui.preferences_manager"
-            ".PreferencesManager",
+            protocol="apptools.preferences.ui.preferences_manager.PreferencesManager",
             factory=self._create_preferences_manager_service,
         )
 

--- a/src/envisage/ui/workbench/workbench_preferences.py
+++ b/src/envisage/ui/workbench/workbench_preferences.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The workbench preferences. """
-
+"""The workbench preferences."""
 
 # Enthought library imports.
 from apptools.preferences.api import PreferencesHelper

--- a/src/envisage/ui/workbench/workbench_preferences_page.py
+++ b/src/envisage/ui/workbench/workbench_preferences_page.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The main preferences page for the workbench. """
-
+"""The main preferences page for the workbench."""
 
 # Enthought library imports.
 from apptools.preferences.ui.api import PreferencesPage

--- a/src/envisage/ui/workbench/workbench_window.py
+++ b/src/envisage/ui/workbench/workbench_window.py
@@ -7,8 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" An extensible workbench window. """
-
+"""An extensible workbench window."""
 
 # Standard library imports.
 import logging
@@ -177,9 +176,7 @@ class WorkbenchWindow(pyface.WorkbenchWindow):
     def get_service(self, protocol, query="", minimize="", maximize=""):
         """Return at most one service that matches the specified query."""
 
-        service = self.service_registry.get_service(
-            protocol, query, minimize, maximize
-        )
+        service = self.service_registry.get_service(protocol, query, minimize, maximize)
 
         return service
 
@@ -200,9 +197,7 @@ class WorkbenchWindow(pyface.WorkbenchWindow):
     def register_service(self, protocol, obj, properties=None):
         """Register a service."""
 
-        service_id = self.service_registry.register_service(
-            protocol, obj, properties
-        )
+        service_id = self.service_registry.register_service(protocol, obj, properties)
 
         return service_id
 

--- a/src/envisage/unknown_extension.py
+++ b/src/envisage/unknown_extension.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The exception raised when an unknown extension is referenced. """
+"""The exception raised when an unknown extension is referenced."""
 
 
 class UnknownExtension(Exception):

--- a/src/envisage/unknown_extension_point.py
+++ b/src/envisage/unknown_extension_point.py
@@ -7,7 +7,7 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-""" The exception raised when an unknown extension point is referenced. """
+"""The exception raised when an unknown extension point is referenced."""
 
 
 class UnknownExtensionPoint(Exception):


### PR DESCRIPTION
Part of #636, and the follow-up to #637. Replaces #638, which was branched
before #637's review changes; this one is built from scratch on current `main`
so that it is exactly reproducible.

## How to reproduce this PR

```bash
git checkout main            # afa89ddb
git checkout -b ruff-reformat
uv run --locked --only-group style -m ruff format .   # commit 1
# add `ruff format --check --diff .` to check-style.yml   # commit 2
```

Two commits, ordered so that each one is green on its own:

1. **The reformat** — mechanical, the entire diff is the output of
   `ruff format .`. 133 files, +196/-435, `.py` files only.
2. **One line** adding `ruff format --check --diff` to the style workflow.
   Separated from the reformat so the check is only turned on once the
   codebase already satisfies it, rather than merging something red.

## What's actually in the diff

Almost all of it is docstring normalization:

```diff
-""" An application event. """
-
+"""An application event."""
```

That is the same change black wants at its current version, so it was coming
either way — see #632. The remainder is lines rejoined at the length of 88 set
in #637.

## Checks run locally, on each commit separately

| | `ruff check` | `ruff format --check` |
| --- | --- | --- |
| Reformat commit | All checks passed | 215 files already formatted |
| CI commit | All checks passed | 215 files already formatted |

Also `uv run -m pytest` — 178 passed — and the `check-copyright-year` grep
passes (2026/2026).

*This PR was created with the assistance of an AI coding agent.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)