### PR TITLE
Tidy the in-development changelog entries for the Qt support changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,15 +9,13 @@ Released: YYYY-MM-DD
 
 Fixes
 -----
-* The Sphinx configuration asks for Qt's ``offscreen`` platform plugin.
-  Importing Pyface's toolkit constructs a ``QApplication``, which aborts the
-  process when no platform plugin can be initialized, so the documentation
-  build failed wherever there was no display. (#645)
-* The documentation workflows install ``libegl1``, so that autodoc documents
-  the real Qt-backed classes. Without it PySide6 can't be imported, Pyface
-  falls back to its null toolkit, and the API documentation for
-  ``PythonShellView`` and ``NamespaceView`` described placeholder classes.
-  (#648)
+* The documentation builds where there's no display, so Read the Docs
+  publishes again. Importing Pyface's toolkit constructs a ``QApplication``,
+  which aborts the process when no Qt platform plugin can be initialized, so
+  the Sphinx configuration asks for the ``offscreen`` one. (#645)
+* The API documentation for ``PythonShellView`` and ``NamespaceView``
+  describes the real Qt-backed classes, in place of the placeholders Pyface
+  substitutes when no toolkit is available. (#648)
 
 Build
 -----
@@ -39,14 +37,11 @@ Build
   and ``flake8-ets``. (#637)
 * ``AGENTS.md`` describes the changelog conventions, and a ``CLAUDE.md``
   imports it so that Claude Code picks it up. (#644)
-* The test workflows set ``QT_QPA_PLATFORM=offscreen`` in place of
-  ``xvfb-run`` and the X11 support packages that the ``install-qt-support``
-  action installed with ``apt-get``. That action is gone, and the separate
-  Ubuntu and non-Ubuntu test steps have collapsed into one. (#645)
-* The ``install-qt-support`` action is back, installing ``libegl1`` and
-  nothing else. Without it PySide6 can't be imported at all, so the GUI tests
-  were skipping on Linux rather than running. The packages the xcb platform
-  plugin needs stay uninstalled. (#648)
+* The test and documentation workflows set ``QT_QPA_PLATFORM=offscreen`` in
+  place of ``xvfb-run``, and the ``install-qt-support`` action installs only
+  the two packages needed to import Qt rather than the eight more that the
+  xcb platform plugin needed. The separate Ubuntu and non-Ubuntu test steps
+  have collapsed into one. (#645, #648)
 
 Tests
 -----


### PR DESCRIPTION
Closes #649.

Two changes, both to the in-development section only, and both independent of
which version we release next.

**Consolidated the two `install-qt-support` entries in `Build`.** They
recorded the action being removed (#645) and restored (#648) within one
release cycle. For someone reading the release notes that's churn netting out
to a change in which packages are installed, so it's now one entry ending
`(#645, #648)`, per the AGENTS.md convention for a change spread over several
PRs.

**Reframed the two `Fixes` entries around the user-visible outcome** — that
the documentation builds and publishes again, and that the API documentation
for `PythonShellView` and `NamespaceView` describes the real classes — rather
than repeating the CI mechanism now covered in `Build`.

No entries were dropped: every PR number still appears, and the `Tests`
section is untouched. The section heading still says `Version 8.1.0`, since
that's the one part that depends on the version chosen at release time.

*This PR was created with the assistance of an AI coding agent.*