### PR TITLE
Document the changelog conventions, and make AGENTS.md reach Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,13 @@ strings, `.format()` and f-strings are both acceptable.
 - Define helper classes (interfaces, plugins) inside test methods as needed
 - Prefer `self.addCleanup(...)` for teardown where practical; `tearDown` methods are also acceptable when clearer
 
+## Changelog
+
+Add an entry to `CHANGES.rst` under the in-development section at the top,
+grouped under a heading such as `Fixes`, `Tests` or `Build`. End it with the
+number of the **pull request**, not the issue it closes — `(#635)`, or
+`(#618, #621)` for a change spread over several PRs.
+
 ## Pull Requests
 
 If a PR was created with agent assistance, the PR description must say so.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Build
   pick up an uninstalled source tree. The wheel is unchanged. (#635)
 * Style checks now use ``ruff`` in place of ``black``, ``isort``, ``flake8``
   and ``flake8-ets``. (#637)
+* ``AGENTS.md`` describes the changelog conventions, and a ``CLAUDE.md``
+  imports it so that Claude Code picks it up. (#644)
 
 Version 8.0.0
 =============

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Build
   so that an ``import envisage`` from the repository root can't accidentally
   pick up an uninstalled source tree. The wheel is unchanged. (#635)
 * Style checks now use ``ruff`` in place of ``black``, ``isort``, ``flake8``
-  and ``flake8-ets``. (#636)
+  and ``flake8-ets``. (#637)
 
 Version 8.0.0
 =============

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+Claude Code reads this file automatically. The repository's instructions for
+coding agents live in AGENTS.md, imported below.
+
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,1 @@
-Claude Code reads this file automatically. The repository's instructions for
-coding agents live in AGENTS.md, imported below.
-
 @AGENTS.md


### PR DESCRIPTION
Closes #643.

Changelog entries in `CHANGES.rst` end with the number of the pull request
that made the change, not the issue it closes. Nothing said so, and
`AGENTS.md` had no changelog section at all, so this adds one.

Behind that, Claude Code reads `CLAUDE.md`, not `AGENTS.md`, and this
repository had neither — so nothing in `AGENTS.md` reached it, including the
existing rule that a PR made with agent assistance has to say so. The new
`CLAUDE.md` imports `AGENTS.md` with `@AGENTS.md` rather than repeating any
of it, so there's no second copy to keep in sync.

Also corrects the ruff entry, which cited issue #636 where #637 is the PR.

I checked the other 257 `#N` references in `CHANGES.rst` against the GitHub
API. Every trailing reference is a PR except one in 4.5.0 (`(#37)`), and the
two mentions of `#417` are deliberate inline prose — "which caused the issue
#417", with the PR number correctly in the trailing parens. So the convention
is already near-universal; this just writes it down. I've left the 4.5.0 entry
alone as long-released history.

*This PR was created with the assistance of an AI coding agent.*