### PR TITLE
Reinstate libegl1, the one Qt support package that was load-bearing

### DIFF
--- a/.github/actions/install-qt-support/README.md
+++ b/.github/actions/install-qt-support/README.md
@@ -3,15 +3,10 @@
 This action uses `apt-get` to install the OS packages needed to import Qt on
 Linux. It does nothing on non-Linux runners.
 
-It installs two packages, and only two: `libegl1`, a link-time dependency of
-`libQt6Gui`, and `libopengl0`, which EDM's PySide6 build needs though the PyPI
-wheel doesn't. Together they're what makes PySide6 importable. The packages
-that the xcb platform plugin needs are deliberately not installed, because
-workflows use `QT_QPA_PLATFORM=offscreen` in place of a display.
-
-Without these, the failure is silent rather than loud — Pyface falls back to
-its null toolkit, so GUI tests skip and autodoc documents placeholder classes,
-with everything still reporting success.
+It installs `libegl1`, a link-time dependency of `libQt6Gui`, and
+`libopengl0`, needed by EDM's PySide6 build though not by the PyPI wheel. The
+packages that the xcb platform plugin needs are not installed: workflows use
+`QT_QPA_PLATFORM=offscreen` in place of a display.
 
 ## Inputs
 

--- a/.github/actions/install-qt-support/README.md
+++ b/.github/actions/install-qt-support/README.md
@@ -1,0 +1,35 @@
+# Install Qt dependencies
+
+This action uses `apt-get` to install the OS packages needed to import Qt on
+Linux. It does nothing on non-Linux runners.
+
+It installs `libegl1` and nothing else. That's enough to make PySide6
+importable; the packages that the xcb platform plugin needs are deliberately
+not installed, because workflows use `QT_QPA_PLATFORM=offscreen` in place of a
+display. Without `libegl1` the failure is silent rather than loud — Pyface
+falls back to its null toolkit, so GUI tests skip and autodoc documents
+placeholder classes, with everything still reporting success.
+
+## Inputs
+
+There are no inputs.
+
+## Outputs
+
+There are no outputs.
+
+## Example usage
+
+```yml
+jobs:
+
+  test-with-edm:
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v7
+    - uses: ./.github/actions/install-qt-support
+```

--- a/.github/actions/install-qt-support/README.md
+++ b/.github/actions/install-qt-support/README.md
@@ -3,12 +3,15 @@
 This action uses `apt-get` to install the OS packages needed to import Qt on
 Linux. It does nothing on non-Linux runners.
 
-It installs `libegl1` and nothing else. That's enough to make PySide6
-importable; the packages that the xcb platform plugin needs are deliberately
-not installed, because workflows use `QT_QPA_PLATFORM=offscreen` in place of a
-display. Without `libegl1` the failure is silent rather than loud — Pyface
-falls back to its null toolkit, so GUI tests skip and autodoc documents
-placeholder classes, with everything still reporting success.
+It installs two packages, and only two: `libegl1`, a link-time dependency of
+`libQt6Gui`, and `libopengl0`, which EDM's PySide6 build needs though the PyPI
+wheel doesn't. Together they're what makes PySide6 importable. The packages
+that the xcb platform plugin needs are deliberately not installed, because
+workflows use `QT_QPA_PLATFORM=offscreen` in place of a display.
+
+Without these, the failure is silent rather than loud — Pyface falls back to
+its null toolkit, so GUI tests skip and autodoc documents placeholder classes,
+with everything still reporting success.
 
 ## Inputs
 

--- a/.github/actions/install-qt-support/action.yml
+++ b/.github/actions/install-qt-support/action.yml
@@ -11,9 +11,10 @@ runs:
     # skip and autodoc documents placeholder classes. The packages the xcb
     # platform plugin needs are deliberately absent --
     # QT_QPA_PLATFORM=offscreen replaces them.
+    #
+    # libopengl0 is the workaround for
+    # https://bugreports.qt.io/browse/PYSIDE-1547
     run: |
       sudo apt-get update
-      sudo apt-get install libegl1
-      # Needed to work around https://bugreports.qt.io/browse/PYSIDE-1547
-      sudo apt-get install libopengl0
+      sudo apt-get install -y libegl1 libopengl0
     shell: bash

--- a/.github/actions/install-qt-support/action.yml
+++ b/.github/actions/install-qt-support/action.yml
@@ -5,12 +5,15 @@ runs:
   steps:
   - name: Install Linux packages for Qt
     if: runner.os == 'Linux'
-    # libEGL is a link-time dependency of libQt6Gui, so PySide6 can't be
-    # imported at all without it. That failure is silent: Pyface falls back
-    # to the null toolkit, the GUI tests skip and autodoc documents
-    # placeholder classes. The packages the xcb platform plugin needs are
-    # deliberately absent -- QT_QPA_PLATFORM=offscreen replaces them.
+    # These are the libraries needed to *import* Qt: libEGL is a link-time
+    # dependency of libQt6Gui, and EDM's PySide6 also wants libOpenGL. That
+    # failure is silent: Pyface falls back to the null toolkit, the GUI tests
+    # skip and autodoc documents placeholder classes. The packages the xcb
+    # platform plugin needs are deliberately absent --
+    # QT_QPA_PLATFORM=offscreen replaces them.
     run: |
       sudo apt-get update
       sudo apt-get install libegl1
+      # Needed to work around https://bugreports.qt.io/browse/PYSIDE-1547
+      sudo apt-get install libopengl0
     shell: bash

--- a/.github/actions/install-qt-support/action.yml
+++ b/.github/actions/install-qt-support/action.yml
@@ -6,11 +6,7 @@ runs:
   - name: Install Linux packages for Qt
     if: runner.os == 'Linux'
     # These are the libraries needed to *import* Qt: libEGL is a link-time
-    # dependency of libQt6Gui, and EDM's PySide6 also wants libOpenGL. That
-    # failure is silent: Pyface falls back to the null toolkit, the GUI tests
-    # skip and autodoc documents placeholder classes. The packages the xcb
-    # platform plugin needs are deliberately absent --
-    # QT_QPA_PLATFORM=offscreen replaces them.
+    # dependency of libQt6Gui, and EDM's PySide6 also wants libOpenGL.
     #
     # libopengl0 is the workaround for
     # https://bugreports.qt.io/browse/PYSIDE-1547

--- a/.github/actions/install-qt-support/action.yml
+++ b/.github/actions/install-qt-support/action.yml
@@ -1,0 +1,16 @@
+name: install-qt-support
+description: 'Install supporting OS packages for Qt-using code'
+runs:
+  using: composite
+  steps:
+  - name: Install Linux packages for Qt
+    if: runner.os == 'Linux'
+    # libEGL is a link-time dependency of libQt6Gui, so PySide6 can't be
+    # imported at all without it. That failure is silent: Pyface falls back
+    # to the null toolkit, the GUI tests skip and autodoc documents
+    # placeholder classes. The packages the xcb platform plugin needs are
+    # deliberately absent -- QT_QPA_PLATFORM=offscreen replaces them.
+    run: |
+      sudo apt-get update
+      sudo apt-get install libegl1
+    shell: bash

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Clone the Envisage source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install packages for Qt support
+        uses: ./.github/actions/install-qt-support
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:

--- a/.github/workflows/test-doc-build.yml
+++ b/.github/workflows/test-doc-build.yml
@@ -8,6 +8,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    # Without this, PySide6 can't be imported, Sphinx quietly falls back to
+    # Pyface's null toolkit and autodoc documents placeholder classes. Note
+    # that QT_QPA_PLATFORM is deliberately not set here: the documentation
+    # build has to work on Read the Docs, where nothing sets it, so this job
+    # exercises the same fallback that docs/source/conf.py provides.
+    - name: Install packages for Qt support
+      uses: ./.github/actions/install-qt-support
     - name: Set up uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Clone the Envisage source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install packages for Qt support
+        uses: ./.github/actions/install-qt-support
       - name: Cache EDM packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Clone the Envisage source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install packages for Qt support
+        uses: ./.github/actions/install-qt-support
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:

--- a/.github/workflows/update-gh-pages-on-release.yml
+++ b/.github/workflows/update-gh-pages-on-release.yml
@@ -11,6 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    # Without this, autodoc documents Pyface's placeholder classes in place of
+    # the real Qt-backed ones.
+    - name: Install packages for Qt support
+      uses: ./.github/actions/install-qt-support
     - name: Set up uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:

--- a/.github/workflows/update-gh-pages.yml
+++ b/.github/workflows/update-gh-pages.yml
@@ -11,6 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    # Without this, autodoc documents Pyface's placeholder classes in place of
+    # the real Qt-backed ones.
+    - name: Install packages for Qt support
+      uses: ./.github/actions/install-qt-support
     - name: Set up uv
       uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Fixes
   Importing Pyface's toolkit constructs a ``QApplication``, which aborts the
   process when no platform plugin can be initialized, so the documentation
   build failed wherever there was no display. (#645)
+* The documentation workflows install ``libegl1``, so that autodoc documents
+  the real Qt-backed classes. Without it PySide6 can't be imported, Pyface
+  falls back to its null toolkit, and the API documentation for
+  ``PythonShellView`` and ``NamespaceView`` described placeholder classes.
+  (#648)
 
 Build
 -----
@@ -38,6 +43,10 @@ Build
   ``xvfb-run`` and the X11 support packages that the ``install-qt-support``
   action installed with ``apt-get``. That action is gone, and the separate
   Ubuntu and non-Ubuntu test steps have collapsed into one. (#645)
+* The ``install-qt-support`` action is back, installing ``libegl1`` and
+  nothing else. Without it PySide6 can't be imported at all, so the GUI tests
+  were skipping on Linux rather than running. The packages the xcb platform
+  plugin needs stay uninstalled. (#648)
 
 Tests
 -----
@@ -45,6 +54,8 @@ Tests
   unavailable without it. It's now installed alongside the toolkit, and
   ``requires_gui`` skips rather than letting the import fail when it's
   missing. (#641)
+* A test fails, rather than skipping quietly, when a GUI toolkit is installed
+  but Pyface still falls back to its null toolkit. (#648)
 
 Version 8.0.0
 =============

--- a/src/envisage/tests/test_support.py
+++ b/src/envisage/tests/test_support.py
@@ -1,0 +1,39 @@
+# (C) Copyright 2007-2026 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""Tests for the test support utilities themselves."""
+
+import os
+import unittest
+
+from envisage.tests.support import (
+    gui_available,
+    gui_skip_reason,
+    pyside6_available,
+)
+
+
+class GuiAvailableTestCase(unittest.TestCase):
+    def test_gui_available_when_a_toolkit_is_installed(self):
+        # Pyface falls back to its null toolkit when Qt can't be imported,
+        # which makes every GUI test skip without anything failing. That's
+        # usually a missing system library rather than a deliberate choice,
+        # so treat it as an error instead of letting the skips pass unnoticed.
+        if not pyside6_available:
+            self.skipTest("PySide6 is not installed")
+        if os.environ.get("ETS_TOOLKIT") == "null":
+            self.skipTest("The null toolkit was requested explicitly")
+
+        self.assertTrue(
+            gui_available,
+            "PySide6 is installed, but Pyface fell back to the null toolkit "
+            "({}). A system library needed to import Qt is probably "
+            "missing.".format(gui_skip_reason),
+        )

--- a/src/envisage/tests/test_support.py
+++ b/src/envisage/tests/test_support.py
@@ -10,14 +10,11 @@
 
 """Tests for the test support utilities themselves."""
 
+import importlib.util
 import os
 import unittest
 
-from envisage.tests.support import (
-    gui_available,
-    gui_skip_reason,
-    pyside6_available,
-)
+from envisage.tests.support import gui_available, gui_skip_reason
 
 
 class GuiAvailableTestCase(unittest.TestCase):
@@ -26,7 +23,10 @@ class GuiAvailableTestCase(unittest.TestCase):
         # which makes every GUI test skip without anything failing. That's
         # usually a missing system library rather than a deliberate choice,
         # so treat it as an error instead of letting the skips pass unnoticed.
-        if not pyside6_available:
+        #
+        # Look for the package without importing it. Importing would make
+        # this test skip in one of the cases it exists to catch.
+        if importlib.util.find_spec("PySide6") is None:
             self.skipTest("PySide6 is not installed")
         if os.environ.get("ETS_TOOLKIT") == "null":
             self.skipTest("The null toolkit was requested explicitly")

--- a/src/envisage/tests/test_support.py
+++ b/src/envisage/tests/test_support.py
@@ -31,9 +31,14 @@ class GuiAvailableTestCase(unittest.TestCase):
         if os.environ.get("ETS_TOOLKIT") == "null":
             self.skipTest("The null toolkit was requested explicitly")
 
+        # Report the underlying error, which names the missing library.
+        try:
+            from pyface.qt import QtGui  # noqa: F401
+        except ImportError as exc:
+            self.fail(f"PySide6 is installed, but importing Qt failed: {exc}")
+
         self.assertTrue(
             gui_available,
-            "PySide6 is installed, but Pyface fell back to the null toolkit "
-            "({}). A system library needed to import Qt is probably "
-            "missing.".format(gui_skip_reason),
+            "PySide6 is installed and Qt imports, but Pyface still fell back "
+            f"to the null toolkit ({gui_skip_reason}).",
         )


### PR DESCRIPTION
Closes #647. Closes #646.

#645 removed the `install-qt-support` action entirely, on the evidence that
every check stayed green without it. That evidence was misleading — the checks
stayed green because the GUI tests stopped running.

| Workflow (ubuntu-latest) | Before #645 | After #645 | With this PR |
| --- | --- | --- | --- |
| `test-with-pypi` | 178 passed | 171 passed, **7 skipped** | 178 passed |
| `test-with-edm` (pyside6) | 178 passed | 171 passed, **7 skipped** | 178 passed |

## What was actually going on

`libEGL.so.1` is a link-time dependency of `libQt6Gui`, so without `libegl1`
PySide6 can't be imported at all. Pyface handles that by falling back to its
null toolkit — a *silent* failure. `GUI()` then raises `NotImplementedError`,
`gui_available` becomes `False`, and every `@requires_gui` test skips while
the suite reports success.

So the ten packages fell into two categories. The eight
`libxcb`/`libxkbcommon` ones serve the **xcb platform plugin**, and
`QT_QPA_PLATFORM=offscreen` really does make those redundant. The other two
are needed to import Qt at all, and have to come back:

* `libegl1` — a link-time dependency of `libQt6Gui`, needed everywhere.
* `libopengl0` — needed by EDM's PySide6 build, though not by the PyPI
  wheel. This is what the original action's `PYSIDE-1547` comment was about.

Two packages instead of ten, and `xvfb-run` stays gone.

The second one was found the hard way, and is a good advertisement for the
new test: with only `libegl1`, `test-with-edm (ubuntu, pyside6)` failed on
the guard while the rest of the suite reported `171 passed, 7 skipped`. That
environment had been quietly skipping its GUI tests too, and nothing else in
CI would have said so.

## The same missing library was breaking the documentation (#646)

`test-doc-build.yml` and both `update-gh-pages` workflows build on
`ubuntu-latest` with no Qt packages, so Sphinx got the null toolkit too.
Autodoc only imports classes and never instantiates them, and the null
toolkit's placeholder raises only on instantiation — so the build succeeds
while documenting placeholders.

That is live on the published documentation today, on two of 116 API pages:

* [`python_shell_view`](https://docs.enthought.com/envisage/api/envisage.plugins.python_shell.view.python_shell_view.html) — `Bases: Unimplemented`
* [`namespace_view`](https://docs.enthought.com/envisage/api/envisage.plugins.python_shell.view.namespace_view.html) — `Bases: Unimplemented`

It's long-standing rather than new: `/envisage/7.0/` and `/envisage/8.0/` show
it too, so #628's "a toolkit is needed for accurate API documentation from
autodoc" never took effect on a runner. Adding the action to those workflows
fixes it. `update-gh-pages.yml` runs on push to `main`, so the root
documentation self-corrects when this merges; the versioned `8.0/` copy would
need a manual `workflow_dispatch` if it's worth correcting.

This also makes `test-doc-build.yml` a real guard for #631-style breakage.
`QT_QPA_PLATFORM` is deliberately *not* set in that workflow, so it exercises
the same `conf.py` fallback Read the Docs relies on. Verified on a runner:
with `libegl1` installed and `QT_QPA_PLATFORM` unset, the #631 abort
reproduces verbatim — `Could not load the Qt platform plugin "xcb"`.

## The new test

`test_support.py` fails, rather than skipping, when PySide6 is importable as a
package but Pyface still ends up on the null toolkit. That's the check that
would have caught #645 immediately. It skips when no toolkit is installed (so
`test-without-toolkit` is unaffected) and when `ETS_TOOLKIT=null` is set
deliberately. Drop it if you'd rather not have it — the rest of the PR stands
on its own.

## Verification

All 26 checks pass. `test-with-pypi` and `test-with-edm` are both back to
`179 passed` with **no skips** on ubuntu (179 rather than 178 because of the
new test), and `test-without-toolkit` still skips as it should.

Isolated on an `ubuntu-latest` runner beforehand, with `libegl1` as the only
added package: `PySide6 imports fine`, `platformName: offscreen`,
`gui_available: True`, full suite `178 passed` with no skips, and the
documentation build resolving the real Qt `PythonShell`. With
`QT_QPA_PLATFORM` unset, the same runner reproduced the #631 abort verbatim.

Locally: the guard skips rather than fails under `ETS_TOOLKIT=null`, and ruff
is clean.

*This PR was created with the assistance of an AI coding agent.*
