### PR TITLE
Prepare the 8.0.1 release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,24 @@
  Release history
 =================
 
-Version 8.1.0
+Version 8.0.1
 =============
 
-Released: YYYY-MM-DD
+Released: 2026-08-07
+
+This is a bugfix release aimed at making the Python shell view usable again.
+A change in the way Pyface constructs widgets stopped the view opening at
+all, so ``View -> Other... -> Python`` failed in Envisage-based applications
+such as Mayavi.
+
+The release also restores the Envisage documentation on Read the Docs, whose
+builds had been failing, and fixes several smaller problems in the generated
+documentation.
+
+Thanks to:
+
+* Mark Dickinson
+* Eric Larson
 
 Fixes
 -----
@@ -44,7 +58,11 @@ Build
   so that an ``import envisage`` from the repository root can't accidentally
   pick up an uninstalled source tree. The wheel is unchanged. (#635)
 * Style checks now use ``ruff`` in place of ``black``, ``isort``, ``flake8``
-  and ``flake8-ets``. (#637)
+  and ``flake8-ets``, and the codebase is formatted to ``ruff format``'s 88
+  columns in place of ``black``'s 79. (#637, #642)
+* The EDM environment specification lives in ``.github``, beside the workflow
+  that reads it. (#634)
+* ``pypa/gh-action-pypi-publish`` is updated to 1.14.2. (#633)
 * ``AGENTS.md`` describes the changelog conventions, and a ``CLAUDE.md``
   imports it so that Claude Code picks it up. (#644)
 * The test and documentation workflows set ``QT_QPA_PLATFORM=offscreen`` in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,9 +17,7 @@ builds had been failing, and fixes several smaller problems in the generated
 documentation.
 
 Building from the source distribution now uses the ``uv_build`` backend in
-place of ``setuptools``. Build frontends install it themselves, so ``pip
-install envisage`` is unaffected; only a build that disables build isolation,
-as some packaging recipes do, needs its build requirements updated to match.
+place of ``setuptools``.
 
 Thanks to:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ The release also restores the Envisage documentation on Read the Docs, whose
 builds had been failing, and fixes several smaller problems in the generated
 documentation.
 
+Building from the source distribution now uses the ``uv_build`` backend in
+place of ``setuptools``. Build frontends install it themselves, so ``pip
+install envisage`` is unaffected; only a build that disables build isolation,
+as some packaging recipes do, needs its build requirements updated to match.
+
 Thanks to:
 
 * Mark Dickinson
@@ -52,8 +57,9 @@ Build
 * Build with the ``uv_build`` backend in place of ``setuptools``. Files
   inside the package are included in the wheel automatically, so
   ``MANIFEST.in`` and the explicit ``package-data`` configuration are no
-  longer needed. The source distribution no longer includes
-  ``CHANGES.rst``. (#628)
+  longer needed. The source distribution no longer includes ``CHANGES.rst``,
+  and a build that disables build isolation needs ``uv_build`` among its
+  build requirements in place of ``setuptools``. (#628)
 * The ``envisage`` package now lives in ``src/envisage`` in the repository,
   so that an ``import envisage`` from the repository root can't accidentally
   pick up an uninstalled source tree. The wheel is unchanged. (#635)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'uv_build'
 
 [project]
 name = 'envisage'
-version = '8.0.0'
+version = '8.0.1'
 description = 'Extensible application framework'
 readme = 'README.rst'
 requires-python = '>= 3.10'

--- a/uv.lock
+++ b/uv.lock
@@ -175,7 +175,7 @@ wheels = [
 
 [[package]]
 name = "envisage"
-version = "8.0.0"
+version = "8.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "apptools", extra = ["preferences"] },


### PR DESCRIPTION
Closes #653.

Prepares the 8.0.1 release:

* Retitle the in-development changelog section from `8.1.0` to `8.0.1`, and
  replace the `Released: YYYY-MM-DD` placeholder with today's date.
* Add the overview, in the style used for earlier bugfix releases, and credit
  contributors since 8.0.0 under `Thanks to`.
* Bump the version in `pyproject.toml` from 8.0.0 to 8.0.1, and refresh
  `uv.lock`, which pins the project's own version. (8.0.0 predated the
  lockfile, so this step is new since the last release.)

Three PRs merged since the 8.0.0 tag had no changelog entry, so this adds
them: the ruff reformat (#642), folded into the entry for the PR that
configured ruff (#637), the `edm.yaml` move (#634), and the
`pypa/gh-action-pypi-publish` bump (#633). #650 is deliberately left out,
since it only edited the changelog. Happy to drop #633 and #634 if you'd
rather keep the release notes to things a reader of them would act on.

Pre-flight, beyond CI: `uv build` and `twine check --strict` both pass, and
`uv sync --locked` confirms the refreshed lockfile.

Diffing the 8.0.1 artifacts against the released 8.0.0 ones shows one
difference that isn't explained by the changes since 8.0.0: the sdist now
carries a `pyproject.toml.orig` beside a `pyproject.toml` that has been
rewritten and stripped of its comments. That is `uv_build` working as
designed — since uv 0.12.0 it always rewrites the sdist's `pyproject.toml`
as TOML 1.0, so that older build frontends can consume it, and preserves the
original alongside. The two parse to identical data. It arrived with #628,
along with the switch to `uv_build`, and needs no action.

*This PR was created with the assistance of an AI coding agent.*