### PR TITLE
Bump enthought-sphinx-theme to 0.7.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,13 @@ Fixes
 * The API documentation for ``PythonShellView`` and ``NamespaceView``
   describes the real Qt-backed classes, in place of the placeholders Pyface
   substitutes when no toolkit is available. (#648)
+* Documentation search results show a snippet of surrounding context under
+  each hit again. The Enthought Sphinx theme emitted its own
+  ``DOCUMENTATION_OPTIONS`` object, which kept Sphinx's own copy from
+  loading, and its ``<html>`` element omitted the content root marker that
+  Sphinx uses to find the page a result came from. Both are fixed in theme
+  version 0.7.5, which the documentation dependencies now pin. Long dotted
+  names in API signatures wrap again too. (#652)
 
 Build
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,12 +17,8 @@ Fixes
   describes the real Qt-backed classes, in place of the placeholders Pyface
   substitutes when no toolkit is available. (#648)
 * Documentation search results show a snippet of surrounding context under
-  each hit again. The Enthought Sphinx theme emitted its own
-  ``DOCUMENTATION_OPTIONS`` object, which kept Sphinx's own copy from
-  loading, and its ``<html>`` element omitted the content root marker that
-  Sphinx uses to find the page a result came from. Both are fixed in theme
-  version 0.7.5, which the documentation dependencies now pin. Long dotted
-  names in API signatures wrap again too. (#652)
+  each hit again, and long dotted names in API signatures wrap again. Both
+  come from the upgrade to Enthought Sphinx theme 0.7.5. (#652)
 
 Build
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ gui = [
 ]
 docs = [
     'Sphinx==9.1.0',
-    'enthought-sphinx-theme==0.7.4',
+    'enthought-sphinx-theme==0.7.5',
     'sphinx-copybutton==0.5.2',
     # A toolkit is needed for accurate API documentation from autodoc.
     {include-group = 'gui'},

--- a/uv.lock
+++ b/uv.lock
@@ -166,11 +166,11 @@ wheels = [
 
 [[package]]
 name = "enthought-sphinx-theme"
-version = "0.7.4"
+version = "0.7.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/c8/24c178aa2c55a77c808cd54b4facce995fc031c72c85650f8f37af6ea8e2/enthought_sphinx_theme-0.7.4.tar.gz", hash = "sha256:b396db8638b3167409f6a3a4076087711d9f7c6d59d8fa590836a37ba1373936", size = 255843, upload-time = "2026-02-16T08:55:33.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/4c/a4567ece4fc0e59c40296975a81e1d471003d7b827b020d8c1b4d3c9e419/enthought_sphinx_theme-0.7.5.tar.gz", hash = "sha256:da8a66ffc315e9eabfbcb3d260499dc7f9a8f9583a544af979d028e09b2026ad", size = 254979, upload-time = "2026-08-07T13:46:34.447Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/24/b5c880e604292150c30286290cb9e24e0c10ecb641c0ffc1f1111aee584e/enthought_sphinx_theme-0.7.4-py3-none-any.whl", hash = "sha256:6989e6fe857295abab14d8a9316d39a42bbe28e778ff31f9cd9c3e42f982e63f", size = 217851, upload-time = "2026-02-16T08:55:30.831Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c7/2084112cbbca8d6065bd5a88ec728cf07926b0957fad3e1b2059e6a32b5a/enthought_sphinx_theme-0.7.5-py3-none-any.whl", hash = "sha256:7e429101f123b26160f8edba6bf0784f63bf3bdba8fc9e08823872c9c0188b60", size = 216662, upload-time = "2026-08-07T13:46:33.28Z" },
 ]
 
 [[package]]
@@ -225,7 +225,7 @@ dev = [
     { name = "ruff", specifier = "~=0.16.0" },
 ]
 docs = [
-    { name = "enthought-sphinx-theme", marker = "python_full_version >= '3.12'", specifier = "==0.7.4" },
+    { name = "enthought-sphinx-theme", marker = "python_full_version >= '3.12'", specifier = "==0.7.5" },
     { name = "pygments", marker = "python_full_version >= '3.12'" },
     { name = "pyside6", marker = "python_full_version >= '3.12'" },
     { name = "sphinx", marker = "python_full_version >= '3.12'", specifier = "==9.1.0" },


### PR DESCRIPTION
Closes #651.

Bumps the pinned `enthought-sphinx-theme` in the `docs` dependency group from 0.7.4 to 0.7.5, refreshes `uv.lock`, and adds a changelog entry. Nothing in Envisage's own Sphinx configuration needed to change.

0.7.5 fixes two faults in the theme's `layout.html`, both of which had to go before search context came back:

* The theme emitted its own inline `DOCUMENTATION_OPTIONS`. Since Sphinx 7.2 declares that name with `const`, the redeclaration threw and Sphinx's own `documentation_options.js` never executed, leaving a stale object with no `SHOW_SEARCH_SUMMARY` — so `searchtools.js` never even requested the page it would summarise.
* The `<html>` element carried no `data-content_root`, which Sphinx 7.2 made the source of the URL for that request.

Background in enthought/enthought-sphinx-theme#26 and #27; the fix is enthought/enthought-sphinx-theme#28.

## Verification

`uv lock --check` passes, and the lockfile diff touches only `enthought-sphinx-theme` (4 lines each way). Built the documentation with `--locked` so the theme comes from the lockfile, and drove the result in headless Chromium:

| | Before (0.7.4) | After (0.7.5) |
|---|---|---|
| `data-content_root` | `undefined` | `"./"` |
| context snippets on `?q=ExtensionPoint` | 0 of 139 | **139 of 139** |
| console errors | `DOCUMENTATION_OPTIONS has already been declared`, `$ is not defined` | none |

The 151 hits break down as 139 needing a fetched summary and 12 carrying an index description instead, so 139 is the full set.

Also confirmed on a content page that `.descclassname` gets its `<wbr>` elements back — `<span class="pre">envisage.<wbr>extension_point.<wbr></span>`, with `textContent` unchanged, so copy/paste is unaffected — and that `sphinx-copybutton` still renders its buttons.

`ruff check` and `ruff format --check` both pass.

## Deployment

Merging this is enough to fix https://docs.enthought.com/envisage/: `update-gh-pages.yml` runs on every push to `main` and writes the built documentation to the root of the `gh-pages` branch, which is what that URL serves.

The versioned copies under `/8.0/` and `/latest/` are written only by `update-gh-pages-on-release.yml`, so they keep the old behaviour until the next Envisage release.

---

*This PR was created with the assistance of an AI coding agent.*
